### PR TITLE
Count open pull requests created by Dependabot

### DIFF
--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(DependabotPullRequestProbe.ORDER)
+public class DependabotPullRequestProbe extends Probe {
+    public static final String KEY = "dependabot-pull-requests";
+    public static final int ORDER = DependabotProbe.ORDER + 1;
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        return null;
+    }
+
+    @Override
+    public String key() {
+        return KEY;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+}

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -48,6 +48,6 @@ public class DependabotPullRequestProbe extends Probe {
 
     @Override
     public String getDescription() {
-        return null;
+        return "Reports the number of pull request currently opened by Dependabot";
     }
 }

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
@@ -70,6 +71,11 @@ public class ProbeContext {
 
     public void setGitHub(GitHub github) {
         this.github = github;
+    }
+
+    public Optional<String> getRepositoryName(String scm) {
+        final Matcher match = SCMLinkValidationProbe.GH_PATTERN.matcher(scm);
+        return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
     }
 
     /* default */ void cleanUp() throws IOException {

--- a/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
@@ -60,7 +60,7 @@ public class PullRequestProbe extends Probe {
 
         try {
             final GitHub gh = context.getGitHub();
-            final GHRepository repository = gh.getRepository(getRepositoryName(plugin.getScm()).orElseThrow());
+            final GHRepository repository = gh.getRepository(context.getRepositoryName(plugin.getScm()).orElseThrow());
             final List<GHPullRequest> pullRequests = repository.getPullRequests(GHIssueState.OPEN);
 
             return ProbeResult.success(key(), "%d".formatted(pullRequests.size()));
@@ -70,11 +70,6 @@ public class PullRequestProbe extends Probe {
             }
             return ProbeResult.failure(key(), e.getMessage());
         }
-    }
-
-    private Optional<String> getRepositoryName(String scm) {
-        final Matcher match = SCMLinkValidationProbe.GH_PATTERN.matcher(scm);
-        return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -30,6 +30,7 @@ import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
+import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
 import io.jenkins.pluginhealth.scoring.probes.JenkinsfileProbe;
 
 import org.springframework.stereotype.Component;
@@ -43,6 +44,7 @@ public class PluginMaintenanceScoring extends Scoring {
     protected ScoreResult doApply(Plugin plugin) {
         final ProbeResult jenkinsfileProbeResult = plugin.getDetails().get(JenkinsfileProbe.KEY);
         final ProbeResult dependabotProbeResult = plugin.getDetails().get(DependabotProbe.KEY);
+        final ProbeResult dependabotPullRequestResult = plugin.getDetails().get(DependabotPullRequestProbe.KEY);
         final ProbeResult cdProbeResult = plugin.getDetails().get(ContinuousDeliveryProbe.KEY);
 
         if (jenkinsfileProbeResult == null || jenkinsfileProbeResult.status().equals(ResultStatus.FAILURE)) {
@@ -50,6 +52,11 @@ public class PluginMaintenanceScoring extends Scoring {
         }
 
         if (dependabotProbeResult == null || dependabotProbeResult.status().equals(ResultStatus.FAILURE)) {
+            return new ScoreResult(KEY, .75f, COEFFICIENT);
+        }
+
+        if (dependabotPullRequestResult != null && dependabotPullRequestResult.status().equals(ResultStatus.SUCCESS)
+            && Integer.parseInt(dependabotPullRequestResult.message()) > 0) {
             return new ScoreResult(KEY, .75f, COEFFICIENT);
         }
 

--- a/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
+++ b/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
 import io.jenkins.pluginhealth.scoring.probes.DeprecatedPluginProbe;
 import io.jenkins.pluginhealth.scoring.probes.InstallationStatProbe;
 import io.jenkins.pluginhealth.scoring.probes.JenkinsCoreProbe;
@@ -59,6 +60,7 @@ public class ProbeService {
     }
 
     private static final List<String> IGNORE_RAW_RESULT_PROBES = List.of(
+        DependabotPullRequestProbe.KEY,
         InstallationStatProbe.KEY,
         JenkinsCoreProbe.KEY,
         LastCommitDateProbe.KEY,

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -1,0 +1,119 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DependabotPullRequestProbeTest {
+    @Test
+    public void shouldUseSpecificKey() {
+        assertThat(spy(DependabotPullRequestProbe.class).key()).isEqualTo(DependabotPullRequestProbe.KEY);
+    }
+
+    @Test
+    public void shouldNotRequireRelease() {
+        assertThat(spy(DependabotPullRequestProbe.class).requiresRelease()).isFalse();
+    }
+
+    @Test
+    public void shouldNotBeRelatedToSourceCode() {
+        assertThat(spy(DependabotPullRequestProbe.class).isSourceCodeRelated()).isFalse();
+    }
+
+    @Test
+    public void shouldBeSkippedWhenNoDependabot() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getDetails()).thenReturn(Map.of());
+
+        final DependabotPullRequestProbe probe = new DependabotPullRequestProbe();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result).usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "Repository is not configured to use dependabot"));
+    }
+
+    @Test
+    public void shouldAccessGitHubAPIWhenDependabotActivated() throws IOException {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final GitHub gh = mock(GitHub.class);
+        final GHRepository ghRepository = mock(GHRepository.class);
+
+        when(plugin.getDetails()).thenReturn(Map.of(
+            DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "")
+        ));
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
+
+        when(ctx.getGitHub()).thenReturn(gh);
+        when(gh.getRepository(anyString())).thenReturn(ghRepository);
+
+        final GHLabel dependenciesLabel = mock(GHLabel.class);
+        when(dependenciesLabel.getName()).thenReturn("dependencies");
+
+        final GHPullRequest pr_1 = mock(GHPullRequest.class);
+        when(pr_1.getLabels()).thenReturn(List.of(dependenciesLabel));
+        final GHPullRequest pr_2 = mock(GHPullRequest.class);
+        final GHPullRequest pr_3 = mock(GHPullRequest.class);
+        when(pr_3.getLabels()).thenReturn(List.of(dependenciesLabel));
+        final GHPullRequest pr_4 = mock(GHPullRequest.class);
+        final GHPullRequest pr_5 = mock(GHPullRequest.class);
+        when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(
+            List.of(pr_1, pr_2, pr_3, pr_4, pr_5)
+        );
+
+        final DependabotPullRequestProbe probe = new DependabotPullRequestProbe();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result).usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.success(DependabotPullRequestProbe.KEY, "2"));
+    }
+}

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -24,7 +24,6 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -52,6 +51,11 @@ class DependabotPullRequestProbeTest {
     @Test
     public void shouldUseSpecificKey() {
         assertThat(spy(DependabotPullRequestProbe.class).key()).isEqualTo(DependabotPullRequestProbe.KEY);
+    }
+
+    @Test
+    public void shouldHaveDescription() {
+        assertThat(spy(DependabotPullRequestProbe.class).getDescription()).isNotBlank();
     }
 
     @Test

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -98,6 +98,7 @@ class DependabotPullRequestProbeTest {
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
 
         when(ctx.getGitHub()).thenReturn(gh);
+        when(ctx.getRepositoryName(plugin.getScm())).thenReturn(Optional.of("jenkinsci/mailer-plugin"));
         when(gh.getRepository(anyString())).thenReturn(ghRepository);
 
         final GHLabel dependenciesLabel = mock(GHLabel.class);

--- a/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
+++ b/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
@@ -99,6 +100,7 @@ class PullRequestProbeTest {
         ));
         when(ctx.getGitHub()).thenReturn(gh);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
+        when(ctx.getRepositoryName(plugin.getScm())).thenReturn(Optional.of("jenkinsci/mailer-plugin"));
         when(gh.getRepository(anyString())).thenReturn(ghRepository);
         final List<GHPullRequest> ghPullRequests = List.of(
             new GHPullRequest(),
@@ -131,6 +133,7 @@ class PullRequestProbeTest {
         ));
         when(ctx.getGitHub()).thenReturn(gh);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
+        when(ctx.getRepositoryName(plugin.getScm())).thenReturn(Optional.of("jenkinsci/mailer-plugin"));
         when(gh.getRepository(anyString())).thenThrow(IOException.class);
 
         final PullRequestProbe probe = new PullRequestProbe();


### PR DESCRIPTION
Resolves #196.

This needs to be included in the Plugin Maintenance scoring process as even if dependabot is activated, having pull requests opened by it is not good.