### PR TITLE
Checks dependabot configuration on plugin repository

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -1,0 +1,44 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(DependabotProbe.ORDER)
+public class DependabotProbe extends Probe {
+    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        final Path scmRepository = context.getScmRepository();
+        final Path githubConfig = scmRepository.resolve(".github");
+
+        try (Stream<Path> paths = Files
+            .find(githubConfig, 1, (path, basicFileAttributes) -> Files.isRegularFile(path) && path.getFileName().toString().startsWith("dependabot"))) {
+            return paths.findFirst()
+                .map(file -> ProbeResult.success(key(), "Dependabot is configured"))
+                .orElseGet(() -> ProbeResult.failure(key(), "No configuration file for dependabot"));
+        } catch (IOException ex) {
+            return ProbeResult.failure(key(), "No GitHub configuration folder");
+        }
+    }
+
+    @Override
+    public String key() {
+        return "dependabot";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks if dependabot is configured on a plugin.";
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -1,0 +1,61 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ResultStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DependabotProbeTest {
+    @Test
+    public void shouldNotRequireRelease() {
+        final DependabotProbe probe = spy(DependabotProbe.class);
+        assertThat(probe.requiresRelease()).isFalse();
+    }
+
+    @Test
+    public void shouldUseDependabotKey() {
+        final DependabotProbe probe = spy(DependabotProbe.class);
+        assertThat(probe.key()).isEqualTo("dependabot");
+    }
+
+    @Test
+    public void shouldDetectMissingDependabotFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DependabotProbe probe = new DependabotProbe();
+
+        final Path repo = Files.createTempDirectory("foo");
+        when(ctx.getScmRepository()).thenReturn(repo);
+
+        assertThat(probe.apply(plugin, ctx).status()).isEqualTo(ResultStatus.FAILURE);
+    }
+
+    @Test
+    public void shouldDetectDependabotFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DependabotProbe probe = new DependabotProbe();
+
+        final Path repo = Files.createTempDirectory("foo");
+        final Path github = Files.createDirectories(repo.resolve(".github"));
+
+        Files.createFile(github.resolve("dependabot.yml"));
+
+        when(ctx.getScmRepository()).thenReturn(repo);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+}


### PR DESCRIPTION
Resolves #57 by checking the existence of `.github/dependabot*` file on the plugin repository.