### PR TITLE
Fixes null exception on plugin version

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
@@ -58,13 +58,14 @@ public class VersionNumberType implements UserType<VersionNumber> {
 
     @Override
     public VersionNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
-        return rs.wasNull() ?
-            null : new VersionNumber(rs.getString(position));
+        final String value = rs.getString(position);
+        return rs.wasNull() || Objects.isNull(value) ?
+            null : new VersionNumber(value);
     }
 
     @Override
     public void nullSafeSet(PreparedStatement st, VersionNumber value, int index, SharedSessionContractImplementor session) throws SQLException {
-        if (value == null) {
+        if (Objects.isNull(value)) {
             st.setNull(index, SqlTypes.VARCHAR);
         } else {
             st.setString(index, value.toString());
@@ -73,17 +74,21 @@ public class VersionNumberType implements UserType<VersionNumber> {
 
     @Override
     public VersionNumber deepCopy(VersionNumber value) {
-        return value;
+        if (Objects.isNull(value)) {
+            return null;
+        }
+        return new VersionNumber(value.toString());
     }
 
     @Override
     public boolean isMutable() {
-        return false;
+        return true;
     }
 
     @Override
     public Serializable disassemble(VersionNumber value) {
-        return value.toString();
+        final VersionNumber versionNumber = deepCopy(value);
+        return versionNumber == null ? null : versionNumber.toString();
     }
 
     @Override

--- a/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -26,6 +26,9 @@ package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
 import io.jenkins.pluginhealth.scoring.AbstractDBContainerTest;
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
@@ -60,5 +63,22 @@ public class PluginServiceIT extends AbstractDBContainerTest {
         assertThat(pluginRepository.findAll())
             .hasSize(1)
             .contains(plugin);
+    }
+
+    @Test
+    public void shouldBeAbleToSavePluginWithThreeDigitVersion() {
+        final Plugin plugin = new Plugin("foo-bar", new VersionNumber("1.0.1"), null, ZonedDateTime.now());
+
+        assertThat(pluginRepository.count()).isEqualTo(0);
+        pluginService.saveOrUpdate(plugin);
+        assertThat(pluginRepository.count()).isEqualTo(1);
+
+        final Optional<Plugin> saved = pluginRepository.findByName("foo-bar");
+        assertThat(saved)
+            .isPresent()
+            .get()
+            .extracting("version")
+            .isNotNull()
+            .isEqualTo(new VersionNumber("1.0.1"));
     }
 }


### PR DESCRIPTION
Resolves #115
Resolves #139

The `VersionNumber` was not read correctly from the database, creating a `null` value which was saved as is after the probe engine was executed on the plugin. 
This also created a problem in some probes using the `version` value.