### PR TITLE
Validates documentation migration

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationLocationProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationLocationProbe.java
@@ -1,0 +1,77 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(DocumentationLocationProbe.ORDER)
+public class DocumentationLocationProbe extends Probe {
+    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentationLocationProbe.class);
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        final Path repository = context.getScmRepository();
+        if (Files.notExists(repository)) {
+            return ProbeResult.error(key(), "Cannot find plugin repository");
+        }
+
+        try (Stream<Path> buildConfigs = getFiles(repository, "pom.xml", "build.gradle");
+             Stream<Path> readmes = getFiles(repository, "README.md", "README.adoc")) {
+            final Optional<Path> buildConfig = buildConfigs.findFirst();
+            final Optional<Path> readme = readmes.findFirst();
+            final String scm = plugin.getScm();
+
+            if (readme.isEmpty()) {
+                return ProbeResult.failure(key(), "The plugin has no README");
+            }
+            if (buildConfig.isEmpty()) {
+                return ProbeResult.failure(key(), "Could not find plugin build configuration file");
+            }
+
+            return scm.equals(getBuildConfigSCM(buildConfig.get())) ?
+                ProbeResult.success(key(), "The plugin documentation was migrated") :
+                ProbeResult.failure(key(), "The plugin documentation was not migrated");
+        } catch (IOException e) {
+            LOGGER.warn("Problem inspecting plugin repository", e);
+            return ProbeResult.failure(key(), "Cannot inspect plugin repository");
+        }
+    }
+
+    private Stream<Path> getFiles(Path repository, String... fileNames) throws IOException {
+        return Files.find(repository, 1, (path, basicFileAttributes) ->
+            Files.isReadable(path) && (Arrays.stream(fileNames).anyMatch(name -> name.equals(path.getFileName().toString()))));
+    }
+
+    // TODO how to get the `project.url` in Maven or `jenkinsPlugin.url` in Gradle?
+    private String getBuildConfigSCM(Path buildConfig) {
+        return "";
+    }
+
+    @Override
+    public String key() {
+        return "documentation";
+    }
+
+    @Override
+    protected boolean requiresRelease() {
+        return true;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks if the plugin documentation was migrated to GitHub.";
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationLocationProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationLocationProbeTest.java
@@ -1,0 +1,107 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ResultStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentationLocationProbeTest {
+    @Test
+    public void shouldRequireRelease() {
+        final DocumentationLocationProbe probe = spy(DocumentationLocationProbe.class);
+        assertThat(probe.requiresRelease()).isTrue();
+    }
+
+    @Test
+    public void shouldUseDocumentationKey() {
+        final DocumentationLocationProbe probe = spy(DocumentationLocationProbe.class);
+        assertThat(probe.key()).isEqualTo("documentation");
+    }
+
+    @Test
+    public void shouldHaveDescription() {
+        final DocumentationLocationProbe probe = spy(DocumentationLocationProbe.class);
+        assertThat(probe.getDescription()).isNotBlank();
+    }
+
+    // TODO same for gradle
+    @Test
+    public void shouldValidateCompletedMigrationOnMaven() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DocumentationLocationProbe probe = new DocumentationLocationProbe();
+
+        final String pluginRepositoryUrl = "this-is-the-url";
+        when(plugin.getScm()).thenReturn(pluginRepositoryUrl);
+        final Path repository = Files.createTempDirectory("boo");
+        Files.createFile(repository.resolve("README.md"));
+        final Path pom = Files.createFile(repository.resolve("pom.xml"));
+        Files.write(pom, List.of(
+            "<project>","<url>",pluginRepositoryUrl, "</url>", "</project>"
+        ), StandardCharsets.UTF_8);
+
+        when(ctx.getScmRepository()).thenReturn(repository);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+
+    @Test
+    public void shouldInvalidateRepositoryWithMissingREADME() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DocumentationLocationProbe probe = new DocumentationLocationProbe();
+
+        final String pluginRepositoryUrl = "this-is-the-url";
+        final Path repository = Files.createTempDirectory("boo");
+        final Path pom = Files.createFile(repository.resolve("pom.xml"));
+        Files.write(pom, List.of(
+            "<project>","<url>",pluginRepositoryUrl, "</url>", "</project>"
+        ), StandardCharsets.UTF_8);
+
+        when(ctx.getScmRepository()).thenReturn(repository);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo("The plugin has no README");
+    }
+
+    @Test
+    public void shouldInvalidateRepositoryWithMissingUrl() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DocumentationLocationProbe probe = new DocumentationLocationProbe();
+
+        final String pluginRepositoryUrl = "this-is-the-url";
+        when(plugin.getScm()).thenReturn(pluginRepositoryUrl);
+        final Path repository = Files.createTempDirectory("boo");
+        Files.createFile(repository.resolve("README.md"));
+        final Path pom = Files.createFile(repository.resolve("pom.xml"));
+        Files.write(pom, List.of(
+            "<project>", "</project>"
+        ), StandardCharsets.UTF_8);
+
+        when(ctx.getScmRepository()).thenReturn(repository);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo("The plugin documentation was not migrated");
+    }
+}


### PR DESCRIPTION
Resolves #58.

Based on https://www.jenkins.io/doc/developer/publishing/documentation guidelines. For the migration to be complete, it requires a `README.{md,adoc}` file and for the build tool to have the `url` configured.

Requires to parse build configuration file.