### PR TITLE
Limits scope of Update-Center updates

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
@@ -30,11 +30,14 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateCenterScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateCenterScheduler.class);
     private final UpdateCenterService updateCenterService;
     private final PluginService pluginService;
 
@@ -45,9 +48,13 @@ public class UpdateCenterScheduler {
 
     @Scheduled(cron = "${cron.update-center}", zone = "UTC")
     public void updateDatabase() throws IOException {
+        LOGGER.info("Updating plugins from update-center");
         updateCenterService.fetchUpdateCenter()
             .plugins().values().stream()
             .map(Plugin::toPlugin)
             .forEach(pluginService::saveOrUpdate);
+        if(LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Plugins updated from update-center");
+        }
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
@@ -27,7 +27,6 @@ package io.jenkins.pluginhealth.scoring.schedule;
 import java.io.IOException;
 
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
-import io.jenkins.pluginhealth.scoring.probes.ProbeEngine;
 import io.jenkins.pluginhealth.scoring.service.PluginService;
 import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 
@@ -38,13 +37,10 @@ import org.springframework.stereotype.Component;
 public class UpdateCenterScheduler {
     private final UpdateCenterService updateCenterService;
     private final PluginService pluginService;
-    private final ProbeEngine probeEngine;
 
-    public UpdateCenterScheduler(UpdateCenterService updateCenterService, PluginService pluginService,
-                                 ProbeEngine probeEngine) {
+    public UpdateCenterScheduler(UpdateCenterService updateCenterService, PluginService pluginService) {
         this.updateCenterService = updateCenterService;
         this.pluginService = pluginService;
-        this.probeEngine = probeEngine;
     }
 
     @Scheduled(cron = "${cron.update-center}", zone = "UTC")
@@ -53,6 +49,5 @@ public class UpdateCenterScheduler {
             .plugins().values().stream()
             .map(Plugin::toPlugin)
             .forEach(pluginService::saveOrUpdate);
-        probeEngine.run();
     }
 }


### PR DESCRIPTION
Updating the list of plugins from the update-center shouldn't run the probe-engine.

I believe this was added to simplify execution in dev environment, it was a mistake.