### PR TITLE
Fixes probe requirements to be executed

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
@@ -50,11 +50,6 @@ public class CodeCoverageProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult jenkinsFileResult = plugin.getDetails().get(JenkinsfileProbe.KEY);
-        if (jenkinsFileResult == null || !jenkinsFileResult.status().equals(ResultStatus.SUCCESS)) {
-            return ProbeResult.error(key(), "Requires Jenkinsfile");
-        }
-
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
             context.getUpdateCenter().plugins().get(plugin.getName());
         final String defaultBranch = ucPlugin.defaultBranch();
@@ -91,5 +86,10 @@ public class CodeCoverageProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{JenkinsfileProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
@@ -46,7 +46,7 @@ public class CodeCoverageProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(CodeCoverageProbe.class);
 
     public static final String KEY = "code-coverage";
-    public static final int ORDER = JenkinsfileProbe.ORDER + 100;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.kohsuke.github.GHCheckRun;
 import org.kohsuke.github.GHRepository;
@@ -90,6 +89,6 @@ public class CodeCoverageProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{JenkinsfileProbe.KEY};
+        return new String[]{JenkinsfileProbe.KEY, UpdateCenterPluginPublicationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
@@ -47,10 +47,6 @@ public class ContinuousDeliveryProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        if (plugin.getDetails().get(SCMLinkValidationProbe.KEY) == null) {
-            LOGGER.error("Couldn't run {} on {} because previous SCMLinkValidationProbe has null value in database", key(), plugin.getName());
-            return ProbeResult.error(key(), "SCM link has not been validated yet");
-        }
         final Path repo = context.getScmRepository();
         final Path githubWorkflow = repo.resolve(".github/workflows");
         if (Files.notExists(githubWorkflow)) {
@@ -81,5 +77,10 @@ public class ContinuousDeliveryProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
@@ -42,7 +42,7 @@ import org.springframework.stereotype.Component;
 @Order(ContinuousDeliveryProbe.ORDER)
 public class ContinuousDeliveryProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(ContinuousDeliveryProbe.class);
-    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "jep-229";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
@@ -81,6 +81,6 @@ public class ContinuousDeliveryProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY};
+        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -44,11 +43,6 @@ public class ContributingGuidelinesProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult scmValidationResult = plugin.getDetails().get(SCMLinkValidationProbe.KEY);
-        if (scmValidationResult == null || !scmValidationResult.status().equals(ResultStatus.SUCCESS)) {
-            return ProbeResult.error(key(), "SCM link has not been validated yet");
-        }
-
         final Path repository = context.getScmRepository();
         try (Stream<Path> paths = Files.find(repository, 2,
             (file, basicFileAttributes) -> Files.isReadable(file)
@@ -75,5 +69,10 @@ public class ContributingGuidelinesProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(value = ContributingGuidelinesProbe.ORDER)
 public class ContributingGuidelinesProbe extends Probe {
-    public static final int ORDER = JenkinsfileProbe.ORDER + 1;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "contributing-guidelines";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -73,6 +73,6 @@ public class ContributingGuidelinesProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY};
+        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -73,6 +73,6 @@ public class DependabotProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY};
+        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
 @Order(DependabotProbe.ORDER)
 public class DependabotProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(DependabotProbe.class);
-    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "dependabot";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -32,24 +32,17 @@ import java.util.stream.Stream;
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
 @Order(DependabotProbe.ORDER)
 public class DependabotProbe extends Probe {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DependabotProbe.class);
     public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "dependabot";
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        if (plugin.getDetails().get(SCMLinkValidationProbe.KEY) == null) {
-            LOGGER.error("Couldn't run {} on {} because previous SCMLinkValidationProbe has null value in database", key(), plugin.getName());
-            return ProbeResult.error(key(), "SCM link has not been validated yet");
-        }
         final Path scmRepository = context.getScmRepository();
         final Path githubConfig = scmRepository.resolve(".github");
 
@@ -76,5 +69,10 @@ public class DependabotProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -47,7 +47,7 @@ public class DependabotPullRequestProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(DependabotPullRequestProbe.class);
 
     public static final String KEY = "dependabot-pull-requests";
-    public static final int ORDER = DependabotProbe.ORDER + 1;
+    public static final int ORDER = DependabotProbe.ORDER + 10;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -30,7 +30,6 @@ import java.util.NoSuchElementException;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -51,11 +51,6 @@ public class DependabotPullRequestProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult dependabotResult = plugin.getDetails().get(DependabotProbe.KEY);
-        if (dependabotResult == null || dependabotResult.status().equals(ResultStatus.FAILURE)) {
-            return ProbeResult.error(key(), "Dependabot not configured on the repository");
-        }
-
         try {
             final GitHub gh = context.getGitHub();
             final GHRepository repository = gh.getRepository(context.getRepositoryName(plugin.getScm()).orElseThrow());
@@ -83,5 +78,10 @@ public class DependabotPullRequestProbe extends Probe {
     @Override
     public String getDescription() {
         return "Reports the number of pull request currently opened by Dependabot";
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{DependabotProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(DeprecatedPluginProbe.ORDER)
 public class DeprecatedPluginProbe extends Probe {
-    public static final int ORDER = 1;
+    public static final int ORDER = 0;
     public static final String KEY = "deprecation";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
@@ -41,10 +41,6 @@ public class DocumentationMigrationProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult scmValidationProbe = plugin.getDetails().get(SCMLinkValidationProbe.KEY);
-        if (scmValidationProbe == null || scmValidationProbe.status().equals(ResultStatus.FAILURE)) {
-            return ProbeResult.error(key(), "SCM link needs to be validated");
-        }
         final Map<String, String> pluginDocumentationLinks = context.getPluginDocumentationLinks();
         final String scm = plugin.getScm();
         final String linkDocumentationForPlugin = pluginDocumentationLinks.get(plugin.getName());
@@ -71,5 +67,10 @@ public class DocumentationMigrationProbe extends Probe {
     @Override
     protected boolean requiresRelease() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(DocumentationMigrationProbe.ORDER)
 public class DocumentationMigrationProbe extends Probe {
-    public static final int ORDER = SCMLinkValidationProbe.ORDER + 1;
+    public static final int ORDER = SCMLinkValidationProbe.ORDER + 100;
     public static final String KEY = "documentation-migration";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
@@ -41,10 +41,6 @@ public class InstallationStatProbe extends Probe {
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final UpdateCenter updateCenter = context.getUpdateCenter();
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin = updateCenter.plugins().get(plugin.getName());
-
-        if (ucPlugin == null) {
-            return ProbeResult.failure(KEY, "Plugin is not part of the update-center");
-        }
         return ProbeResult.success(KEY, "%d".formatted(ucPlugin.popularity()));
     }
 
@@ -56,5 +52,10 @@ public class InstallationStatProbe extends Probe {
     @Override
     public String getDescription() {
         return "This probe registers the latest installation count stat for a specific plugin.";
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{UpdateCenterPluginPublicationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @Order(value = InstallationStatProbe.ORDER)
 public class InstallationStatProbe extends Probe {
     public static final String KEY = "stat";
-    public static final int ORDER = DeprecatedPluginProbe.ORDER + 1;
+    public static final int ORDER = 0;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @Order(JenkinsCoreProbe.ORDER)
 public class JenkinsCoreProbe extends Probe {
     public static final String KEY = "jenkins-version";
-    public static final int ORDER = InstallationStatProbe.ORDER + 1;
+    public static final int ORDER = 0;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
@@ -46,10 +46,6 @@ public class JenkinsfileProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        if (plugin.getDetails().get(SCMLinkValidationProbe.KEY) == null) {
-            LOGGER.error("Couldn't run {} on {} because previous SCMLinkValidationProbe has null value in database", key(), plugin.getName());
-            return ProbeResult.error(key(), "SCM link has not been validated yet");
-        }
         final Path repository = context.getScmRepository();
         try (Stream<Path> paths = Files
             .find(repository, 1, (file, basicFileAttributes) -> Files.isReadable(file) && "Jenkinsfile".equals(file.getFileName().toString()))
@@ -78,5 +74,10 @@ public class JenkinsfileProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
@@ -32,15 +32,12 @@ import java.util.stream.Stream;
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
 @Order(value = JenkinsfileProbe.ORDER)
 public class JenkinsfileProbe extends Probe {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JenkinsfileProbe.class);
     public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "jenkinsfile";
 
@@ -78,6 +75,6 @@ public class JenkinsfileProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY};
+        return new String[]{SCMLinkValidationProbe.KEY,LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
@@ -75,6 +75,6 @@ public class JenkinsfileProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY,LastCommitDateProbe.KEY};
+        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(value = KnownSecurityVulnerabilityProbe.ORDER)
 public class KnownSecurityVulnerabilityProbe extends Probe {
-    public static final int ORDER = UpForAdoptionProbe.ORDER + 1;
+    public static final int ORDER = 0;
     public static final String KEY = "security";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -75,9 +75,7 @@ public class LastCommitDateProbe extends Probe {
             context.setLastCommitDate(commitDate);
             return ProbeResult.success(key(), commitDate.toString());
         } catch (GitAPIException ex) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("There was an issue while cloning the plugin repository", ex);
-            }
+            LOGGER.error("There was an issue while cloning the plugin repository", ex);
             return ProbeResult.failure(key(), "Could not clone the plugin repository");
         }
     }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
 public class LastCommitDateProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(LastCommitDateProbe.class);
 
-    public static final int ORDER = SCMLinkValidationProbe.ORDER + 1;
+    public static final int ORDER = SCMLinkValidationProbe.ORDER + 100;
     public static final String KEY = "last-commit-date";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -53,11 +53,6 @@ public class LastCommitDateProbe extends Probe {
 
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        if (plugin.getDetails().get(SCMLinkValidationProbe.KEY) == null) {
-            LOGGER.error("Couldn't run {} on {} because previous SCMLinkValidationProbe has null value in database", key(), plugin.getName());
-            return ProbeResult.error(key(), "SCM link has not been validated yet");
-        }
-
         if (plugin.getDetails().get(SCMLinkValidationProbe.KEY).status() == ResultStatus.SUCCESS) {
             final Matcher matcher = SCMLinkValidationProbe.GH_PATTERN.matcher(plugin.getScm());
             if (!matcher.find()) {
@@ -110,5 +105,10 @@ public class LastCommitDateProbe extends Probe {
          * ProbeEngine, is must be `false`.
          */
         return false;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -65,9 +65,9 @@ public abstract class Probe {
 
     /**
      * List of probe key to be present in the {@link Plugin#details} map and to be {@link ResultStatus#SUCCESS} in
-     * order to consider executing the probe.
+     * order to consider executing the {@link Probe#doApply(Plugin, ProbeContext)} code.
      *
-     * @return
+     * @return array of {@link Probe#key()} to be present in {@link Plugin#details}.
      */
     protected String[] getProbeResultRequirement() {
         return new String[]{};

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -66,6 +66,7 @@ public abstract class Probe {
     /**
      * List of probe key to be present in the {@link Plugin#details} map and to be {@link ResultStatus#SUCCESS} in
      * order to consider executing the {@link Probe#doApply(Plugin, ProbeContext)} code.
+     * By default, the requirement is an empty array. I cannot be null.
      *
      * @return array of {@link Probe#key()} to be present in {@link Plugin#details}.
      */

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
@@ -30,7 +30,6 @@ import java.util.NoSuchElementException;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
@@ -51,11 +50,6 @@ public class PullRequestProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult scmValidationResult = plugin.getDetails().get(SCMLinkValidationProbe.KEY);
-        if (scmValidationResult == null || !ResultStatus.SUCCESS.equals(scmValidationResult.status())) {
-            return ProbeResult.error(key(), "SCM link is not valid, cannot continue");
-        }
-
         try {
             final GitHub gh = context.getGitHub();
             final GHRepository repository = gh.getRepository(context.getRepositoryName(plugin.getScm()).orElseThrow());
@@ -78,5 +72,10 @@ public class PullRequestProbe extends Probe {
     @Override
     public String getDescription() {
         return "Count the number of open pull request on the plugin repository";
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Component;
 public class PullRequestProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(PullRequestProbe.class);
 
-    public static final int ORDER = LastCommitDateProbe.ORDER + 1;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "pull-request";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -47,7 +47,7 @@ public final class SCMLinkValidationProbe extends Probe {
 
     private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)(?:/(?<folder>.*))?";
     public static final Pattern GH_PATTERN = Pattern.compile(GH_REGEXP);
-    public static final int ORDER = DeprecatedPluginProbe.ORDER + 20;
+    public static final int ORDER = DeprecatedPluginProbe.ORDER + 100;
     public static final String KEY = "scm";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -52,10 +52,6 @@ public class SCMLinkValidationProbe extends Probe {
 
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult deprecatedProbeResult = plugin.getDetails().get(DeprecatedPluginProbe.KEY);
-        if (deprecatedProbeResult != null && deprecatedProbeResult.status().equals(ResultStatus.FAILURE)) {
-            return ProbeResult.failure(key(), "Plugin is deprecated");
-        }
         if (plugin.getScm() == null || plugin.getScm().isBlank()) {
             LOGGER.warn("{} has no SCM link", plugin.getName());
             return ProbeResult.failure(key(), "The plugin SCM link is empty");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -42,7 +42,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Order(value = SCMLinkValidationProbe.ORDER)
-public final class SCMLinkValidationProbe extends Probe {
+public class SCMLinkValidationProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(SCMLinkValidationProbe.class);
 
     private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)(?:/(?<folder>.*))?";

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.kohsuke.github.GHCheckRun;
 import org.kohsuke.github.GHRepository;
@@ -51,9 +50,6 @@ public class SpotBugsProbe extends Probe {
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
             context.getUpdateCenter().plugins().get(plugin.getName());
-        if (ucPlugin == null) {
-            return ProbeResult.error(key(), "This plugin is no longer in the update-center");
-        }
         final String defaultBranch = ucPlugin.defaultBranch();
         try {
             final Optional<String> repositoryName = context.getRepositoryName(plugin.getScm());
@@ -92,6 +88,6 @@ public class SpotBugsProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{JenkinsfileProbe.KEY};
+        return new String[]{JenkinsfileProbe.KEY, UpdateCenterPluginPublicationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 @Order(SpotBugsProbe.ORDER)
 public class SpotBugsProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpotBugsProbe.class);
-    public static final int ORDER = ContributingGuidelinesProbe.ORDER + 1;
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     public static final String KEY = "spotbugs";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -49,11 +49,6 @@ public class SpotBugsProbe extends Probe {
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
-        final ProbeResult jenkinsFileResult = plugin.getDetails().get(JenkinsfileProbe.KEY);
-        if (jenkinsFileResult == null || !jenkinsFileResult.status().equals(ResultStatus.SUCCESS)) {
-            return ProbeResult.error(key(), "Requires Jenkinsfile");
-        }
-
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
             context.getUpdateCenter().plugins().get(plugin.getName());
         if (ucPlugin == null) {
@@ -93,5 +88,10 @@ public class SpotBugsProbe extends Probe {
     @Override
     protected boolean isSourceCodeRelated() {
         return true;
+    }
+
+    @Override
+    protected String[] getProbeResultRequirement() {
+        return new String[]{JenkinsfileProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -88,6 +88,6 @@ public class SpotBugsProbe extends Probe {
 
     @Override
     protected String[] getProbeResultRequirement() {
-        return new String[]{JenkinsfileProbe.KEY, UpdateCenterPluginPublicationProbe.KEY};
+        return new String[]{JenkinsfileProbe.KEY, UpdateCenterPluginPublicationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 @Order(value = UpForAdoptionProbe.ORDER)
 public class UpForAdoptionProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(UpForAdoptionProbe.class);
-    public static final int ORDER = DeprecatedPluginProbe.ORDER + 1;
+    public static final int ORDER = 0;
     public static final String KEY = "up-for-adoption";
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbe.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component;
 @Order(UpdateCenterPluginPublicationProbe.ORDER)
 public class UpdateCenterPluginPublicationProbe extends Probe {
     public static final String KEY = "update-center-plugin-publication-probe";
-    public static final int ORDER = DeprecatedPluginProbe.ORDER + 1;
+    public static final int ORDER = DeprecatedPluginProbe.ORDER + 100;
 
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext ctx) {

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+abstract class AbstractProbeTest<T extends Probe> {
+    /**
+     * Create a {@link org.mockito.Mockito#spy(Object)} spy} of the specific Probe implementation to be tested.
+     *
+     * @return a spy of the Probe been tested
+     */
+    abstract T getSpy();
+
+    @Test
+    void shouldUseValidKey() {
+        assertThat(getSpy().key()).isNotBlank();
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(getSpy().getDescription()).isNotBlank();
+    }
+
+    @Test
+    void shouldNotHaveNullRequirement() {
+        assertThat(getSpy().getProbeResultRequirement()).isNotNull();
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
@@ -25,16 +25,6 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Map;
-
-import io.jenkins.pluginhealth.scoring.model.Plugin;
-import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
@@ -25,6 +25,16 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,4 +60,25 @@ abstract class AbstractProbeTest<T extends Probe> {
     void shouldNotHaveNullRequirement() {
         assertThat(getSpy().getProbeResultRequirement()).isNotNull();
     }
+/*
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldValidateProbeRequirements() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Probe probe = getSpy();
+        final int probeRequirementsLength = probe.getProbeResultRequirement().length;
+
+        when(plugin.getDetails()).thenReturn(
+            Map.of()
+        );
+        // TODO generate required mocking to validate the requirements
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        for (int i = 0; i < Math.pow(probeRequirementsLength, probeRequirementsLength) - probeRequirementsLength; i++) {
+            assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
+            verify(probe, never()).doApply(plugin, ctx);
+        }
+    }*/
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
@@ -26,9 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -43,60 +41,25 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHCheckRun;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.PagedIterable;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class CodeCoverageProbeTest {
-    @Test
-    public void shouldHaveSpecificKey() {
-        assertThat(spy(CodeCoverageProbe.class).key()).isEqualTo(CodeCoverageProbe.KEY);
-    }
-
-    @Test
-    public void shouldHaveDescription() {
-        assertThat(spy(CodeCoverageProbe.class).getDescription()).isNotBlank();
+class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
+    @Override
+    CodeCoverageProbe getSpy() {
+        return spy(CodeCoverageProbe.class);
     }
 
     @Test
     public void shouldNotRequireRelease() {
-        assertThat(spy(CodeCoverageProbe.class).requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     public void shouldBeRelatedToCode() {
-        assertThat(spy(CodeCoverageProbe.class).isSourceCodeRelated()).isTrue();
-    }
-
-    @Test
-    public void shouldRequireJenkinsfile() {
-        final Plugin plugin = mock(Plugin.class);
-        final ProbeContext ctx = mock(ProbeContext.class);
-
-        when(plugin.getDetails()).thenReturn(
-            Map.of(),
-            Map.of(
-                JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, "")
-            )
-        );
-
-        final CodeCoverageProbe probe = new CodeCoverageProbe();
-
-        // ProbeResult missing
-        assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status")
-            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, ""));
-
-        // ProbeResult failure
-        assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status")
-            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, ""));
+        assertThat(getSpy().isSourceCodeRelated()).isTrue();
     }
 
     @Test
@@ -129,7 +92,7 @@ class CodeCoverageProbeTest {
         ));
         when(ctx.getRepositoryName(plugin.getScm())).thenReturn(Optional.empty());
 
-        final CodeCoverageProbe probe = new CodeCoverageProbe();
+        final CodeCoverageProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
@@ -184,7 +147,7 @@ class CodeCoverageProbeTest {
         when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage")))
             .thenReturn(checkRuns);
 
-        final CodeCoverageProbe probe = new CodeCoverageProbe();
+        final CodeCoverageProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
@@ -232,7 +195,7 @@ class CodeCoverageProbeTest {
         when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage")))
             .thenReturn(checkRuns);
 
-        final CodeCoverageProbe probe = new CodeCoverageProbe();
+        final CodeCoverageProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
@@ -26,7 +26,9 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -110,7 +112,9 @@ class CodeCoverageProbeTest {
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
 
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -150,7 +154,9 @@ class CodeCoverageProbeTest {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -203,7 +209,9 @@ class CodeCoverageProbeTest {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
@@ -87,14 +87,14 @@ class CodeCoverageProbeTest {
         // ProbeResult missing
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, "Requires Jenkinsfile"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, ""));
 
         // ProbeResult failure
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, "Requires Jenkinsfile"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, ""));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
@@ -71,7 +71,6 @@ class ContinuousDeliveryProbeTest {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of());
 
         final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
@@ -38,51 +38,28 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class ContinuousDeliveryProbeTest {
+class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryProbe> {
+    @Override
+    ContinuousDeliveryProbe getSpy() {
+        return spy(ContinuousDeliveryProbe.class);
+    }
+
     @Test
     void shouldNotRequireRelease() {
-        final ContinuousDeliveryProbe probe = spy(ContinuousDeliveryProbe.class);
-        assertThat(probe.requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldBeRelatedToCode() {
-        assertThat(spy(ContinuousDeliveryProbe.class).isSourceCodeRelated()).isTrue();
-    }
-
-    @Test
-    void shouldKeepUsingJEP229Key() {
-        final ContinuousDeliveryProbe probe = spy(ContinuousDeliveryProbe.class);
-        assertThat(probe.key()).isEqualTo("jep-229");
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(ContinuousDeliveryProbe.class).getDescription()).isNotBlank();
-    }
-
-    @Test
-    void shouldRequireSCMValidation() {
-        final Plugin plugin = mock(Plugin.class);
-        final ProbeContext ctx = mock(ProbeContext.class);
-
-        when(plugin.getDetails()).thenReturn(Map.of());
-
-        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
-        final ProbeResult result = probe.apply(plugin, ctx);
-
-        assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
+        assertThat(getSpy().isSourceCodeRelated()).isTrue();
     }
 
     @Test
     void shouldBeAbleToDetectRepositoryWithNoGHA() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
+        final ContinuousDeliveryProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
@@ -99,7 +76,7 @@ class ContinuousDeliveryProbeTest {
     void shouldBeAbleToDetectNotConfiguredRepository() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
+        final ContinuousDeliveryProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
@@ -118,7 +95,7 @@ class ContinuousDeliveryProbeTest {
     void shouldBeAbleToDetectConfiguredRepository() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
+        final ContinuousDeliveryProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
@@ -138,7 +115,7 @@ class ContinuousDeliveryProbeTest {
     void shouldBeAbleToDetectConfiguredRepositoryWithLongExtension() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
+        final ContinuousDeliveryProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
@@ -51,9 +51,33 @@ class ContinuousDeliveryProbeTest {
     }
 
     @Test
+    void shouldBeRelatedToCode() {
+        assertThat(spy(ContinuousDeliveryProbe.class).isSourceCodeRelated()).isTrue();
+    }
+
+    @Test
     void shouldKeepUsingJEP229Key() {
         final ContinuousDeliveryProbe probe = spy(ContinuousDeliveryProbe.class);
         assertThat(probe.key()).isEqualTo("jep-229");
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(ContinuousDeliveryProbe.class).getDescription()).isNotBlank();
+    }
+
+    @Test
+    void shouldRequireSCMValidation() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getName()).thenReturn("foo");
+        when(plugin.getDetails()).thenReturn(Map.of());
+
+        final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -86,7 +85,8 @@ class ContinuousDeliveryProbeTest {
         final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(Files.createTempDirectory("foo"));
 
@@ -102,7 +102,8 @@ class ContinuousDeliveryProbeTest {
         final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repo = Files.createTempDirectory("foo");
         Files.createDirectories(repo.resolve(".github/workflows"));
@@ -120,7 +121,8 @@ class ContinuousDeliveryProbeTest {
         final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repo = Files.createTempDirectory("foo");
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
@@ -139,7 +141,8 @@ class ContinuousDeliveryProbeTest {
         final ContinuousDeliveryProbe probe = new ContinuousDeliveryProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repo = Files.createTempDirectory("foo");
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -39,52 +39,28 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-public class ContributingGuidelinesProbeTest {
+public class ContributingGuidelinesProbeTest extends AbstractProbeTest<ContributingGuidelinesProbe> {
+    @Override
+    ContributingGuidelinesProbe getSpy() {
+        return spy(ContributingGuidelinesProbe.class);
+    }
+
     @Test
     public void shouldNotRequireRelease() {
-        final ContributingGuidelinesProbe contributingGuidelinesProbe = spy(ContributingGuidelinesProbe.class);
-        assertThat(contributingGuidelinesProbe.requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     public void shouldExecuteOnSourceCodeChange() {
-        final ContributingGuidelinesProbe contributingGuidelinesProbe = spy(ContributingGuidelinesProbe.class);
-        assertThat(contributingGuidelinesProbe.isSourceCodeRelated()).isTrue();
-    }
-
-    @Test
-    public void shouldKeepUsingTheSameKey() {
-        final ContributingGuidelinesProbe contributingGuidelinesProbe = spy(ContributingGuidelinesProbe.class);
-        assertThat(contributingGuidelinesProbe.key()).isEqualTo("contributing-guidelines");
-    }
-
-    @Test
-    public void shouldBeDescribed() {
-        assertThat(spy(ContributingGuidelinesProbe.class).getDescription()).isNotBlank();
-    }
-
-    @Test
-    public void shouldGiveErrorIfSCMLinkIsNotValidated() {
-        final Plugin plugin = mock(Plugin.class);
-        final ProbeContext ctx = mock(ProbeContext.class);
-
-        when(plugin.getDetails()).thenReturn(Map.of());
-
-        final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
-        final ProbeResult result = probe.apply(plugin, ctx);
-
-        assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
+        assertThat(getSpy().isSourceCodeRelated()).isTrue();
     }
 
     @Test
     public void shouldCorrectlyDetectMissingContributingGuidelines() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
+        final ContributingGuidelinesProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of(
@@ -101,7 +77,7 @@ public class ContributingGuidelinesProbeTest {
     public void shouldCorrectlyDetectContributingGuidelinesInRootLevelOfRepository() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
+        final ContributingGuidelinesProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of(
@@ -120,7 +96,7 @@ public class ContributingGuidelinesProbeTest {
     public void shouldCorrectlyDetectContributingGuidelinesInDocsFolder() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
+        final ContributingGuidelinesProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -89,8 +88,8 @@ public class ContributingGuidelinesProbeTest {
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY,
-            new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repository = Files.createTempDirectory(plugin.getName());
         when(ctx.getScmRepository()).thenReturn(repository);
@@ -105,12 +104,10 @@ public class ContributingGuidelinesProbeTest {
         final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
 
         when(plugin.getName()).thenReturn("foo");
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                SCMLinkValidationProbe.KEY,
-                new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
-            )
-        );
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
+        ));
         final Path repository = Files.createTempDirectory(plugin.getName());
         Files.createFile(repository.resolve("CONTRIBUTING.md"));
         when(ctx.getScmRepository()).thenReturn(repository);
@@ -126,12 +123,10 @@ public class ContributingGuidelinesProbeTest {
         final ContributingGuidelinesProbe probe = new ContributingGuidelinesProbe();
 
         when(plugin.getName()).thenReturn("foo");
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                SCMLinkValidationProbe.KEY,
-                new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
-            )
-        );
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
+        ));
         final Path repository = Files.createTempDirectory(plugin.getName());
         Files.createFile(Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
         when(ctx.getScmRepository()).thenReturn(repository);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.ZonedDateTime;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -85,7 +84,8 @@ class DependabotProbeTest {
         final DependabotProbe probe = new DependabotProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repo = Files.createTempDirectory("foo");
         when(ctx.getScmRepository()).thenReturn(repo);
@@ -100,7 +100,8 @@ class DependabotProbeTest {
         final DependabotProbe probe = new DependabotProbe();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         final Path repo = Files.createTempDirectory("foo");
         final Path github = Files.createDirectories(repo.resolve(".github"));

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -70,7 +70,6 @@ class DependabotProbeTest {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(plugin.getName()).thenReturn("foo");
         when(plugin.getDetails()).thenReturn(Map.of());
 
         final DependabotProbe probe = new DependabotProbe();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -46,14 +46,37 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DependabotProbeTest {
     @Test
     void shouldNotRequireRelease() {
-        final DependabotProbe probe = spy(DependabotProbe.class);
-        assertThat(probe.requiresRelease()).isFalse();
+        assertThat(spy(DependabotProbe.class).requiresRelease()).isFalse();
     }
 
     @Test
+    void shouldBeRelatedToCode() {
+        assertThat(spy(DependabotProbe.class).isSourceCodeRelated()).isTrue();
+    }
+
+
+    @Test
     void shouldUseDependabotKey() {
-        final DependabotProbe probe = spy(DependabotProbe.class);
-        assertThat(probe.key()).isEqualTo("dependabot");
+        assertThat(spy(DependabotProbe.class).key()).isEqualTo("dependabot");
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(DependabotProbe.class).getDescription()).isNotBlank();
+    }
+
+    @Test
+    void shouldRequireValidSCM() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getName()).thenReturn("foo");
+        when(plugin.getDetails()).thenReturn(Map.of());
+
+        final DependabotProbe probe = new DependabotProbe();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -80,8 +80,8 @@ class DependabotPullRequestProbeTest {
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "Dependabot not configured on the repository"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, ""));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -39,34 +39,26 @@ import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class DependabotPullRequestProbeTest {
-    @Test
-    void shouldUseSpecificKey() {
-        assertThat(spy(DependabotPullRequestProbe.class).key()).isEqualTo(DependabotPullRequestProbe.KEY);
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(DependabotPullRequestProbe.class).getDescription()).isNotBlank();
+class DependabotPullRequestProbeTest extends AbstractProbeTest<DependabotPullRequestProbe> {
+    @Override
+    DependabotPullRequestProbe getSpy() {
+        return spy(DependabotPullRequestProbe.class);
     }
 
     @Test
     void shouldNotRequireRelease() {
-        assertThat(spy(DependabotPullRequestProbe.class).requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldNotBeRelatedToSourceCode() {
-        assertThat(spy(DependabotPullRequestProbe.class).isSourceCodeRelated()).isFalse();
+        assertThat(getSpy().isSourceCodeRelated()).isFalse();
     }
 
     @Test
@@ -76,7 +68,7 @@ class DependabotPullRequestProbeTest {
 
         when(plugin.getDetails()).thenReturn(Map.of());
 
-        final DependabotPullRequestProbe probe = new DependabotPullRequestProbe();
+        final DependabotPullRequestProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).usingRecursiveComparison()
@@ -115,7 +107,7 @@ class DependabotPullRequestProbeTest {
             List.of(pr_1, pr_2, pr_3, pr_4, pr_5)
         );
 
-        final DependabotPullRequestProbe probe = new DependabotPullRequestProbe();
+        final DependabotPullRequestProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).usingRecursiveComparison()
@@ -139,7 +131,7 @@ class DependabotPullRequestProbeTest {
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(anyString())).thenThrow(IOException.class);
 
-        final DependabotPullRequestProbe probe = new DependabotPullRequestProbe();
+        final DependabotPullRequestProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
@@ -43,27 +43,22 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
 
-class DeprecatedPluginProbeTest {
+class DeprecatedPluginProbeTest extends AbstractProbeTest<DeprecatedPluginProbe> {
+    @Override
+    DeprecatedPluginProbe getSpy() {
+        return spy(DeprecatedPluginProbe.class);
+    }
+
     @Test
     void shouldNotRequireRelease() {
-        assertThat(new DeprecatedPluginProbe().requiresRelease()).isFalse();
-    }
-
-    @Test
-    void shouldHaveStaticKey() {
-        assertThat(new DeprecatedPluginProbe().key()).isEqualTo("deprecation");
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(DeprecatedPluginProbe.class).getDescription()).isNotBlank();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldBeAbleToDetectNonDeprecatedPlugin() {
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
+        final DeprecatedPluginProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -81,7 +76,7 @@ class DeprecatedPluginProbeTest {
     void shouldBeAbleToDetectDeprecatedPlugin() {
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
+        final DeprecatedPluginProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -111,7 +106,7 @@ class DeprecatedPluginProbeTest {
             Collections.emptyList()
         ));
 
-        final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
+        final DeprecatedPluginProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
@@ -133,7 +128,7 @@ class DeprecatedPluginProbeTest {
             Collections.emptyList()
         ));
 
-        final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
+        final DeprecatedPluginProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
@@ -54,8 +55,13 @@ class DeprecatedPluginProbeTest {
     }
 
     @Test
+    void shouldHaveDescription() {
+        assertThat(spy(DeprecatedPluginProbe.class).getDescription()).isNotBlank();
+    }
+
+    @Test
     void shouldBeAbleToDetectNonDeprecatedPlugin() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
 
@@ -73,7 +79,7 @@ class DeprecatedPluginProbeTest {
 
     @Test
     void shouldBeAbleToDetectDeprecatedPlugin() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final DeprecatedPluginProbe probe = new DeprecatedPluginProbe();
 
@@ -92,7 +98,7 @@ class DeprecatedPluginProbeTest {
 
     @Test
     void shouldBeAbleToDetectDeprecatedPluginFromLabels() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final String pluginName = "foo";
 
@@ -116,7 +122,7 @@ class DeprecatedPluginProbeTest {
 
     @Test
     void shouldSurviveIfPluginIsNotInUpdateCenter() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final String pluginName = "foo";
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
@@ -36,25 +36,20 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 
 import org.junit.jupiter.api.Test;
 
-class DocumentationMigrationProbeTest {
-    @Test
-    void shouldHaveKey() {
-        assertThat(spy(DocumentationMigrationProbe.class).key()).isEqualTo("documentation-migration");
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(DocumentationMigrationProbe.class).getDescription()).isNotBlank();
+class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMigrationProbe> {
+    @Override
+    DocumentationMigrationProbe getSpy() {
+        return spy(DocumentationMigrationProbe.class);
     }
 
     @Test
     void shouldRequiredRelease() {
-        assertThat(spy(DocumentationMigrationProbe.class).requiresRelease()).isTrue();
+        assertThat(getSpy().requiresRelease()).isTrue();
     }
 
     @Test
     void shouldNotBeRelatedToSourceCodeModifications() {
-        assertThat(spy(DocumentationMigrationProbe.class).isSourceCodeRelated()).isFalse();
+        assertThat(getSpy().isSourceCodeRelated()).isFalse();
     }
 
     @SuppressWarnings("unchecked")
@@ -68,14 +63,15 @@ class DocumentationMigrationProbeTest {
             Map.of(SCMLinkValidationProbe.KEY, ProbeResult.failure(SCMLinkValidationProbe.KEY, ""))
         );
 
-        final DocumentationMigrationProbe probe = new DocumentationMigrationProbe();
+        final DocumentationMigrationProbe probe = getSpy();
 
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status")
             .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, ""));
 
-
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status")
             .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, ""));
     }
@@ -95,13 +91,15 @@ class DocumentationMigrationProbeTest {
             Map.of("something-else", "not-what-we-are-looking-for")
         );
 
-        final DocumentationMigrationProbe probe = new DocumentationMigrationProbe();
+        final DocumentationMigrationProbe probe = getSpy();
 
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, "No link to documentation can be confirmed"));
 
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.failure(DocumentationMigrationProbe.KEY, "Plugin is not listed in documentation migration source"));
     }
@@ -122,10 +120,11 @@ class DocumentationMigrationProbeTest {
             Map.of(pluginName, "https://wiki.jenkins-ci.org/DISPLAY/foo-plugin")
         );
 
-        final DocumentationMigrationProbe probe = new DocumentationMigrationProbe();
+        final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
-        assertThat(result).usingRecursiveComparison()
+        assertThat(result)
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.failure(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository"));
     }
@@ -146,10 +145,11 @@ class DocumentationMigrationProbeTest {
             Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin")
         );
 
-        final DocumentationMigrationProbe probe = new DocumentationMigrationProbe();
+        final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
-        assertThat(result).usingRecursiveComparison()
+        assertThat(result)
+            .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository"));
     }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
@@ -71,13 +71,13 @@ class DocumentationMigrationProbeTest {
         final DocumentationMigrationProbe probe = new DocumentationMigrationProbe();
 
         assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, "SCM link needs to be validated"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, ""));
 
 
         assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, "SCM link needs to be validated"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, ""));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
@@ -99,6 +99,9 @@ class InstallationStatProbeTest {
 
         final String pluginName = "plugin";
         when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
             Map.of(
                 pluginName,

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
@@ -26,7 +26,9 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -39,56 +41,41 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class InstallationStatProbeTest {
+class InstallationStatProbeTest extends AbstractProbeTest<InstallationStatProbe> {
+    @Override
+    InstallationStatProbe getSpy() {
+        return spy(InstallationStatProbe.class);
+    }
 
     @Test
     void doesNotRequireRelease() {
-        final InstallationStatProbe probe = spy(InstallationStatProbe.class);
-        assertThat(probe.requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void doesNotRequireCodeModification() {
-        final InstallationStatProbe probe = spy(InstallationStatProbe.class);
-        assertThat(probe.isSourceCodeRelated()).isFalse();
+        assertThat(getSpy().isSourceCodeRelated()).isFalse();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    void shouldHaveStatAsKey() {
-        final InstallationStatProbe probe = spy(InstallationStatProbe.class);
-        assertThat(probe.key()).isEqualTo("stat");
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        final InstallationStatProbe probe = spy(InstallationStatProbe.class);
-        assertThat(probe.getDescription()).isNotBlank();
-    }
-
-    @Test
-    void shouldFailWhenPluginIsNotInUpdateCenter() {
+    void shouldRequirePluginToBeInUpdateCenter() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getDetails()).thenReturn(
+            Map.of(),
+            Map.of(
+                UpdateCenterPluginPublicationProbe.KEY, ProbeResult.failure(UpdateCenterPluginPublicationProbe.KEY, "")
+            )
+        );
+
         final InstallationStatProbe probe = spy(InstallationStatProbe.class);
-
-        final String pluginName = "plugin";
-        when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            List.of()
-        ));
-
-        final ProbeResult result = probe.apply(plugin, ctx);
-
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(result).isNotNull();
-            softly.assertThat(result).extracting("status").isEqualTo(ResultStatus.FAILURE);
-        });
+        for (int i = 0; i < 2; i++) {
+            assertThat(probe.apply(plugin, ctx).status()).isEqualTo(ResultStatus.ERROR);
+            verify(probe, never()).doApply(plugin, ctx);
+        }
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
@@ -39,33 +39,21 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class JenkinsCoreProbeTest {
-    @Test
-    void shouldBeUsingJenkinsVersionKey() {
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
-        assertThat(probe.key()).isEqualTo("jenkins-version");
+class JenkinsCoreProbeTest extends AbstractProbeTest<JenkinsCoreProbe> {
+    @Override
+    JenkinsCoreProbe getSpy() {
+        return spy(JenkinsCoreProbe.class);
     }
 
     @Test
     void shouldRequireRelease() {
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
-        assertThat(probe.requiresRelease()).isTrue();
+        assertThat(getSpy().requiresRelease()).isTrue();
     }
 
     @Test
     void shouldNotRequireSourceCodeChange() {
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
-        assertThat(probe.isSourceCodeRelated()).isFalse();
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
-        assertThat(probe.getDescription()).isNotBlank();
+        assertThat(getSpy().isSourceCodeRelated()).isFalse();
     }
 
     @Test
@@ -81,7 +69,7 @@ class JenkinsCoreProbeTest {
             List.of()
         ));
 
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
+        final JenkinsCoreProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).isNotNull();
@@ -110,7 +98,7 @@ class JenkinsCoreProbeTest {
             List.of()
         ));
 
-        final JenkinsCoreProbe probe = spy(JenkinsCoreProbe.class);
+        final JenkinsCoreProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).isNotNull();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.ZonedDateTime;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
@@ -55,7 +55,6 @@ class JenkinsfileProbeTest {
         assertThat(spy(JenkinsfileProbe.class).isSourceCodeRelated()).isTrue();
     }
 
-
     @Test
     void shouldKeepUsingTheSameKey() {
         assertThat(spy(JenkinsfileProbe.class).key()).isEqualTo("jenkinsfile");

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
@@ -84,7 +84,8 @@ class JenkinsfileProbeTest extends AbstractProbeTest<JenkinsfileProbe> {
         final JenkinsfileProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(
             Files.createTempDirectory("foo")
@@ -100,7 +101,8 @@ class JenkinsfileProbeTest extends AbstractProbeTest<JenkinsfileProbe> {
         final JenkinsfileProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
-            SCMLinkValidationProbe.KEY, new ProbeResult(SCMLinkValidationProbe.KEY, "", ResultStatus.SUCCESS, ZonedDateTime.now().minusMinutes(5))
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(
             Files.createFile(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
@@ -47,14 +47,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JenkinsfileProbeTest {
     @Test
     void shouldNotRequireRelease() {
-        final JenkinsfileProbe jenkinsfileProbe = spy(JenkinsfileProbe.class);
-        assertThat(jenkinsfileProbe.requiresRelease()).isFalse();
+        assertThat(spy(JenkinsfileProbe.class).requiresRelease()).isFalse();
     }
 
     @Test
+    void shouldBeRelatedToCode() {
+        assertThat(spy(JenkinsfileProbe.class).isSourceCodeRelated()).isTrue();
+    }
+
+
+    @Test
     void shouldKeepUsingTheSameKey() {
-        final JenkinsfileProbe jenkinsfileProbe = spy(JenkinsfileProbe.class);
-        assertThat(jenkinsfileProbe.key()).isEqualTo("jenkinsfile");
+        assertThat(spy(JenkinsfileProbe.class).key()).isEqualTo("jenkinsfile");
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(JenkinsfileProbe.class).getDescription()).isNotBlank();
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -43,33 +43,23 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class KnownSecurityVulnerabilityProbeTest {
-    @Test
-    void shouldUseKeySecurity() {
-        final KnownSecurityVulnerabilityProbe probe = spy(KnownSecurityVulnerabilityProbe.class);
-        assertThat(probe.key()).isEqualTo("security");
+class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurityVulnerabilityProbe> {
+    @Override
+    KnownSecurityVulnerabilityProbe getSpy() {
+        return spy(KnownSecurityVulnerabilityProbe.class);
     }
 
     @Test
     void shouldNotRequireNewRelease() {
-        final KnownSecurityVulnerabilityProbe probe = spy(KnownSecurityVulnerabilityProbe.class);
-        assertThat(probe.requiresRelease()).isFalse();
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(KnownSecurityVulnerabilityProbe.class).getDescription()).isNotBlank();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldBeOKWithNoSecurityWarning() {
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(ctx.getUpdateCenter()).thenReturn(
             new UpdateCenter(
@@ -91,7 +81,7 @@ class KnownSecurityVulnerabilityProbeTest {
         final var pluginInUC = new Plugin(pluginName, pluginVersion, "scm", ZonedDateTime.now().minusHours(1), List.of(), 0, "", "main");
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(ctx.getUpdateCenter()).thenReturn(
             new UpdateCenter(
@@ -115,7 +105,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
@@ -144,7 +134,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
@@ -172,7 +162,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
@@ -201,7 +191,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
@@ -231,7 +221,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
@@ -259,7 +249,7 @@ class KnownSecurityVulnerabilityProbeTest {
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final KnownSecurityVulnerabilityProbe probe = new KnownSecurityVulnerabilityProbe();
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
@@ -100,7 +100,7 @@ class LastCommitDateProbeTest {
     }
 
     @Test
-    void shouldReturnFailureOnInvalidSCM() {
+    void shouldReturnErrorOnInvalidSCM() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final LastCommitDateProbe probe = new LastCommitDateProbe();
@@ -108,7 +108,7 @@ class LastCommitDateProbeTest {
         when(plugin.getDetails()).thenReturn(Map.of(SCMLinkValidationProbe.KEY, ProbeResult.failure("scm", "The plugin SCM link is invalid")));
         final ProbeResult r = probe.apply(plugin, ctx);
 
-        assertThat(r.status()).isEqualTo(ResultStatus.FAILURE);
+        assertThat(r.status()).isEqualTo(ResultStatus.ERROR);
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
@@ -75,7 +75,9 @@ class LastCommitDateProbeTest {
         final ProbeContext ctx = mock(ProbeContext.class);
         final LastCommitDateProbe probe = new LastCommitDateProbe();
 
-        when(plugin.getDetails()).thenReturn(Map.of(SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid")));
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid"))
+        );
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/parameterized-trigger-plugin.git");
         when(ctx.getScmRepository()).thenReturn(Files.createTempDirectory(UUID.randomUUID().toString()));
         final ProbeResult r = probe.apply(plugin, ctx);
@@ -90,7 +92,9 @@ class LastCommitDateProbeTest {
         final ProbeContext ctx = mock(ProbeContext.class);
         final LastCommitDateProbe probe = new LastCommitDateProbe();
 
-        when(plugin.getDetails()).thenReturn(Map.of(SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid")));
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid"))
+        );
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/aws-java-sdk-plugin/aws-java-sdk-logs");
         when(ctx.getScmRepository()).thenReturn(Files.createTempDirectory(UUID.randomUUID().toString()));
         final ProbeResult r = probe.apply(plugin, ctx);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -45,17 +46,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LastCommitDateProbeTest {
     @Test
     void shouldKeepScmAsKey() {
-        assertThat(new LastCommitDateProbe().key()).isEqualTo("last-commit-date");
+        assertThat(spy(LastCommitDateProbe.class).key()).isEqualTo("last-commit-date");
     }
 
     @Test
     void shouldNotRequireRelease() {
-        assertThat(new LastCommitDateProbe().requiresRelease()).isFalse();
+        assertThat(spy(LastCommitDateProbe.class).requiresRelease()).isFalse();
     }
 
     @Test
     void shouldNotBeRelatedToSourceCode() {
-        assertThat(new LastCommitDateProbe().isSourceCodeRelated()).isFalse();
+        assertThat(spy(LastCommitDateProbe.class).isSourceCodeRelated()).isFalse();
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(LastCommitDateProbe.class).getDescription()).isNotBlank();
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbeTest.java
@@ -26,7 +26,9 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -39,29 +41,21 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class LastCommitDateProbeTest {
-    @Test
-    void shouldKeepScmAsKey() {
-        assertThat(spy(LastCommitDateProbe.class).key()).isEqualTo("last-commit-date");
+class LastCommitDateProbeTest extends AbstractProbeTest<LastCommitDateProbe> {
+    @Override
+    LastCommitDateProbe getSpy() {
+        return spy(LastCommitDateProbe.class);
     }
 
     @Test
     void shouldNotRequireRelease() {
-        assertThat(spy(LastCommitDateProbe.class).requiresRelease()).isFalse();
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldNotBeRelatedToSourceCode() {
-        assertThat(spy(LastCommitDateProbe.class).isSourceCodeRelated()).isFalse();
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(LastCommitDateProbe.class).getDescription()).isNotBlank();
+        assertThat(getSpy().isSourceCodeRelated()).isFalse();
     }
 
     @Test
@@ -73,7 +67,7 @@ class LastCommitDateProbeTest {
     void shouldReturnSuccessStatusOnValidSCM() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final LastCommitDateProbe probe = new LastCommitDateProbe();
+        final LastCommitDateProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid"))
@@ -90,7 +84,7 @@ class LastCommitDateProbeTest {
     void shouldReturnSuccessStatusOnValidSCMWithSubFolder() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final LastCommitDateProbe probe = new LastCommitDateProbe();
+        final LastCommitDateProbe probe = getSpy();
 
         when(plugin.getDetails()).thenReturn(Map.of(
             SCMLinkValidationProbe.KEY, ProbeResult.success("scm", "The plugin SCM link is valid"))
@@ -103,27 +97,21 @@ class LastCommitDateProbeTest {
         assertThat(r.status()).isEqualTo(ResultStatus.SUCCESS);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    void shouldReturnErrorOnInvalidSCM() {
+    void shouldRespectRequirements() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final LastCommitDateProbe probe = new LastCommitDateProbe();
 
-        when(plugin.getDetails()).thenReturn(Map.of(SCMLinkValidationProbe.KEY, ProbeResult.failure("scm", "The plugin SCM link is invalid")));
-        final ProbeResult r = probe.apply(plugin, ctx);
+        when(plugin.getDetails()).thenReturn(
+            Map.of(),
+            Map.of(SCMLinkValidationProbe.KEY, ProbeResult.failure("scm", "The plugin SCM link is invalid"))
+        );
+        final LastCommitDateProbe probe = getSpy();
 
-        assertThat(r.status()).isEqualTo(ResultStatus.ERROR);
-    }
-
-    @Test
-    void shouldFailToRunAsFirstProbe() {
-        final Plugin plugin = mock(Plugin.class);
-        final ProbeContext ctx = mock(ProbeContext.class);
-        final LastCommitDateProbe probe = new LastCommitDateProbe();
-
-        when(plugin.getDetails()).thenReturn(Map.of());
-        final ProbeResult r = probe.apply(plugin, ctx);
-
-        assertThat(r.status()).isEqualTo(ResultStatus.ERROR);
+        for (int i = 0; i < 2; i++) {
+            assertThat(probe.apply(plugin, ctx).status()).isEqualTo(ResultStatus.ERROR);
+            verify(probe, never()).doApply(plugin, ctx);
+        }
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
@@ -83,8 +83,8 @@ class PullRequestProbeTest {
 
         assertThat(result)
             .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(PullRequestProbe.KEY, "SCM link is not valid, cannot continue"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(PullRequestProbe.KEY, ""));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -36,26 +36,18 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class SCMLinkValidationProbeTest {
-    @Test
-    void shouldKeepScmAsKey() {
-        assertThat(spy(SCMLinkValidationProbe.class).key()).isEqualTo("scm");
+class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProbe> {
+    @Override
+    SCMLinkValidationProbe getSpy() {
+        return spy(SCMLinkValidationProbe.class);
     }
 
     @Test
     void shouldRequireRelease() {
-        assertThat(spy(SCMLinkValidationProbe.class).requiresRelease()).isTrue();
-    }
-
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(SCMLinkValidationProbe.class).getDescription()).isNotBlank();
+        assertThat(getSpy().requiresRelease()).isTrue();
     }
 
     @Test
@@ -64,7 +56,7 @@ class SCMLinkValidationProbeTest {
         final ProbeContext ctxP1 = mock(ProbeContext.class);
         final Plugin p2 = mock(Plugin.class);
         final ProbeContext ctxP2 = mock(ProbeContext.class);
-        final SCMLinkValidationProbe probe = new SCMLinkValidationProbe();
+        final SCMLinkValidationProbe probe = getSpy();
 
         when(p1.getScm()).thenReturn(null);
         when(p2.getScm()).thenReturn("");
@@ -81,7 +73,7 @@ class SCMLinkValidationProbeTest {
     void shouldRecognizeIncorrectSCMUrl() {
         final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final SCMLinkValidationProbe probe = new SCMLinkValidationProbe();
+        final SCMLinkValidationProbe probe = getSpy();
 
         when(p1.getScm()).thenReturn("this-is-not-correct");
         final ProbeResult r1 = probe.apply(p1, ctx);
@@ -101,7 +93,7 @@ class SCMLinkValidationProbeTest {
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenReturn(new GHRepository());
 
-        final SCMLinkValidationProbe probe = new SCMLinkValidationProbe();
+        final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
@@ -119,7 +111,7 @@ class SCMLinkValidationProbeTest {
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenThrow(IOException.class);
 
-        final SCMLinkValidationProbe probe = new SCMLinkValidationProbe();
+        final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -44,12 +45,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SCMLinkValidationProbeTest {
     @Test
     void shouldKeepScmAsKey() {
-        assertThat(new SCMLinkValidationProbe().key()).isEqualTo("scm");
+        assertThat(spy(SCMLinkValidationProbe.class).key()).isEqualTo("scm");
     }
 
     @Test
     void shouldRequireRelease() {
-        assertThat(new SCMLinkValidationProbe().requiresRelease()).isTrue();
+        assertThat(spy(SCMLinkValidationProbe.class).requiresRelease()).isTrue();
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(SCMLinkValidationProbe.class).getDescription()).isNotBlank();
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -79,7 +79,8 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
         when(plugin.getScm()).thenReturn(scmLink);
         when(plugin.getDetails()).thenReturn(Map.of(
             JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
 
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -120,7 +121,8 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
             JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -171,7 +173,8 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
             JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, ""),
+            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -111,7 +111,8 @@ class SpotBugsProbeTest {
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
 
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -151,7 +152,8 @@ class SpotBugsProbeTest {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -202,7 +204,8 @@ class SpotBugsProbeTest {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getDetails()).thenReturn(Map.of(
-            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "")
+            JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -88,14 +88,14 @@ class SpotBugsProbeTest {
         // ProbeResult missing
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, "Requires Jenkinsfile"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, ""));
 
         // ProbeResult failure
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, "Requires Jenkinsfile"));
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, ""));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
@@ -43,6 +44,11 @@ import org.junit.jupiter.api.Test;
 
 class UpForAdoptionProbeTest {
     @Test
+    void shouldHaveDescription() {
+        assertThat(spy(UpForAdoptionProbe.class).getDescription()).isNotBlank();
+    }
+
+    @Test
     void shouldNotRequireNewRelease() {
         assertThat(new UpForAdoptionProbe().requiresRelease()).isFalse();
     }
@@ -54,7 +60,7 @@ class UpForAdoptionProbeTest {
 
     @Test
     void shouldBeAbleToDetectPluginForAdoption() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final UpForAdoptionProbe upForAdoptionProbe = new UpForAdoptionProbe();
 
@@ -86,5 +92,24 @@ class UpForAdoptionProbeTest {
         final ProbeResult result = upForAdoptionProbe.apply(plugin, ctx);
 
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+    }
+
+    @Test
+    void shouldFailWhenPluginNotPresentInUpdateCenter() {
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getName()).thenReturn("foo");
+
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
+            Map.of(),
+            Map.of(),
+            List.of()
+        ));
+
+        final UpForAdoptionProbe probe = new UpForAdoptionProbe();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
@@ -42,27 +42,22 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import hudson.util.VersionNumber;
 import org.junit.jupiter.api.Test;
 
-class UpForAdoptionProbeTest {
-    @Test
-    void shouldHaveDescription() {
-        assertThat(spy(UpForAdoptionProbe.class).getDescription()).isNotBlank();
+class UpForAdoptionProbeTest extends AbstractProbeTest<UpForAdoptionProbe> {
+    @Override
+    UpForAdoptionProbe getSpy() {
+        return spy(UpForAdoptionProbe.class);
     }
 
     @Test
     void shouldNotRequireNewRelease() {
-        assertThat(new UpForAdoptionProbe().requiresRelease()).isFalse();
-    }
-
-    @Test
-    void shouldKeepTheSameKey() {
-        assertThat(new UpForAdoptionProbe().key()).isEqualTo("up-for-adoption");
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
     void shouldBeAbleToDetectPluginForAdoption() {
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final UpForAdoptionProbe upForAdoptionProbe = new UpForAdoptionProbe();
+        final UpForAdoptionProbe upForAdoptionProbe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -80,7 +75,7 @@ class UpForAdoptionProbeTest {
     void shouldBeAbleToDetectPluginNotForAdoption() {
         final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final UpForAdoptionProbe upForAdoptionProbe = new UpForAdoptionProbe();
+        final UpForAdoptionProbe upForAdoptionProbe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
@@ -107,7 +102,7 @@ class UpForAdoptionProbeTest {
             List.of()
         ));
 
-        final UpForAdoptionProbe probe = new UpForAdoptionProbe();
+        final UpForAdoptionProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result.status()).isEqualTo(ResultStatus.FAILURE);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -39,15 +40,19 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import org.junit.jupiter.api.Test;
 
 public class UpdateCenterPluginPublicationProbeTest {
-
     @Test
     public void shouldNotRequireRelease() {
-        assertThat(new UpdateCenterPluginPublicationProbe().requiresRelease()).isFalse();
+        assertThat(spy(UpdateCenterPluginPublicationProbe.class).requiresRelease()).isFalse();
     }
 
     @Test
     public void shouldHaveStaticKey() {
-        assertThat(new UpdateCenterPluginPublicationProbe().key()).isEqualTo("update-center-plugin-publication-probe");
+        assertThat(spy(UpdateCenterPluginPublicationProbe.class).key()).isEqualTo("update-center-plugin-publication-probe");
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(spy(UpdateCenterPluginPublicationProbe.class).getDescription()).isNotBlank();
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
@@ -39,24 +39,19 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
 import org.junit.jupiter.api.Test;
 
-public class UpdateCenterPluginPublicationProbeTest {
-    @Test
-    public void shouldNotRequireRelease() {
-        assertThat(spy(UpdateCenterPluginPublicationProbe.class).requiresRelease()).isFalse();
+class UpdateCenterPluginPublicationProbeTest extends AbstractProbeTest<UpdateCenterPluginPublicationProbe> {
+    @Override
+    UpdateCenterPluginPublicationProbe getSpy() {
+        return spy(UpdateCenterPluginPublicationProbe.class);
     }
 
     @Test
-    public void shouldHaveStaticKey() {
-        assertThat(spy(UpdateCenterPluginPublicationProbe.class).key()).isEqualTo("update-center-plugin-publication-probe");
+    void shouldNotRequireRelease() {
+        assertThat(getSpy().requiresRelease()).isFalse();
     }
 
     @Test
-    void shouldHaveDescription() {
-        assertThat(spy(UpdateCenterPluginPublicationProbe.class).getDescription()).isNotBlank();
-    }
-
-    @Test
-    public void shouldFailIfPluginIsNotInUpdateCenterMap() {
+    void shouldFailIfPluginIsNotInUpdateCenterMap() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final String pluginName = "foo";
@@ -68,7 +63,7 @@ public class UpdateCenterPluginPublicationProbeTest {
             Collections.emptyList()
         ));
 
-        final UpdateCenterPluginPublicationProbe probe = new UpdateCenterPluginPublicationProbe();
+        final UpdateCenterPluginPublicationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
@@ -78,7 +73,7 @@ public class UpdateCenterPluginPublicationProbeTest {
     }
 
     @Test
-    public void shouldSucceedIfPluginIsInUpdateCenterMap() {
+    void shouldSucceedIfPluginIsInUpdateCenterMap() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final String pluginName = "foo";
@@ -92,7 +87,7 @@ public class UpdateCenterPluginPublicationProbeTest {
             List.of()
         ));
 
-        final UpdateCenterPluginPublicationProbe probe = new UpdateCenterPluginPublicationProbe();
+        final UpdateCenterPluginPublicationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
@@ -96,16 +96,21 @@ public final class ProbeEngine {
         if (!probe.requiresRelease() && !probe.isSourceCodeRelated()) {
             return true;
         }
-        if (probe.requiresRelease() && (previousResult.timestamp() != null)
-            && previousResult.timestamp().isBefore(plugin.getReleaseTimestamp())) {
+        if (probe.requiresRelease() &&
+            (previousResult.timestamp() != null && previousResult.timestamp().isBefore(plugin.getReleaseTimestamp()))) {
             return true;
         }
         final Optional<ZonedDateTime> optionalLastCommit = ctx.getLastCommitDate();
         if (probe.isSourceCodeRelated() && optionalLastCommit.isEmpty()) {
-            LOGGER.error("{} requires last commit date but was executed before the date time is registered in ctx", probe.key());
+            LOGGER.error(
+                "{} requires last commit date for {} but was executed before the date time is registered in ctx",
+                probe.key(), plugin.getName()
+            );
         }
-        if (probe.isSourceCodeRelated() && optionalLastCommit.map(date -> previousResult.timestamp() != null
-            && previousResult.timestamp().isBefore(date)).orElse(false)) {
+        if (probe.isSourceCodeRelated() &&
+            optionalLastCommit
+                .map(date -> previousResult.timestamp() != null && previousResult.timestamp().isBefore(date))
+                .orElse(false)) {
             return true;
         }
         return false;

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -78,7 +78,7 @@ class ProbeEngineTest {
     @Test
     void shouldBeAbleToRunSimpleProbe() throws IOException {
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         final ProbeResult expectedResult = ProbeResult.success("foo", "bar");
@@ -103,7 +103,7 @@ class ProbeEngineTest {
     void shouldNotApplyProbeWithReleaseRequirementOnPluginWithNoNewReleaseWithPastResult() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final String probeKey = "wiz";
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
@@ -127,7 +127,7 @@ class ProbeEngineTest {
     @Test
     void shouldNotApplyProbeRelatedToCodeWithNoNewCode() throws IOException {
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getDetails()).thenReturn(Map.of(
@@ -146,13 +146,13 @@ class ProbeEngineTest {
         final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, githubConfiguration, pluginDocumentationService);
         probeEngine.run();
 
-        verify(probe, never()).apply(plugin, ctx);
+        verify(probe, never()).doApply(plugin, ctx);
     }
 
     @Test
     void shouldApplyProbeRelatedToCodeWithNewCommit() throws IOException {
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final ProbeResult result = new ProbeResult("probe", "message", ResultStatus.SUCCESS);
 
@@ -174,7 +174,7 @@ class ProbeEngineTest {
         final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, githubConfiguration, pluginDocumentationService);
         probeEngine.run();
 
-        verify(probe).apply(plugin, ctx);
+        verify(probe).doApply(plugin, ctx);
         verify(plugin).addDetails(result);
     }
 
@@ -182,16 +182,16 @@ class ProbeEngineTest {
     void shouldApplyProbeWithReleaseRequirementOnPluginWithNewReleaseAndPastResult() throws IOException {
         final String probeKey = "wiz";
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now());
         when(plugin.getDetails()).thenReturn(Map.of(probeKey, new ProbeResult(probeKey, "this is ok", ResultStatus.SUCCESS, ZonedDateTime.now().minusDays(1))));
-        when(probe.requiresRelease()).thenReturn(true);
-        when(probe.apply(any(Plugin.class), any(ProbeContext.class)))
-            .thenReturn(ProbeResult.success(probeKey, "This is also ok"));
+
         when(probe.key()).thenReturn(probeKey);
+        when(probe.requiresRelease()).thenReturn(true);
+        when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.success(probeKey, "This is also ok"));
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
@@ -208,7 +208,7 @@ class ProbeEngineTest {
     void shouldApplyProbeWithNoReleaseRequirementOnPluginWithPastResult() throws IOException {
         final String probeKey = "wiz";
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
@@ -218,7 +218,7 @@ class ProbeEngineTest {
         ));
 
         when(probe.requiresRelease()).thenReturn(false);
-        when(probe.apply(eq(plugin), any(ProbeContext.class))).thenReturn(ProbeResult.success(probeKey, "This is also ok"));
+        when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.success(probeKey, "This is also ok"));
         when(probe.key()).thenReturn(probeKey);
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
@@ -235,12 +235,12 @@ class ProbeEngineTest {
     @Test
     void shouldNotSaveErrors() throws IOException {
         final Plugin plugin = mock(Plugin.class);
-        final Probe probe = mock(Probe.class);
+        final Probe probe = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
 
-        when(probe.doApply(eq(plugin), any(ProbeContext.class))).thenReturn(ProbeResult.error("foo", "bar"));
+        when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.error("foo", "bar"));
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
@@ -255,7 +255,7 @@ class ProbeEngineTest {
     @Test
     void shouldBeAbleToGetPreviousContextResultInExecution() throws IOException {
         final Plugin plugin = spy(Plugin.class);
-        final Probe probeOne = mock(Probe.class);
+        final Probe probeOne = spy(Probe.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final Probe probeTwo = new Probe() {
             @Override
@@ -272,15 +272,14 @@ class ProbeEngineTest {
 
             @Override
             public String getDescription() {
-                return null;
+                return "description";
             }
         };
 
         when(plugin.getName()).thenReturn("foo");
 
         when(probeOne.key()).thenReturn("foo");
-        when(probeOne.doApply(any(Plugin.class), any(ProbeContext.class)))
-            .thenReturn(ProbeResult.success("foo", "This is ok"));
+        when(probeOne.doApply(plugin, ctx)).thenReturn(ProbeResult.success("foo", "This is ok"));
 
         when(probeService.getProbeContext(anyString(), any(UpdateCenter.class))).thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probeOne, probeTwo));


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #262.

Since logging when a probe is supposed to be executed when a new code was added to the repository but the last commit date is not registered yet, we can see errors in the logs. 

Some plugin have an incorrect SCM link. The link is valid because the repository exists but they are pointed to a sub folder which doesn't exists. This causes `LastCommitDateProbe` to fail when `SCMLinkValidationProbe` is successful.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
