### PR TITLE
Fixes NPE in SpotBugsProbe when plugin is not part of UpdateCenter

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -56,6 +56,9 @@ public class SpotBugsProbe extends Probe {
 
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
             context.getUpdateCenter().plugins().get(plugin.getName());
+        if (ucPlugin == null) {
+            return ProbeResult.error(key(), "This plugin is no longer in the update-center");
+        }
         final String defaultBranch = ucPlugin.defaultBranch();
         try {
             final Optional<String> repositoryName = context.getRepositoryName(plugin.getScm());

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -231,4 +231,32 @@ class SpotBugsProbeTest {
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.failure(SpotBugsProbe.KEY, "SpotBugs not found in build configuration"));
     }
+
+    @Test
+    void shouldNotThrowExceptionWhenPluginRemovedFromUpdateCenter() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getName()).thenReturn("mailer");
+        when(plugin.getDetails()).thenReturn(Map.of(
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
+            Map.of(),
+            Map.of(),
+            List.of()
+        ));
+
+        final SpotBugsProbe probe = new SpotBugsProbe();
+        try {
+            final ProbeResult result = probe.apply(plugin, ctx);
+            assertThat(result)
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, "This plugin is no longer in the update-center"));
+        } catch(NullPointerException ex) {
+            assert false;
+        }
+
+    }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -254,7 +254,7 @@ class SpotBugsProbeTest {
                 .usingRecursiveComparison()
                 .comparingOnlyFields("id", "status", "message")
                 .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, "This plugin is no longer in the update-center"));
-        } catch(NullPointerException ex) {
+        } catch (NullPointerException ex) {
             assert false;
         }
 


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #252.

SpotBugs probe is using details from the UpdateCenter. However, plugins can be removed from the update-center, which creates an NullPointerException when executed.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
