### PR TITLE
Plugin deprecation does not imply security issue

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarning;
 
 import org.springframework.core.annotation.Order;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -45,10 +45,6 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult deprecatedProbeResult = plugin.getDetails().get(DeprecatedPluginProbe.KEY);
-        if (deprecatedProbeResult != null && deprecatedProbeResult.status().equals(ResultStatus.FAILURE)) {
-            return ProbeResult.failure(key(), "Plugin is deprecated");
-        }
         final List<SecurityWarning> warnings = context.getUpdateCenter().warnings();
         final String issues = warnings.stream()
             .filter(w -> w.name().equals(plugin.getName()))

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
@@ -26,7 +26,6 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.slf4j.Logger;

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
@@ -47,10 +47,6 @@ public class UpForAdoptionProbe extends Probe {
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final UpdateCenter updateCenter = context.getUpdateCenter();
-        final ProbeResult deprecatedProbeResult = plugin.getDetails().get(DeprecatedPluginProbe.KEY);
-        if (deprecatedProbeResult != null && deprecatedProbeResult.status().equals(ResultStatus.FAILURE)) {
-            return ProbeResult.failure(key(), "Plugin is deprecated");
-        }
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin pl = updateCenter.plugins().get(plugin.getName());
         if (pl == null) {
             LOGGER.info("Couldn't not find {} in update-center", plugin.getName());

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -61,6 +61,11 @@ class KnownSecurityVulnerabilityProbeTest {
     }
 
     @Test
+    public void shouldHaveDescription() {
+        assertThat(spy(KnownSecurityVulnerabilityProbe.class).getDescription()).isNotBlank();
+    }
+
+    @Test
     public void shouldBeOKWithNoSecurityWarning() {
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);


### PR DESCRIPTION
A plugin marked as deprecated doesn't mean that it has a security issue. 

cc @jmMeessen @gounthar