### PR TITLE
Protects `/api/scores` against plugins with null version 

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
@@ -59,8 +59,7 @@ public class VersionNumberType implements UserType<VersionNumber> {
     @Override
     public VersionNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
         final String value = rs.getString(position);
-        return rs.wasNull() || Objects.isNull(value) ?
-            null : new VersionNumber(value);
+        return Objects.isNull(value) ? null : new VersionNumber(value);
     }
 
     @Override
@@ -74,15 +73,12 @@ public class VersionNumberType implements UserType<VersionNumber> {
 
     @Override
     public VersionNumber deepCopy(VersionNumber value) {
-        if (Objects.isNull(value)) {
-            return null;
-        }
-        return new VersionNumber(value.toString());
+        return Objects.isNull(value) ? null : new VersionNumber(value.toString());
     }
 
     @Override
     public boolean isMutable() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -52,7 +52,7 @@ public class Plugin {
     private String name;
 
     @Type(VersionNumberType.class)
-    @Column(name = "version", updatable = false)
+    @Column(name = "version", nullable = false)
     private VersionNumber version;
 
     @Column(name = "scm")

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
@@ -37,8 +37,8 @@ import io.jenkins.pluginhealth.scoring.probes.Probe;
 import io.jenkins.pluginhealth.scoring.probes.ProbeContext;
 import io.jenkins.pluginhealth.scoring.repository.PluginRepository;
 
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProbeService {
@@ -54,7 +54,7 @@ public class ProbeService {
         return probes;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Map<String, Long> getProbesFinalResults() {
         return probes.stream()
             .filter(probe ->

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoreService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoreService.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.Score;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.repository.ScoreRepository;
@@ -62,10 +63,19 @@ public class ScoreService {
         return repository.findLatestScoreForAllPlugins().stream()
             .collect(Collectors.toMap(
                 score -> score.getPlugin().getName(),
-                score -> new ScoreSummary(score.getValue(), score.getPlugin().getVersion().toString(), score.getDetails(), score.getComputedAt())
+                ScoreSummary::fromScore
             ));
     }
 
     public record ScoreSummary(long value, String version, Set<ScoreResult> details, ZonedDateTime timestamp) {
+        public static ScoreSummary fromScore(Score score) {
+            final Plugin plugin = score.getPlugin();
+            return new ScoreSummary(
+                score.getValue(),
+                plugin.getVersion() == null ? "" : plugin.getVersion().toString(),
+                score.getDetails(),
+                score.getComputedAt()
+            );
+        }
     }
 }


### PR DESCRIPTION
Resolves #175.

This is treating the error but plugins should have empty version in the first place.