### PR TITLE
Publish project binairies to Maven Repository Manager

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 
+String phase = infra.isInfra() ? 'deploy' : 'verify'
+
 pipeline {
   agent {
     // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
@@ -17,8 +19,14 @@ pipeline {
         JAVA_HOME = '/opt/jdk-17/'
       }
       steps {
-        final String phase = infra.isInfra() ? 'deploy' : 'verify'
-        sh "./mvnw -V $phase checkstyle:checkstyle spotbugs:spotbugs -Dmaven.test.failure.ignore -Dcheckstyle.failOnViolation=false -Dspotbugs.failOnError=false"
+        sh """
+          ./mvnw -V ${phase}\
+            checkstyle:checkstyle \
+            spotbugs:spotbugs \
+            -Dmaven.test.failure.ignore \
+            -Dcheckstyle.failOnViolation=false \
+            -Dspotbugs.failOnError=false
+        """
       }
 
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         JAVA_HOME = '/opt/jdk-17/'
       }
       steps {
-        sh './mvnw -V verify checkstyle:checkstyle spotbugs:spotbugs -Dmaven.test.failure.ignore -Dcheckstyle.failOnViolation=false -Dspotbugs.failOnError=false'
+        sh './mvnw -V deploy checkstyle:checkstyle spotbugs:spotbugs -Dmaven.test.failure.ignore -Dcheckstyle.failOnViolation=false -Dspotbugs.failOnError=false'
       }
 
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ pipeline {
         JAVA_HOME = '/opt/jdk-17/'
       }
       steps {
-        sh './mvnw -V deploy checkstyle:checkstyle spotbugs:spotbugs -Dmaven.test.failure.ignore -Dcheckstyle.failOnViolation=false -Dspotbugs.failOnError=false'
+        final String phase = infra.isInfra() ? 'deploy' : 'verify'
+        sh "./mvnw -V $phase checkstyle:checkstyle spotbugs:spotbugs -Dmaven.test.failure.ignore -Dcheckstyle.failOnViolation=false -Dspotbugs.failOnError=false"
       }
 
       post {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,4 +100,12 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,18 @@
 					</configuration>
 				</plugin>
 				<plugin>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.2.1</version>
+					<executions>
+						<execution>
+							<phase>verify</phase>
+							<goals>
+								<goal>jar-no-fork</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.0.0-M9</version>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,13 @@
 					</configuration>
 				</plugin>
 				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.1.0</version>
+					<configuration>
+						<deployAtEnd>true</deployAtEnd>
+					</configuration>
+				</plugin>
+				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
 					<version>3.0.0-M9</version>
 					<configuration>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -57,4 +57,12 @@
 			<artifactId>postgresql</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #231.

The main idea behind the split of the source of the application into modules is to allow external parties to create their own Probe and Scoring implementation and ran their version of the project.
However, the binaries necessary for this are not published to the Maven Repository Manager so those external parties cannot get the dependencies. 

As this is a build modification, this is the test.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
