### PR TITLE
Checks update-center for known vulnerabilities on plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>6.2.0.202206071550-r</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci</groupId>
+			<artifactId>version-number</artifactId>
+			<version>1.10</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
@@ -1,0 +1,80 @@
+package io.jenkins.pluginhealth.scoring.config;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import hudson.util.VersionNumber;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.StringType;
+import org.hibernate.usertype.UserType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VersionNumberType implements UserType {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VersionNumberType.class);
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{StringType.INSTANCE.sqlType()};
+    }
+
+    @Override
+    public Class<?> returnedClass() {
+        return VersionNumber.class;
+    }
+
+    @Override
+    public boolean equals(Object x, Object y) throws HibernateException {
+        return Objects.equals(x, y);
+    }
+
+    @Override
+    public int hashCode(Object x) throws HibernateException {
+        return Objects.hash(x);
+    }
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws HibernateException, SQLException {
+        String columnName = names[0];
+        final String columnValue = rs.getString(columnName);
+        return columnValue == null ? null : new VersionNumber(columnValue);
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
+        if (value == null) {
+            st.setNull(index, StringType.INSTANCE.sqlType());
+        } else {
+            st.setString(index, value.toString());
+        }
+    }
+
+    @Override
+    public Object deepCopy(Object value) throws HibernateException {
+        return value;
+    }
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        return value.toString();
+    }
+
+    @Override
+    public Object assemble(Serializable cached, Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return deepCopy(original);
+    }
+}

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -35,13 +35,17 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import io.jenkins.pluginhealth.scoring.config.VersionNumberType;
+
 import com.vladmihalcea.hibernate.type.json.JsonType;
+import hudson.util.VersionNumber;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
 @Entity
 @Table(name = "plugins")
 @TypeDef(name = "json", typeClass = JsonType.class)
