### PR TITLE
Prevent duplication when storing plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,10 @@
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>4.6.0.0</version>
+					<version>4.7.0.0</version>
+					<configuration>
+						<effort>Max</effort>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.jacoco</groupId>

--- a/src/checkstyle/checkstyle-configuration.xml
+++ b/src/checkstyle/checkstyle-configuration.xml
@@ -52,7 +52,7 @@
         <module name="AvoidStarImport"/>
         <module name="CustomImportOrder">
             <property name="customImportOrderRules"
-                      value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STATIC"/>
+                      value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
             <property name="specialImportsRegExp" value="^io.jenkins.pluginhealth.scoring\."/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>

--- a/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
@@ -50,6 +50,6 @@ public class PluginHealthScoring implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws IOException {
-        updateCenterService.readUpdateCenter().forEach(pluginService::saveOrUpdate);
+        updateCenterService.readUpdateCenter().forEach(pluginService::updateDatabase);
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
@@ -24,10 +24,10 @@
 
 package io.jenkins.pluginhealth.scoring;
 
+import java.io.IOException;
+
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
-
-import java.io.IOException;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
@@ -50,6 +50,6 @@ public class PluginHealthScoring implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws IOException {
-        updateCenterService.readUpdateCenter().forEach(pluginService::updateDatabase);
+        updateCenterService.readUpdateCenter().forEach(pluginService::saveOrUpdate);
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/cli/ImportPluginCLR.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/cli/ImportPluginCLR.java
@@ -22,14 +22,26 @@
  * SOFTWARE.
  */
 
-package io.jenkins.pluginhealth.scoring;
+package io.jenkins.pluginhealth.scoring.cli;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.jenkins.pluginhealth.scoring.service.PluginService;
+import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 
-@SpringBootApplication(scanBasePackages = "io.jenkins.pluginhealth.scoring")
-public class PluginHealthScoring {
-    public static void main(String[] args) {
-        SpringApplication.run(PluginHealthScoring.class, args);
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImportPluginCLR implements CommandLineRunner {
+    private final UpdateCenterService updateCenterService;
+    private final PluginService pluginService;
+
+    public ImportPluginCLR(UpdateCenterService updateCenterService, PluginService pluginService) {
+        this.updateCenterService = updateCenterService;
+        this.pluginService = pluginService;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        updateCenterService.readUpdateCenter().forEach(pluginService::saveOrUpdate);
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/cli/ImportPluginCLR.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/cli/ImportPluginCLR.java
@@ -24,6 +24,8 @@
 
 package io.jenkins.pluginhealth.scoring.cli;
 
+import java.io.IOException;
+
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 
@@ -41,7 +43,7 @@ public class ImportPluginCLR implements CommandLineRunner {
     }
 
     @Override
-    public void run(String... args) throws Exception {
+    public void run(String... args) throws IOException {
         updateCenterService.readUpdateCenter().forEach(pluginService::saveOrUpdate);
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/config/DatabaseConfiguration.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/config/DatabaseConfiguration.java
@@ -22,14 +22,16 @@
  * SOFTWARE.
  */
 
-package io.jenkins.pluginhealth.scoring;
+package io.jenkins.pluginhealth.scoring.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@SpringBootApplication(scanBasePackages = "io.jenkins.pluginhealth.scoring")
-public class PluginHealthScoring {
-    public static void main(String[] args) {
-        SpringApplication.run(PluginHealthScoring.class, args);
-    }
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(basePackages = "io.jenkins.pluginhealth.scoring.repository")
+@EntityScan(basePackages = "io.jenkins.pluginhealth.scoring.model")
+public class DatabaseConfiguration {
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -75,16 +75,18 @@ public class Plugin {
         return scm;
     }
 
-    public void setScm(String scm) {
+    public Plugin setScm(String scm) {
         this.scm = scm;
+        return this;
     }
 
     public ZonedDateTime getReleaseTimestamp() {
         return releaseTimestamp;
     }
 
-    public void setReleaseTimestamp(ZonedDateTime releaseTimestamp) {
+    public Plugin setReleaseTimestamp(ZonedDateTime releaseTimestamp) {
         this.releaseTimestamp = releaseTimestamp;
+        return this;
     }
 
     @Override

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -40,7 +40,7 @@ public class Plugin {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
 
-    @Column(name = "name")
+    @Column(name = "name", unique = true)
     private String name;
 
     @Column(name = "scm")

--- a/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.pluginhealth.scoring.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -34,4 +35,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PluginRepository extends JpaRepository<Plugin, Long> {
     Optional<Plugin> findByName(String name);
+
+    List<Plugin> findAllByName(String name);
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
@@ -24,7 +24,6 @@
 
 package io.jenkins.pluginhealth.scoring.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
@@ -35,6 +35,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PluginRepository extends JpaRepository<Plugin, Long> {
     Optional<Plugin> findByName(String name);
-
-    List<Plugin> findAllByName(String name);
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
@@ -24,6 +24,8 @@
 
 package io.jenkins.pluginhealth.scoring.repository;
 
+import java.util.Optional;
+
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,5 +33,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PluginRepository extends JpaRepository<Plugin, Long> {
-
+    Optional<Plugin> findByName(String name);
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -39,7 +39,7 @@ public class PluginService {
         this.pluginRepository = pluginRepository;
     }
 
-    public void updateDatabase(Plugin plugin) {
+    public void saveOrUpdate(Plugin plugin) {
         Optional<Plugin> pluginFromDatabase = pluginRepository.findByName(plugin.getName());
 
         if (pluginFromDatabase.isPresent()) {
@@ -55,10 +55,6 @@ public class PluginService {
         else {
             saveOrUpdate(plugin);
         }
-    }
-
-    public void saveOrUpdate(Plugin plugin) {
-        pluginRepository.save(plugin);
     }
 
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -40,19 +40,9 @@ public class PluginService {
     }
 
     public Plugin saveOrUpdate(Plugin plugin) {
-//        return pluginRepository.findByName(plugin.getName())
-//            .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
-//            .map(pluginRepository::save)
-//            .orElse(pluginRepository.save(plugin));
-        if (pluginRepository.findByName(plugin.getName()).isPresent()) {
-            Optional<Plugin> pluginFromDB = pluginRepository.findByName(plugin.getName());
-            pluginFromDB.get().setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp());
-            pluginRepository.save(pluginFromDB.get());
-            return pluginFromDB.get();
-        }
-        else {
-            pluginRepository.save(plugin);
-            return plugin;
-        }
+        return pluginRepository.findByName(plugin.getName())
+            .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
+            .map(pluginRepository::save)
+            .orElseGet(() -> pluginRepository.save(plugin));
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -24,6 +24,8 @@
 
 package io.jenkins.pluginhealth.scoring.service;
 
+import java.util.Optional;
+
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
@@ -38,9 +40,19 @@ public class PluginService {
     }
 
     public Plugin saveOrUpdate(Plugin plugin) {
-        return pluginRepository.findByName(plugin.getName())
-            .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
-            .map(pluginRepository::save)
-            .orElse(pluginRepository.save(plugin));
+//        return pluginRepository.findByName(plugin.getName())
+//            .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
+//            .map(pluginRepository::save)
+//            .orElse(pluginRepository.save(plugin));
+        if (pluginRepository.findByName(plugin.getName()).isPresent()) {
+            Optional<Plugin> pluginFromDB = pluginRepository.findByName(plugin.getName());
+            pluginFromDB.get().setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp());
+            pluginRepository.save(pluginFromDB.get());
+            return pluginFromDB.get();
+        }
+        else {
+            pluginRepository.save(plugin);
+            return plugin;
+        }
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -24,6 +24,8 @@
 
 package io.jenkins.pluginhealth.scoring.service;
 
+import java.util.Optional;
+
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
@@ -35,6 +37,24 @@ public class PluginService {
 
     public PluginService(PluginRepository pluginRepository) {
         this.pluginRepository = pluginRepository;
+    }
+
+    public void updateDatabase(Plugin plugin) {
+        Optional<Plugin> pluginFromDatabase = pluginRepository.findByName(plugin.getName());
+
+        if (pluginFromDatabase.isPresent()) {
+            if (pluginFromDatabase.get().getReleaseTimestamp() != plugin.getReleaseTimestamp()) {
+                pluginFromDatabase.get().setReleaseTimestamp(plugin.getReleaseTimestamp());
+                saveOrUpdate(pluginFromDatabase.get());
+            }
+            if (pluginFromDatabase.get().getScm() != null && !pluginFromDatabase.get().getScm().equals(plugin.getScm())) {
+                pluginFromDatabase.get().setScm(plugin.getScm());
+                saveOrUpdate(pluginFromDatabase.get());
+            }
+        }
+        else {
+            saveOrUpdate(plugin);
+        }
     }
 
     public void saveOrUpdate(Plugin plugin) {

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -40,17 +40,10 @@ public class PluginService {
     }
 
     public void saveOrUpdate(Plugin plugin) {
-        Optional<Plugin> pluginFromDatabase = pluginRepository.findByName(plugin.getName());
-
-        if (pluginFromDatabase.isPresent()) {
-            pluginFromDatabase.get().setReleaseTimestamp(plugin.getReleaseTimestamp());
-            pluginFromDatabase.get().setScm(plugin.getScm());
-
-            pluginRepository.save(pluginFromDatabase.get());
-        }
-        else {
-            pluginRepository.save(plugin);
-        }
+        pluginRepository.findByName(plugin.getName())
+            .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
+            .map(updatedPluginFromDatabase -> pluginRepository.save(updatedPluginFromDatabase))
+            .orElse(pluginRepository.save(plugin));
     }
 
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -24,8 +24,6 @@
 
 package io.jenkins.pluginhealth.scoring.service;
 
-import java.util.Optional;
-
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -37,11 +37,10 @@ public class PluginService {
         this.pluginRepository = pluginRepository;
     }
 
-    public void saveOrUpdate(Plugin plugin) {
-        pluginRepository.findByName(plugin.getName())
+    public Plugin saveOrUpdate(Plugin plugin) {
+        return pluginRepository.findByName(plugin.getName())
             .map(pluginFromDatabase -> pluginFromDatabase.setScm(plugin.getScm()).setReleaseTimestamp(plugin.getReleaseTimestamp()))
-            .map(updatedPluginFromDatabase -> pluginRepository.save(updatedPluginFromDatabase))
+            .map(pluginRepository::save)
             .orElse(pluginRepository.save(plugin));
     }
-
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -43,17 +43,13 @@ public class PluginService {
         Optional<Plugin> pluginFromDatabase = pluginRepository.findByName(plugin.getName());
 
         if (pluginFromDatabase.isPresent()) {
-            if (pluginFromDatabase.get().getReleaseTimestamp() != plugin.getReleaseTimestamp()) {
-                pluginFromDatabase.get().setReleaseTimestamp(plugin.getReleaseTimestamp());
-                saveOrUpdate(pluginFromDatabase.get());
-            }
-            if (pluginFromDatabase.get().getScm() != null && !pluginFromDatabase.get().getScm().equals(plugin.getScm())) {
-                pluginFromDatabase.get().setScm(plugin.getScm());
-                saveOrUpdate(pluginFromDatabase.get());
-            }
+            pluginFromDatabase.get().setReleaseTimestamp(plugin.getReleaseTimestamp());
+            pluginFromDatabase.get().setScm(plugin.getScm());
+
+            pluginRepository.save(pluginFromDatabase.get());
         }
         else {
-            saveOrUpdate(plugin);
+            pluginRepository.save(plugin);
         }
     }
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -35,6 +35,7 @@ import io.jenkins.pluginhealth.scoring.model.Plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -42,8 +43,8 @@ public class UpdateCenterService {
     private final ObjectMapper objectMapper;
     private final String updateCenterURL;
 
-    public UpdateCenterService(ObjectMapper objectMapper, @Value("${jenkins.update.center}") String updateCenterURL) {
-        this.objectMapper = objectMapper;
+    public UpdateCenterService(@Value("${jenkins.update.center}") String updateCenterURL) {
+        this.objectMapper = Jackson2ObjectMapperBuilder.json().build();
         this.updateCenterURL = updateCenterURL;
     }
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -53,6 +53,7 @@ public class UpdateCenterService {
                 return new Plugin(this.name, this.scm, this.releaseTimestamp);
             }
         }
+
         record UpdateCenter(Map<String, UpdateCenterPlugin> plugins) {
         }
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -51,7 +51,7 @@ public class UpdateCenterService {
     public List<Plugin> readUpdateCenter() throws IOException {
         record UpdateCenterPlugin(String name, String scm, ZonedDateTime releaseTimestamp) {
             Plugin toPlugin() {
-                return new Plugin(this.name, this.scm, this.releaseTimestamp);
+                return new Plugin(this.name(), this.scm(), this.releaseTimestamp());
             }
         }
 
@@ -59,7 +59,7 @@ public class UpdateCenterService {
         }
 
         UpdateCenter updateCenter = objectMapper.readValue(new URL(updateCenterURL), UpdateCenter.class);
-        return updateCenter.plugins.values().stream()
+        return updateCenter.plugins().values().stream()
             .map(UpdateCenterPlugin::toPlugin)
             .collect(Collectors.toList());
     }

--- a/src/test/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+
+@ContextConfiguration(initializers = AbstractDBContainerTest.DockerPostgresDatasourceInitializer.class)
+@Testcontainers
+public abstract class AbstractDBContainerTest {
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:14.1")
+        .withDatabaseName("testdb")
+        .withUsername("sa")
+        .withPassword("sa");
+
+    public static class DockerPostgresDatasourceInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+            TestPropertyValues.of(
+                "spring.datasource.url=" + POSTGRES_SQL_CONTAINER.getJdbcUrl(),
+                "spring.datasource.username=" + POSTGRES_SQL_CONTAINER.getUsername(),
+                "spring.datasource.password=" + POSTGRES_SQL_CONTAINER.getPassword()
+            ).applyTo(applicationContext);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
@@ -25,7 +25,6 @@
 package io.jenkins.pluginhealth.scoring;
 
 import org.jetbrains.annotations.NotNull;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;

--- a/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringIT.java
@@ -24,45 +24,17 @@
 
 package io.jenkins.pluginhealth.scoring;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ContextConfiguration(initializers = PluginHealthScoringIT.DockerPostgresDatasourceInitializer.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-class PluginHealthScoringIT {
-    @Container
-    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:14.1")
-        .withDatabaseName("testdb")
-        .withUsername("sa")
-        .withPassword("sa");
-
-    public static class DockerPostgresDatasourceInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        @Override
-        public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
-            TestPropertyValues.of(
-                "spring.datasource.url=" + POSTGRE_SQL_CONTAINER.getJdbcUrl(),
-                "spring.datasource.username=" + POSTGRE_SQL_CONTAINER.getUsername(),
-                "spring.datasource.password=" + POSTGRE_SQL_CONTAINER.getPassword()
-            ).applyTo(applicationContext);
-        }
-    }
-
+public final class PluginHealthScoringIT extends AbstractDBContainerTest {
     @Test
     void contextLoads() {
     }
-
 }

--- a/src/test/java/io/jenkins/pluginhealth/scoring/PluginServiceTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/PluginServiceTest.java
@@ -1,0 +1,65 @@
+package io.jenkins.pluginhealth.scoring;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
+import io.jenkins.pluginhealth.scoring.service.PluginService;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.mockito.Mockito.mock;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(initializers = PluginServiceTest.DockerPostgresDatasourceInitializer.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@RunWith(MockitoJUnitRunner.class)
+public class PluginServiceTest {
+    private final PluginRepository pluginRepository;
+    private final PluginService pluginService;
+
+    Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
+
+    public PluginServiceTest(PluginRepository pluginRepository, PluginService pluginService) {
+        this.pluginRepository = pluginRepository;
+        this.pluginService = pluginService;
+    }
+
+    @Container
+    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:14.1")
+        .withDatabaseName("testdb")
+        .withUsername("sa")
+        .withPassword("sa");
+
+    public static class DockerPostgresDatasourceInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+            TestPropertyValues.of(
+                "spring.datasource.url=" + POSTGRE_SQL_CONTAINER.getJdbcUrl(),
+                "spring.datasource.username=" + POSTGRE_SQL_CONTAINER.getUsername(),
+                "spring.datasource.password=" + POSTGRE_SQL_CONTAINER.getPassword()
+            ).applyTo(applicationContext);
+        }
+    }
+
+    @Test
+    public void myTest() {
+        pluginService.saveOrUpdate(plugin);
+        pluginService.saveOrUpdate(plugin);
+
+        assertEquals(1, pluginRepository.findAllByName("myPlugin").size());
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/PluginServiceTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/PluginServiceTest.java
@@ -1,10 +1,10 @@
 package io.jenkins.pluginhealth.scoring;
 
+import static org.junit.Assert.assertEquals;
+
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 import io.jenkins.pluginhealth.scoring.service.PluginService;
-
-import static org.junit.Assert.assertEquals;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -19,8 +19,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import static org.mockito.Mockito.mock;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = PluginServiceTest.DockerPostgresDatasourceInitializer.class)

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -50,7 +50,7 @@ public class PluginServiceIT {
     }
 
     @Test
-    public void myTest() {
+    public void shouldNotDuplicatePlugin() {
         pluginService.saveOrUpdate(plugin);
         pluginService.saveOrUpdate(plugin);
 

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -54,6 +54,6 @@ public class PluginServiceIT {
         pluginService.saveOrUpdate(plugin);
         pluginService.saveOrUpdate(plugin);
 
-        assertEquals(1, pluginRepository.findAllByName("myPlugin").size());
+        assertEquals(1, pluginRepository.findAll().size());
     }
 }

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -2,53 +2,39 @@ package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.jenkins.pluginhealth.scoring.AbstractDBContainerTest;
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
-import org.springframework.test.context.ContextConfiguration;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ContextConfiguration(initializers = PluginServiceIT.DockerPostgresDatasourceInitializer.class)
 @DataJpaTest(includeFilters = @ComponentScan.Filter(Service.class))
-@Testcontainers
-public class PluginServiceIT {
+public class PluginServiceIT extends AbstractDBContainerTest {
     @Autowired
     private PluginRepository pluginRepository;
     @Autowired
     private PluginService pluginService;
 
-    @Container
-    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:14.1")
-        .withDatabaseName("testdb")
-        .withUsername("sa")
-        .withPassword("sa");
+    @Test
+    public void shouldNotDuplicatePlugin() {
+        Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
 
-    public static class DockerPostgresDatasourceInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        @Override
-        public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
-            TestPropertyValues.of(
-                "spring.datasource.url=" + POSTGRE_SQL_CONTAINER.getJdbcUrl(),
-                "spring.datasource.username=" + POSTGRE_SQL_CONTAINER.getUsername(),
-                "spring.datasource.password=" + POSTGRE_SQL_CONTAINER.getPassword()
-            ).applyTo(applicationContext);
-        }
+        pluginService.saveOrUpdate(plugin);
+        pluginService.saveOrUpdate(plugin);
+
+        assertThat(pluginRepository.findAll())
+            .hasSize(1)
+            .contains(plugin);
     }
 
     @Test
-    public void shouldNotDuplicatePlugin() {
+    public void shouldNotDuplicatePluginWhenNameIsTheSame() {
         Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
 
         pluginService.saveOrUpdate(plugin);

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -1,15 +1,12 @@
-package io.jenkins.pluginhealth.scoring;
+package io.jenkins.pluginhealth.scoring.service;
 
 import static org.junit.Assert.assertEquals;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
-import io.jenkins.pluginhealth.scoring.service.PluginService;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -21,17 +18,16 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ContextConfiguration(initializers = PluginServiceTest.DockerPostgresDatasourceInitializer.class)
+@ContextConfiguration(initializers = PluginServiceIT.DockerPostgresDatasourceInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
-@RunWith(MockitoJUnitRunner.class)
-public class PluginServiceTest {
+public class PluginServiceIT {
     private final PluginRepository pluginRepository;
     private final PluginService pluginService;
 
     Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
 
-    public PluginServiceTest(PluginRepository pluginRepository, PluginService pluginService) {
+    public PluginServiceIT(PluginRepository pluginRepository, PluginService pluginService) {
         this.pluginRepository = pluginRepository;
         this.pluginService = pluginService;
     }

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -22,18 +22,6 @@ public class PluginServiceIT extends AbstractDBContainerTest {
     private PluginService pluginService;
 
     @Test
-    public void shouldNotDuplicatePlugin() {
-        Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
-
-        pluginService.saveOrUpdate(plugin);
-        pluginService.saveOrUpdate(plugin);
-
-        assertThat(pluginRepository.findAll())
-            .hasSize(1)
-            .contains(plugin);
-    }
-
-    @Test
     public void shouldNotDuplicatePluginWhenNameIsTheSame() {
         Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
 

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -7,6 +7,7 @@ import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -22,15 +23,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 public class PluginServiceIT {
-    private final PluginRepository pluginRepository;
-    private final PluginService pluginService;
+    @Autowired
+    private PluginRepository pluginRepository;
+    @Autowired
+    private PluginService pluginService;
 
     Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
-
-    public PluginServiceIT(PluginRepository pluginRepository, PluginService pluginService) {
-        this.pluginRepository = pluginRepository;
-        this.pluginService = pluginService;
-    }
 
     @Container
     private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:14.1")

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -28,8 +28,6 @@ public class PluginServiceIT {
     @Autowired
     private PluginService pluginService;
 
-    Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
-
     @Container
     private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer("postgres:14.1")
         .withDatabaseName("testdb")
@@ -49,6 +47,8 @@ public class PluginServiceIT {
 
     @Test
     public void shouldNotDuplicatePlugin() {
+        Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
+
         pluginService.saveOrUpdate(plugin);
         pluginService.saveOrUpdate(plugin);
 

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -6,7 +6,7 @@ import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Closes #8 

* Now when I start the app, it doesn't populate the DB with duplicate plugins.
* Now there's a check added before we save an object into the DB. The flow now first checks if for a given plugin received from the DB has the same name as any other plugin stored already inside the DB,
  * If no, then save the object in DB.
  * If yes, check if there is any difference in `releaseTimestamp` and `scm` field values, if yes (for both or any one field) then update the object present inside the DB.