### PR TITLE
Includes long yaml file extension to detect CD workflows

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbe.java
@@ -27,6 +27,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -50,7 +51,9 @@ public class ContinuousDeploymentProbe extends Probe {
         if (Files.notExists(githubWorkflow)) {
             return ProbeResult.failure(key(), "Plugin has no GitHub Action configured");
         }
-        try (Stream<Path> files = Files.find(githubWorkflow, 1, (path, basicFileAttributes) -> Files.isRegularFile(path) && "cd.yml".equals(path.getFileName().toString()))) {
+        try (Stream<Path> files = Files.find(githubWorkflow, 1,
+            (path, basicFileAttributes) -> Files.isRegularFile(path) && List.of("cd.yml", "cd.yaml").contains(path.getFileName().toString())
+        )) {
             return files.findFirst().isPresent() ?
                 ProbeResult.success(key(), "JEP-229 workflow definition found") :
                 ProbeResult.failure(key(), "Could not find JEP-229 workflow definition");

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeploymentProbeTest.java
@@ -49,7 +49,7 @@ class ContinuousDeploymentProbeTest {
     }
 
     @Test
-    public void shouldKeepUsingJEP229Key() throws Exception {
+    public void shouldKeepUsingJEP229Key() {
         final ContinuousDeploymentProbe probe = spy(ContinuousDeploymentProbe.class);
         assertThat(probe.key()).isEqualTo("jep-229");
     }
@@ -91,6 +91,22 @@ class ContinuousDeploymentProbeTest {
         final Path repo = Files.createTempDirectory("foo");
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         Files.createFile(workflows.resolve("cd.yml"));
+        when(ctx.getScmRepository()).thenReturn(repo);
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+        assertThat(result.message()).isEqualTo("JEP-229 workflow definition found");
+    }
+
+    @Test
+    public void shouldBeAbleToDetectConfiguredRepositoryWithLongExtension() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final ContinuousDeploymentProbe probe = new ContinuousDeploymentProbe();
+
+        final Path repo = Files.createTempDirectory("foo");
+        final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
+        Files.createFile(workflows.resolve("cd.yaml"));
         when(ctx.getScmRepository()).thenReturn(repo);
 
         final ProbeResult result = probe.apply(plugin, ctx);


### PR DESCRIPTION
Resolves #91.
Thanks @NotMyFault for catching this. 

Not all JEP-229 workflow files are named `cd.yml` but some are also using the "long" yaml file extension.

Theoretically, some could also be name something completely different and I guess the content of the file would be more relevant. But that is many for another time.