### PR TITLE
Fixes release drafter VM selection

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ concurrency: "release-drafter"
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-22.10
+    runs-on: ubuntu-22.04
     steps:
       - uses: release-drafter/release-drafter@v5.21.0
         env:


### PR DESCRIPTION
because of #52, I should have read more carefully the available VM for the workflow. 
Based on https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources, `ubuntu-22.10` doesn't exist.