### PR TITLE
Fix last commit date probe execution requirement

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -111,9 +111,9 @@ public class Plugin {
     }
 
     public Plugin addDetails(ProbeResult newProbeResult) {
-        this.details.compute(newProbeResult.id(), (s, previousProbeResult) -> {
-            return Objects.equals(previousProbeResult, newProbeResult) ? previousProbeResult : newProbeResult;
-        });
+        this.details.compute(newProbeResult.id(), (s, previousProbeResult) ->
+            Objects.equals(previousProbeResult, newProbeResult) ? previousProbeResult : newProbeResult
+        );
         return this;
     }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -104,6 +104,11 @@ public class LastCommitDateProbe extends Probe {
 
     @Override
     protected boolean isSourceCodeRelated() {
-        return true;
+        /*
+         * This is counter intuitive, but this probe needs to be executed all the time.
+         * So even if the probe seems to be related to code, in order to not be skipped by the
+         * ProbeEngine, is must be `false`.
+         */
+        return false;
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
@@ -25,6 +25,7 @@
 package io.jenkins.pluginhealth.scoring.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.spy;
 
 import java.time.ZonedDateTime;
@@ -58,7 +59,8 @@ class PluginTest {
         plugin.addDetails(probeResult);
 
         assertThat(plugin.getDetails()).hasSize(1);
-        assertThat(plugin.getDetails()).containsEntry(probeKey, probeResult);
+        assertThat(plugin.getDetails())
+            .containsExactly(entry(probeKey, probeResult));
     }
 
     @Test
@@ -74,6 +76,7 @@ class PluginTest {
         plugin.addDetails(probeResult);
 
         assertThat(plugin.getDetails()).hasSize(1);
-        assertThat(plugin.getDetails()).containsEntry(probeKey, previousProbeResult);
+        assertThat(plugin.getDetails())
+            .containsExactly(entry(probeKey, previousProbeResult));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class ProbeResultTest {
+    @Test
+    void shouldBeEqualsWithSameStatusAndIdAndMessage() {
+        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1));
+        final ProbeResult result2 = new ProbeResult("probe", "this is a message", ResultStatus.SUCCESS, ZonedDateTime.now());
+
+        assertThat(result1).isEqualTo(result2);
+    }
+
+    @Test
+    void shouldNotBeEqualsWithDifferentMessages() {
+        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1));
+        final ProbeResult result2 = new ProbeResult("probe", "this is a different message", ResultStatus.SUCCESS, ZonedDateTime.now());
+
+        assertThat(result1).isNotEqualTo(result2);
+    }
+
+    @Test
+    void shouldNotBeEqualsWithDifferentStatues() {
+        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1));
+        final ProbeResult result2 = new ProbeResult("probe", "this is a message", ResultStatus.FAILURE, ZonedDateTime.now());
+
+        assertThat(result1).isNotEqualTo(result2);
+    }
+
+    @Test
+    void shouldNotBeEqualsWithDifferentMessagesAndStatues() {
+        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1));
+        final ProbeResult result2 = new ProbeResult("probe", "this is a different message", ResultStatus.FAILURE, ZonedDateTime.now());
+
+        assertThat(result1).isNotEqualTo(result2);
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -73,7 +73,6 @@ public class ContributingGuidelinesProbeTest {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of());
 
         final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
@@ -54,6 +54,11 @@ class LastCommitDateProbeTest {
     }
 
     @Test
+    void shouldNotBeRelatedToSourceCode() {
+        assertThat(new LastCommitDateProbe().isSourceCodeRelated()).isFalse();
+    }
+
+    @Test
     void shouldBeExecutedAfterSCMLinkValidation() {
         assertThat(SCMLinkValidationProbe.ORDER).isLessThan(LastCommitDateProbe.ORDER);
     }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -84,7 +84,8 @@ class ProbeEngineTest {
         final ProbeResult expectedResult = ProbeResult.success("foo", "bar");
 
         when(plugin.getName()).thenReturn("foo");
-        when(probe.doApply(any(Plugin.class), any(ProbeContext.class))).thenReturn(expectedResult);
+
+        when(probe.doApply(plugin, ctx)).thenReturn(expectedResult);
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
@@ -93,7 +94,7 @@ class ProbeEngineTest {
         final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, githubConfiguration, pluginDocumentationService);
         probeEngine.run();
 
-        verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
+        verify(probe).doApply(plugin, ctx);
         verify(plugin).addDetails(expectedResult);
         verify(pluginService).saveOrUpdate(plugin);
     }
@@ -108,6 +109,7 @@ class ProbeEngineTest {
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusDays(1));
         when(plugin.getDetails()).thenReturn(Map.of(probeKey, ProbeResult.success(probeKey, "This is good")));
+
         when(probe.requiresRelease()).thenReturn(true);
         when(probe.key()).thenReturn(probeKey);
 
@@ -132,6 +134,7 @@ class ProbeEngineTest {
             "probe", new ProbeResult("probe", "message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1))
         ));
         when(plugin.getName()).thenReturn("foo");
+
         when(probe.key()).thenReturn("probe");
         when(probe.requiresRelease()).thenReturn(false);
         when(probe.isSourceCodeRelated()).thenReturn(true);
@@ -156,8 +159,10 @@ class ProbeEngineTest {
         when(plugin.getDetails()).thenReturn(Map.of(
             "probe", new ProbeResult("probe", "message", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1))
         ));
-        when(ctx.getLastCommitDate()).thenReturn(Optional.of(ZonedDateTime.now()));
         when(plugin.getName()).thenReturn("foo");
+
+        when(ctx.getLastCommitDate()).thenReturn(Optional.of(ZonedDateTime.now()));
+
         when(probe.key()).thenReturn("probe");
         when(probe.isSourceCodeRelated()).thenReturn(true);
         when(probe.doApply(plugin, ctx)).thenReturn(result);
@@ -211,6 +216,7 @@ class ProbeEngineTest {
             probeKey,
             new ProbeResult(probeKey, "this is ok", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1))
         ));
+
         when(probe.requiresRelease()).thenReturn(false);
         when(probe.apply(eq(plugin), any(ProbeContext.class))).thenReturn(ProbeResult.success(probeKey, "This is also ok"));
         when(probe.key()).thenReturn(probeKey);
@@ -233,6 +239,7 @@ class ProbeEngineTest {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
+
         when(probe.doApply(eq(plugin), any(ProbeContext.class))).thenReturn(ProbeResult.error("foo", "bar"));
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
@@ -270,6 +277,7 @@ class ProbeEngineTest {
         };
 
         when(plugin.getName()).thenReturn("foo");
+
         when(probeOne.key()).thenReturn("foo");
         when(probeOne.doApply(any(Plugin.class), any(ProbeContext.class)))
             .thenReturn(ProbeResult.success("foo", "This is ok"));


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #256.

The `LastCommitDateProbe` implementation is registering the date of the last commit on the main branch of the plugin repository into the `ProbeContext`. 
Even if this probe is logically related to the source code, because this probe needs to be executed all the time and to prevent the `ProbeEngine` to skip it, its `isSourceCodeRelated` method implementation needs to return `false`. Otherwise, the date of the latest commit will never be updated.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
