### PR TITLE
Creates a context across probe executions for a plugin

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
@@ -62,7 +62,7 @@ public class ProbeEngine {
             .peek(plugin -> {
                 probes.forEach(probe -> {
                     try {
-                        var previousResult = plugin.getDetails().get(probe.key());
+                        final ProbeResult previousResult = plugin.getDetails().get(probe.key());
                         if (previousResult == null ||
                             (probe.requiresRelease()
                                 && previousResult.timestamp() != null

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
@@ -25,7 +25,6 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
@@ -59,33 +58,33 @@ public class ProbeEngine {
      */
     public void run() {
         LOGGER.info("Start running probes on all plugins");
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Registered probes: {}", probes.stream().map(Probe::key).collect(Collectors.joining(", ")));
-        }
         pluginService.streamAll().parallel()
-            .peek(plugin -> probes.stream()
-                .map(probe -> {
+            .peek(plugin -> {
+                probes.forEach(probe -> {
                     try {
-                        if (probe.requiresRelease() && plugin.getDetails().containsKey(probe.key())) {
-                            ProbeResult probeResult = plugin.getDetails().get(probe.key());
-                            if (probeResult.timestamp() != null && plugin.getReleaseTimestamp().isBefore(probeResult.timestamp())) {
-                                if (LOGGER.isDebugEnabled()) {
-                                    LOGGER.debug("{} requires a release of {} to process it again.", probe.key(), plugin.getName());
-                                }
-                                return probeResult;
+                        var previousResult = plugin.getDetails().get(probe.key());
+                        if (previousResult == null ||
+                            (probe.requiresRelease()
+                                && previousResult.timestamp() != null
+                                && previousResult.timestamp().isBefore(plugin.getReleaseTimestamp()))
+                        ) {
+                            if (LOGGER.isTraceEnabled()) {
+                                LOGGER.trace("Running {} on {}", probe.key(), plugin.getName());
+                            }
+                            final ProbeResult result = probe.apply(plugin);
+                            if (result.status() != ResultStatus.ERROR) {
+                                plugin.addDetails(result);
+                            }
+                        } else {
+                            if (LOGGER.isDebugEnabled()) {
+                                LOGGER.debug("{} requires a release of {} to process it again.", probe.key(), plugin.getName());
                             }
                         }
-                        if (LOGGER.isTraceEnabled()) {
-                            LOGGER.trace("Running {} on {}", probe.key(), plugin.getName());
-                        }
-                        return probe.apply(plugin);
                     } catch (Throwable t) {
                         LOGGER.error("Couldn't run {} on {}", probe.key(), plugin.getName(), t);
-                        return ProbeResult.error(probe.key(), "Could not run probe " + probe.key());
                     }
-                })
-                .filter(result -> result.status() != ResultStatus.ERROR)
-                .forEach(plugin::addDetails))
+                });
+            })
             .forEach(pluginService::saveOrUpdate);
         LOGGER.info("Probe engine has finished");
     }

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -106,7 +106,7 @@ class ProbeEngineTest {
             }
 
             @Override
-            protected String key() {
+            public String key() {
                 return "foo";
             }
         };
@@ -119,7 +119,7 @@ class ProbeEngineTest {
             }
 
             @Override
-            protected String key() {
+            public String key() {
                 return "bar";
             }
         };

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -69,7 +69,7 @@ class ProbeEngineTest {
     }
 
     @Test
-    public void shouldNotAccessPluginWithPastResultAndReleaseRequirement() {
+    public void shouldNotAccessPluginWithNoNewReleaseWithPastResultAndReleaseRequirement() {
         final Plugin plugin = new Plugin("foo", "bar", ZonedDateTime.now().minusDays(1))
             .addDetails(ProbeResult.success("wiz", "This is good"));
         final Probe probe = mock(Probe.class);
@@ -81,6 +81,7 @@ class ProbeEngineTest {
         probeEngine.run();
 
         verify(probe, never()).doApply(plugin);
+        verify(pluginService, times(1)).saveOrUpdate(plugin);
     }
 
     @Test
@@ -96,6 +97,7 @@ class ProbeEngineTest {
         probeEngine.run();
 
         verify(probe, times(1)).doApply(plugin);
+        verify(pluginService, times(1)).saveOrUpdate(plugin);
     }
 
     @Test
@@ -111,6 +113,7 @@ class ProbeEngineTest {
         probeEngine.run();
 
         verify(probe, never()).doApply(plugin);
+        verify(pluginService, times(1)).saveOrUpdate(plugin);
     }
 
     @Test

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -99,7 +99,7 @@ class ProbeEngineTest {
     @Test
     public void shouldBeAbleToGetPreviousContextResultInExecution() throws Exception {
         final Plugin plugin = spy(Plugin.class);
-        var probeOne = new Probe() {
+        final Probe probeOne = new Probe() {
             @Override
             protected ProbeResult doApply(Plugin plugin) {
                 return ProbeResult.success(key(), "This is ok");
@@ -110,7 +110,7 @@ class ProbeEngineTest {
                 return "foo";
             }
         };
-        var probeTwo = new Probe() {
+        final Probe probeTwo = new Probe() {
             @Override
             protected ProbeResult doApply(Plugin plugin) {
                 return plugin.getDetails().get("foo") != null ?

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -84,6 +84,36 @@ class ProbeEngineTest {
     }
 
     @Test
+    public void shouldAccessPluginWithNewReleaseAndPastResultAndReleaseRequirement() {
+        final Plugin plugin = new Plugin("foo", "bar", ZonedDateTime.now().plusDays(1))
+            .addDetails(ProbeResult.success("wiz", "This is good"));
+        final Probe probe = mock(Probe.class);
+        final ProbeEngine probeEngine = new ProbeEngine(List.of(probe), pluginService);
+
+        when(probe.requiresRelease()).thenReturn(Boolean.TRUE);
+        when(probe.key()).thenReturn("wiz");
+        when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
+        probeEngine.run();
+
+        verify(probe, times(1)).doApply(plugin);
+    }
+
+    @Test
+    public void shouldNotAccessPluginWithPastResultAndNoReleaseRequirement() {
+        final Plugin plugin = new Plugin("foo", "bar", ZonedDateTime.now())
+            .addDetails(ProbeResult.success("wiz", "This is good"));
+        final Probe probe = mock(Probe.class);
+        final ProbeEngine probeEngine = new ProbeEngine(List.of(probe), pluginService);
+
+        when(probe.requiresRelease()).thenReturn(Boolean.FALSE);
+        when(probe.key()).thenReturn("wiz");
+        when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
+        probeEngine.run();
+
+        verify(probe, never()).doApply(plugin);
+    }
+
+    @Test
     public void shouldNotSaveErrors() {
         final Plugin plugin = mock(Plugin.class);
         final Probe probe = mock(Probe.class);

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -81,7 +81,7 @@ class ProbeEngineTest {
         probeEngine.run();
 
         verify(probe, never()).doApply(plugin);
-        verify(pluginService, times(1)).saveOrUpdate(plugin);
+        verify(pluginService).saveOrUpdate(plugin);
     }
 
     @Test
@@ -96,8 +96,8 @@ class ProbeEngineTest {
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
         probeEngine.run();
 
-        verify(probe, times(1)).doApply(plugin);
-        verify(pluginService, times(1)).saveOrUpdate(plugin);
+        verify(probe).doApply(plugin);
+        verify(pluginService).saveOrUpdate(plugin);
     }
 
     @Test

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -75,7 +75,7 @@ class ProbeEngineTest {
         final Probe probe = mock(Probe.class);
         final ProbeEngine probeEngine = new ProbeEngine(List.of(probe), pluginService);
 
-        when(probe.requiresRelease()).thenReturn(Boolean.TRUE);
+        when(probe.requiresRelease()).thenReturn(true);
         when(probe.key()).thenReturn("wiz");
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
         probeEngine.run();
@@ -91,7 +91,7 @@ class ProbeEngineTest {
         final Probe probe = mock(Probe.class);
         final ProbeEngine probeEngine = new ProbeEngine(List.of(probe), pluginService);
 
-        when(probe.requiresRelease()).thenReturn(Boolean.TRUE);
+        when(probe.requiresRelease()).thenReturn(true);
         when(probe.key()).thenReturn("wiz");
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
         probeEngine.run();


### PR DESCRIPTION
Resolves #31 

This create an environment where one probe could use a previously executed probe result to condition its execution. 