### PR TITLE
Uses OkHttp to cache responses from GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,10 @@
 			<artifactId>java-jwt</artifactId>
 			<version>4.2.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Based on https://github-api.kohsuke.org/#Pluggable_HTTP_client, it is possible to leverage the OkHttp library and its caching feature to limit the requests against GitHub.

This could help with the growing numbers of probes which are checking elements on GitHub API.