### PR TITLE
Validates configuration of JEP-229 on plugin repository

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(ContinuousDeploymentProbe.ORDER)
+public class ContinuousDeploymentProbe extends Probe {
+    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContinuousDeploymentProbe.class);
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        final Path repo = context.getScmRepository();
+        final Path githubWorkflow = repo.resolve(".github/workflows");
+        try (Stream<Path> files = Files.find(githubWorkflow, 1, (path, basicFileAttributes) -> Files.isRegularFile(path) && "cd.yml".equals(path.getFileName().toString()))) {
+            return files.findFirst().isPresent() ?
+                ProbeResult.success(key(), "JEP-229 workflow definition found") :
+                ProbeResult.failure(key(), "Could not find JEP-229 workflow definition");
+        } catch (IOException ex) {
+            LOGGER.warn("Could not walk {} Git clone in {}", plugin.getName(), repo, ex);
+            return ProbeResult.failure(key(), "Could not find GHA workflows definitions directory");
+        }
+    }
+
+    @Override
+    public String key() {
+        return "jep-229";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks if JEP-229 (Continuous Deployment) has been activated on the plugin";
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ResultStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContinuousDeploymentProbeTest {
+    @Test
+    public void shouldNotRequireRelease() {
+        final ContinuousDeploymentProbe probe = spy(ContinuousDeploymentProbe.class);
+        assertThat(probe.requiresRelease()).isFalse();
+    }
+
+    @Test
+    public void shouldKeepUsingJEP229Key() throws Exception {
+        final ContinuousDeploymentProbe probe = spy(ContinuousDeploymentProbe.class);
+        assertThat(probe.key()).isEqualTo("jep-229");
+    }
+
+    @Test
+    public void shouldBeAbleToDetectRepositoryWithNoGHA() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final ContinuousDeploymentProbe probe = new ContinuousDeploymentProbe();
+
+        when(plugin.getName()).thenReturn("foo");
+        when(ctx.getScmRepository()).thenReturn(Files.createTempDirectory("foo"));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo("Could not find GHA workflows definitions directory");
+    }
+
+    @Test
+    public void shouldBeAbleToDetectNotConfiguredRepository() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final ContinuousDeploymentProbe probe = new ContinuousDeploymentProbe();
+
+        final Path repo = Files.createTempDirectory("foo");
+        Files.createDirectories(repo.resolve(".github/workflows"));
+        when(ctx.getScmRepository()).thenReturn(repo);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(result.message()).isEqualTo("Could not find JEP-229 workflow definition");
+    }
+
+    @Test
+    public void shouldBeAbleToDetectConfiguredRepository() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final ContinuousDeploymentProbe probe = new ContinuousDeploymentProbe();
+
+        final Path repo = Files.createTempDirectory("foo");
+        final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
+        Files.createFile(workflows.resolve("cd.yml"));
+        when(ctx.getScmRepository()).thenReturn(repo);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+        assertThat(result.message()).isEqualTo("JEP-229 workflow definition found");
+    }
+}


### PR DESCRIPTION
Resolved #56 by checking the existence of the `.github/workflows/cd.yml` file in the plugin repository.

We could rely on the GitHub API for this, and look for the workflows on the repository. But this way seemed more efficient and we can spare a call to GitHub API so we can use it for other probes with no other options. 