### PR TITLE
Fixes unnecessary log with no gha configurations

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
@@ -47,13 +47,16 @@ public class ContinuousDeploymentProbe extends Probe {
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final Path repo = context.getScmRepository();
         final Path githubWorkflow = repo.resolve(".github/workflows");
+        if (Files.notExists(githubWorkflow)) {
+            return ProbeResult.failure(key(), "Plugin has no GitHub Action configured");
+        }
         try (Stream<Path> files = Files.find(githubWorkflow, 1, (path, basicFileAttributes) -> Files.isRegularFile(path) && "cd.yml".equals(path.getFileName().toString()))) {
             return files.findFirst().isPresent() ?
                 ProbeResult.success(key(), "JEP-229 workflow definition found") :
                 ProbeResult.failure(key(), "Could not find JEP-229 workflow definition");
         } catch (IOException ex) {
             LOGGER.warn("Could not walk {} Git clone in {}", plugin.getName(), repo, ex);
-            return ProbeResult.failure(key(), "Could not find GHA workflows definitions directory");
+            return ProbeResult.error(key(), "Could not work plugin repository");
         }
     }
 

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
@@ -60,12 +60,11 @@ class ContinuousDeploymentProbeTest {
         final ProbeContext ctx = mock(ProbeContext.class);
         final ContinuousDeploymentProbe probe = new ContinuousDeploymentProbe();
 
-        when(plugin.getName()).thenReturn("foo");
         when(ctx.getScmRepository()).thenReturn(Files.createTempDirectory("foo"));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
-        assertThat(result.message()).isEqualTo("Could not find GHA workflows definitions directory");
+        assertThat(result.message()).isEqualTo("Plugin has no GitHub Action configured");
     }
 
     @Test


### PR DESCRIPTION
Fixes #89.

Not all plugins have a GHA directory and this should be a simple failure from the CD probe. It doesn't require logs.