+@TypeDef(name = "version", typeClass = VersionNumberType.class)
 public class Plugin {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -49,6 +53,10 @@ public class Plugin {
 
     @Column(name = "name", unique = true)
     private String name;
+
+    @Type(type = "version")
+    @Column(name = "version")
+    private VersionNumber version;
 
     @Column(name = "scm")
     private String scm;
@@ -63,14 +71,24 @@ public class Plugin {
     public Plugin() {
     }
 
-    public Plugin(String name, String scm, ZonedDateTime releaseTimestamp) {
+    public Plugin(String name, VersionNumber version, String scm, ZonedDateTime releaseTimestamp) {
         this.name = name;
+        this.version = version;
         this.scm = scm;
         this.releaseTimestamp = releaseTimestamp;
     }
 
     public String getName() {
         return name;
+    }
+
+    public VersionNumber getVersion() {
+        return version;
+    }
+
+    public Plugin setVersion(VersionNumber version) {
+        this.version = version;
+        return this;
     }
 
     public String getScm() {

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Deprecation.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Deprecation.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package io.jenkins.pluginhealth.scoring.model;
+package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
-public record UpdateCenterDeprecation(String url) {
+public record Deprecation(String url) {
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Plugin.java
@@ -22,9 +22,15 @@
  * SOFTWARE.
  */
 
-package io.jenkins.pluginhealth.scoring.model;
+package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
-import java.util.Map;
+import java.time.ZonedDateTime;
+import java.util.List;
 
-public record UpdateCenter(Map<String, UpdateCenterPlugin> plugins, Map<String, UpdateCenterDeprecation> deprecations) {
+import hudson.util.VersionNumber;
+
+public record Plugin(String name, VersionNumber version, String scm, ZonedDateTime releaseTimestamp, List<String> labels) {
+    public io.jenkins.pluginhealth.scoring.model.Plugin toPlugin() {
+        return new io.jenkins.pluginhealth.scoring.model.Plugin(this.name(), this.version(), this.scm(), this.releaseTimestamp());
+    }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
@@ -5,7 +5,6 @@ import java.util.List;
 public record SecurityWarning(
     String id,
     String name,
-    String type,
     List<SecurityWarningVersion> versions
 ) {
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
@@ -1,0 +1,11 @@
+package io.jenkins.pluginhealth.scoring.model.updatecenter;
+
+import java.util.List;
+
+public record SecurityWarning(
+    String id,
+    String name,
+    String type,
+    List<SecurityWarningVersion> versions
+) {
+}

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
@@ -1,0 +1,9 @@
+package io.jenkins.pluginhealth.scoring.model.updatecenter;
+
+import hudson.util.VersionNumber;
+
+public record SecurityWarningVersion(
+    VersionNumber lastVersion,
+    String pattern
+) {
+}

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/UpdateCenter.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/UpdateCenter.java
@@ -22,13 +22,13 @@
  * SOFTWARE.
  */
 
-package io.jenkins.pluginhealth.scoring.model;
+package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
-import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
-public record UpdateCenterPlugin(String name, String scm, ZonedDateTime releaseTimestamp, List<String> labels) {
-    public Plugin toPlugin() {
-        return new Plugin(this.name(), this.scm(), this.releaseTimestamp());
-    }
+public record UpdateCenter(Map<String, Plugin> plugins,
+                           Map<String, Deprecation> deprecations,
+                           List<SecurityWarning> warnings
+) {
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
@@ -2,7 +2,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -44,6 +44,6 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
 
     @Override
     public String getDescription() {
-        return "Detects if a given plugin as a public security vulnerability advertised in a security advisory.";
+        return "Detects if a given plugin has a public security vulnerability advertised in a security advisory.";
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -23,7 +23,7 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
         final Optional<SecurityWarning> warning = warnings.stream()
             .filter(w -> w.name().equals(plugin.getName()))
             .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
-                if(securityWarningVersion.lastVersion() != null) {
+                if (securityWarningVersion.lastVersion() != null) {
                     return plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion());
                 }
                 final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -1,9 +1,9 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
@@ -20,7 +20,7 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final List<SecurityWarning> warnings = context.getUpdateCenter().warnings();
-        final Optional<SecurityWarning> warning = warnings.stream()
+        final String issues = warnings.stream()
             .filter(w -> w.name().equals(plugin.getName()))
             .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
                 if (securityWarningVersion.lastVersion() != null) {
@@ -30,11 +30,12 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
                 final Matcher matcher = pattern.matcher(plugin.getVersion().toString());
                 return matcher.find();
             }))
-            .findAny();
+            .map(SecurityWarning::id)
+            .collect(Collectors.joining(", "));
 
-        return warning
-            .map(w -> ProbeResult.failure(key(), w.id()))
-            .orElseGet(() -> ProbeResult.success(key(), "Plugin is OK"));
+        return !issues.isBlank() ?
+            ProbeResult.failure(key(), issues) :
+            ProbeResult.success(key(), "Plugin is OK");
     }
 
     @Override

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -1,0 +1,49 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarning;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(value = KnownSecurityVulnerabilityProbe.ORDER)
+public class KnownSecurityVulnerabilityProbe extends Probe {
+    public static final int ORDER = UpForAdoptionProbe.ORDER + 1;
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        final List<SecurityWarning> warnings = context.getUpdateCenter().warnings();
+        final Optional<SecurityWarning> warning = warnings.stream()
+            .filter(w -> w.name().equals(plugin.getName()))
+            .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
+                if(securityWarningVersion.lastVersion() != null) {
+                    return plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion());
+                }
+                final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());
+                final Matcher matcher = pattern.matcher(plugin.getVersion().toString());
+                return matcher.find();
+            }))
+            .findAny();
+
+        return warning
+            .map(w -> ProbeResult.failure(key(), w.id()))
+            .orElseGet(() -> ProbeResult.success(key(), "Plugin is OK"));
+    }
+
+    @Override
+    public String key() {
+        return "security";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Detects if a given plugin as a public security vulnerability advertised in a security advisory.";
+    }
+}

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -24,7 +24,7 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 /*default*/ class ProbeContext {
     private final UpdateCenter updateCenter;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
@@ -2,7 +2,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
@@ -26,7 +26,7 @@ package io.jenkins.pluginhealth.scoring.schedule;
 
 import java.io.IOException;
 
-import io.jenkins.pluginhealth.scoring.model.UpdateCenterPlugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 import io.jenkins.pluginhealth.scoring.probes.ProbeEngine;
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
@@ -51,7 +51,7 @@ public class UpdateCenterScheduler {
     public void updateDatabase() throws IOException {
         updateCenterService.fetchUpdateCenter()
             .plugins().values().stream()
-            .map(UpdateCenterPlugin::toPlugin)
+            .map(Plugin::toPlugin)
             .forEach(pluginService::saveOrUpdate);
         probeEngine.run();
     }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -46,6 +46,7 @@ public class PluginService {
             .map(pluginFromDatabase -> pluginFromDatabase
                 .setScm(plugin.getScm())
                 .setReleaseTimestamp(plugin.getReleaseTimestamp())
+                .setVersion(plugin.getVersion())
                 .addDetails(plugin.getDetails()))
             .map(pluginRepository::save)
             .orElseGet(() -> pluginRepository.save(plugin));

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -27,7 +27,7 @@ package io.jenkins.pluginhealth.scoring.service;
 import java.io.IOException;
 import java.net.URL;
 
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
@@ -34,9 +34,9 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
-import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Deprecation;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
@@ -32,13 +32,13 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Map;
 
-import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenterDeprecation;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenterPlugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Deprecation;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 
+import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
 
 public class DeprecatedPluginProbeTest {
@@ -54,14 +54,15 @@ public class DeprecatedPluginProbeTest {
 
     @Test
     public void shouldBeAbleToDetectNonDeprecatedPlugin() {
-        final Plugin plugin = mock(Plugin.class);
+        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new UpdateCenterPlugin("foo", "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList())),
-            Map.of("bar", new UpdateCenterDeprecation("find-the-reason-here"))
+            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList())),
+            Map.of("bar", new Deprecation("find-the-reason-here")),
+            Collections.emptyList()
         ));
 
         final ProbeResult result = probe.apply(plugin, ctx);
@@ -71,14 +72,15 @@ public class DeprecatedPluginProbeTest {
 
     @Test
     public void shouldBeAbleToDetectDeprecatedPlugin() {
-        final Plugin plugin = mock(Plugin.class);
+        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new UpdateCenterPlugin("foo", "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList())),
-            Map.of("bar", new UpdateCenterDeprecation("find-the-reason-here"), "foo", new UpdateCenterDeprecation("this-is-the-reason"))
+            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList())),
+            Map.of("bar", new Deprecation("find-the-reason-here"), "foo", new Deprecation("this-is-the-reason")),
+            Collections.emptyList()
         ));
 
         final ProbeResult result = probe.apply(plugin, ctx);

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -111,6 +111,7 @@ class KnownSecurityVulnerabilityProbeTest {
     public void shouldNotBeOKWithWarningOnCurrentVersion() {
         final String pluginName = "foo-bar";
         final VersionNumber pluginVersion = new VersionNumber("1.1");
+        final String warningId = "SECURITY-1";
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
@@ -123,7 +124,7 @@ class KnownSecurityVulnerabilityProbeTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 List.of(
-                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(pluginVersion, "1.0")))
+                    new SecurityWarning(warningId, pluginName, List.of(new SecurityWarningVersion(pluginVersion, "1.0")))
                 )
             )
         );
@@ -131,12 +132,14 @@ class KnownSecurityVulnerabilityProbeTest {
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo(warningId);
     }
 
     @Test
     public void shouldNotBeOKWithWarningWithoutLastVersion() {
         final String pluginName = "foo-bar";
         final VersionNumber pluginVersion = new VersionNumber("1.1");
+        final String warningId = "SECURITY-1";
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
@@ -149,7 +152,7 @@ class KnownSecurityVulnerabilityProbeTest {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 List.of(
-                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(null, ".*")))
+                    new SecurityWarning(warningId, pluginName, List.of(new SecurityWarningVersion(null, ".*")))
                 )
             )
         );
@@ -157,6 +160,67 @@ class KnownSecurityVulnerabilityProbeTest {
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo(warningId);
+    }
+
+    @Test
+    public void shouldNotBeOKWithMultipleWarningsWithoutLastVersion() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.1");
+        final String warningId1 = "SECURITY-1";
+        final String warningId2 = "SECURITY-2";
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning(warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
+                    new SecurityWarning(warningId2, pluginName, List.of(new SecurityWarningVersion(null, ".*")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo("%s, %s".formatted(warningId1, warningId2));
+    }
+
+    @Test
+    public void shouldNotBeOKWithWarningWithoutLastVersionAndOneResolved() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.2");
+        final String warningId1 = "SECURITY-1";
+        final String warningId2 = "SECURITY-1";
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning(warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
+                    new SecurityWarning(warningId2, pluginName, List.of(new SecurityWarningVersion(new VersionNumber("1.1"), ".*")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo(warningId1);
     }
 
     @Test

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -1,0 +1,187 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ResultStatus;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarning;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarningVersion;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+
+import hudson.util.VersionNumber;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KnownSecurityVulnerabilityProbeTest {
+    @Test
+    public void shouldUseKeySecurity() {
+        final KnownSecurityVulnerabilityProbe probe = spy(KnownSecurityVulnerabilityProbe.class);
+        assertThat(probe.key()).isEqualTo("security");
+    }
+
+    @Test
+    public void shouldNotRequireNewRelease() {
+        final KnownSecurityVulnerabilityProbe probe = spy(KnownSecurityVulnerabilityProbe.class);
+        assertThat(probe.requiresRelease()).isFalse();
+    }
+
+    @Test
+    public void shouldBeOKWithNoSecurityWarning() {
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyList()
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+
+    @Test
+    public void shouldBeOKWithWarningOnDifferentPlugin() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.0");
+        final var pluginInUC = new Plugin(pluginName, pluginVersion, "scm", ZonedDateTime.now().minusHours(1), List.of());
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Map.of(pluginName, pluginInUC),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning("SECURITY-1", "wiz", List.of(new SecurityWarningVersion(null, ".*")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+
+    @Test
+    public void shouldBeOKWithWarningOnOlderVersion() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.1");
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning("SECURITY-1", pluginName, List.of(
+                        new SecurityWarningVersion(new VersionNumber("1.0"), "0\\.*")
+                    ))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+
+    @Test
+    public void shouldNotBeOKWithWarningOnCurrentVersion() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.1");
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(pluginVersion, "1.0")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+    }
+
+    @Test
+    public void shouldNotBeOKWithWarningWithoutLastVersion() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("1.1");
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(null, ".*")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+    }
+
+    @Test
+    public void shouldBeOKWithWarningWithoutLastVersionButOutOfPattern() {
+        final String pluginName = "foo-bar";
+        final VersionNumber pluginVersion = new VersionNumber("2.0");
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter()).thenReturn(
+            new UpdateCenter(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                List.of(
+                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(null, "[0-1]\\..*")))
+                )
+            )
+        );
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbesDescriptionValidationTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbesDescriptionValidationTest.java
@@ -48,7 +48,8 @@ public class ProbesDescriptionValidationTest {
         new DeprecatedPluginProbe(),
         new LastCommitDateProbe(),
         new SCMLinkValidationProbe(httpClient, githubConfiguration),
-        new UpForAdoptionProbe()
+        new UpForAdoptionProbe(),
+        new KnownSecurityVulnerabilityProbe()
     );
 
     @Test

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -35,7 +35,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.ZonedDateTime;
 import java.util.Optional;
 import javax.net.ssl.SSLSession;
 

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -66,11 +66,14 @@ class SCMLinkValidationProbeTest {
 
     @Test
     public void shouldNotAcceptNullNorEmptyScm() {
-        final Plugin p1 = new Plugin("foo", null, ZonedDateTime.now());
+        final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctxP1 = mock(ProbeContext.class);
-        final Plugin p2 = new Plugin("bar", "", ZonedDateTime.now());
+        final Plugin p2 = mock(Plugin.class);
         final ProbeContext ctxP2 = mock(ProbeContext.class);
         final SCMLinkValidationProbe probe = new SCMLinkValidationProbe(httpClient, githubConfiguration);
+
+        when(p1.getScm()).thenReturn(null);
+        when(p2.getScm()).thenReturn("");
 
         final ProbeResult r1 = probe.apply(p1, ctxP1);
         final ProbeResult r2 = probe.apply(p2, ctxP2);
@@ -82,10 +85,11 @@ class SCMLinkValidationProbeTest {
 
     @Test
     public void shouldRecognizeIncorrectSCMUrl() {
-        final Plugin p1 = new Plugin("foo", "this-is-not-correct", ZonedDateTime.now());
+        final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final SCMLinkValidationProbe probe = new SCMLinkValidationProbe(httpClient, githubConfiguration);
 
+        when(p1.getScm()).thenReturn("this-is-not-correct");
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);
@@ -94,10 +98,11 @@ class SCMLinkValidationProbeTest {
 
     @Test
     public void shouldRecognizeCorrectGitHubUrl() throws IOException, InterruptedException {
-        final Plugin p1 = new Plugin("foo", "https://github.com/jenkinsci/mailer-plugin", ZonedDateTime.now());
+        final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final SCMLinkValidationProbe probe = new SCMLinkValidationProbe(httpClient, githubConfiguration);
 
+        when(p1.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
         when(httpClient.<String>send(any(HttpRequest.class), any())).thenReturn(
             new HttpResponse<>() {
                 @Override
@@ -149,10 +154,11 @@ class SCMLinkValidationProbeTest {
 
     @Test
     public void shouldRecognizeInvalidGitHubUrl() throws Exception {
-        final Plugin p1 = new Plugin("foo", "https://github.com/jenkinsci/this-is-not-going-to-work", ZonedDateTime.now());
+        final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final SCMLinkValidationProbe probe = new SCMLinkValidationProbe(httpClient, githubConfiguration);
 
+        when(p1.getScm()).thenReturn("https://github.com/jenkinsci/this-is-not-going-to-work");
         when(httpClient.<String>send(any(HttpRequest.class), any())).thenReturn(
             new HttpResponse<>() {
                 @Override

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
@@ -33,12 +33,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
-import io.jenkins.pluginhealth.scoring.model.UpdateCenterPlugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 
+import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
 
 public class UpForAdoptionProbeTest {
@@ -54,14 +54,15 @@ public class UpForAdoptionProbeTest {
 
     @Test
     public void shouldBeAbleToDetectPluginForAdoption() {
-        final Plugin plugin = mock(Plugin.class);
+        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final UpForAdoptionProbe upForAdoptionProbe = new UpForAdoptionProbe();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new UpdateCenterPlugin("foo", "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder", "adopt-this-plugin"))),
-            Collections.emptyMap()
+            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder", "adopt-this-plugin"))),
+            Collections.emptyMap(),
+            Collections.emptyList()
         ));
 
         final ProbeResult result = upForAdoptionProbe.apply(plugin, ctx);
@@ -71,14 +72,15 @@ public class UpForAdoptionProbeTest {
 
     @Test
     public void shouldBeAbleToDetectPluginNotForAdoption() {
-        final Plugin plugin = mock(Plugin.class);
+        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final UpForAdoptionProbe upForAdoptionProbe = new UpForAdoptionProbe();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new UpdateCenterPlugin("foo", "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder"))),
-            Collections.emptyMap()
+            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder"))),
+            Collections.emptyMap(),
+            Collections.emptyList()
         ));
 
         final ProbeResult result = upForAdoptionProbe.apply(plugin, ctx);

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
@@ -35,8 +35,8 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
-import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -6,6 +6,7 @@ import io.jenkins.pluginhealth.scoring.AbstractDBContainerTest;
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
+import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -23,14 +24,14 @@ public class PluginServiceIT extends AbstractDBContainerTest {
 
     @Test
     public void shouldNotDuplicatePluginWhenNameIsTheSame() {
-        Plugin plugin = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
+        Plugin plugin = new Plugin("myPlugin", new VersionNumber("1.0"), "https://github.com/jenkinsci/my-plugin", null);
 
         pluginService.saveOrUpdate(plugin);
         assertThat(pluginRepository.findAll())
             .hasSize(1)
             .contains(plugin);
 
-        Plugin copy = new Plugin("myPlugin", "https://github.com/jenkinsci/my-plugin", null);
+        Plugin copy = new Plugin("myPlugin", new VersionNumber("1.0"), "https://github.com/jenkinsci/my-plugin", null);
         pluginService.saveOrUpdate(copy);
         assertThat(pluginRepository.findAll())
             .hasSize(1)

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
 
-import io.jenkins.pluginhealth.scoring.model.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
Resolves #55 by looking at the `warnings` section of the `update-center`. In this section we can find publicly known security vulnerabilities, so we can determine if they apply to the current plugin and to its current version.

In order to get the required details, I had to retrieve the plugin latest version from the update-center and store it in the DB. 

The trick is that, a plugin *requires* a release to not be impacted by a security vulnerability, but can be impacted by a new one without a new release. So this probe needs to be ran every time.