### PR TITLE
Updates probe result in plugins only when status/reason changes

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -113,13 +113,15 @@ public class Plugin {
         return Map.copyOf(details);
     }
 
-    public Plugin addDetails(ProbeResult result) {
-        details.put(result.id(), result);
+    public Plugin addDetails(ProbeResult newProbeResult) {
+        this.details.compute(newProbeResult.id(), (s, previousProbeResult) -> {
+            return Objects.equals(previousProbeResult, newProbeResult) ? previousProbeResult : newProbeResult;
+        });
         return this;
     }
 
     public Plugin addDetails(Map<String, ProbeResult> details) {
-        this.details.putAll(details);
+        details.values().forEach(this::addDetails);
         return this;
     }
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
@@ -25,6 +25,7 @@
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 /**
  * Represents the result of one analyze performed by a {@link io.jenkins.pluginhealth.scoring.probes.Probe} implementation on a {@link Plugin}
@@ -36,6 +37,19 @@ import java.time.ZonedDateTime;
 public record ProbeResult(String id, String message, ResultStatus status, ZonedDateTime timestamp) {
     public ProbeResult(String id, String message, ResultStatus status) {
         this(id, message, status, ZonedDateTime.now());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProbeResult that = (ProbeResult) o;
+        return id.equals(that.id) && message.equals(that.message) && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, status);
     }
 
     public static ProbeResult success(String id, String message) {

--- a/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PluginTest {
+    @Test
+    public void shouldUpdateDetailsIfNoPreviousDetailsPresent() {
+        final Plugin plugin = spy(Plugin.class);
+        final ProbeResult probeResult = ProbeResult.success("foo", "this is a message");
+
+        plugin.addDetails(probeResult);
+        assertThat(plugin.getDetails()).hasSize(1);
+        assertThat(plugin.getDetails()).containsEntry("foo", probeResult);
+    }
+
+    @Test
+    public void shouldUpdateDetailsIfPreviousDetailsPresentAndDifferent() {
+        final Plugin plugin = spy(Plugin.class);
+        final String probeKey = "foo";
+        final String probeResultMessage = "this is a message";
+
+        final ProbeResult previousProbeResult = new ProbeResult(probeKey, probeResultMessage, ResultStatus.FAILURE, ZonedDateTime.now().minusMinutes(10));
+        final ProbeResult probeResult = new ProbeResult(probeKey, probeResultMessage, ResultStatus.SUCCESS, ZonedDateTime.now());
+
+        plugin.addDetails(previousProbeResult);
+        plugin.addDetails(probeResult);
+
+        assertThat(plugin.getDetails()).hasSize(1);
+        assertThat(plugin.getDetails()).containsEntry(probeKey, probeResult);
+    }
+
+    @Test
+    public void shouldNotUpdateDetailsIfPreviousDetailsPresentButSame() {
+        final Plugin plugin = spy(Plugin.class);
+        final String probeKey = "foo";
+        final String probeResultMessage = "this is a message";
+
+        final ProbeResult previousProbeResult = new ProbeResult(probeKey, probeResultMessage, ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(10));
+        final ProbeResult probeResult = new ProbeResult(probeKey, probeResultMessage, ResultStatus.SUCCESS, ZonedDateTime.now());
+
+        plugin.addDetails(previousProbeResult);
+        plugin.addDetails(probeResult);
+
+        assertThat(plugin.getDetails()).hasSize(1);
+        assertThat(plugin.getDetails()).containsEntry(probeKey, previousProbeResult);
+    }
+}


### PR DESCRIPTION
Excludes timestamp from probe result equality check.

Resolves #125.