### PR TITLE
Removes contributing guide from repository scoring

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -29,7 +29,6 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ResultStatus;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
-import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;
@@ -48,17 +47,12 @@ public class PluginMaintenanceScoring extends Scoring {
         final ProbeResult dependabotProbeResult = plugin.getDetails().get(DependabotProbe.KEY);
         final ProbeResult dependabotPullRequestResult = plugin.getDetails().get(DependabotPullRequestProbe.KEY);
         final ProbeResult cdProbeResult = plugin.getDetails().get(ContinuousDeliveryProbe.KEY);
-        final ProbeResult contributingGuidelinesProbeResult = plugin.getDetails().get(ContributingGuidelinesProbe.KEY);
         final ProbeResult documentationMigrationProbeResult = plugin.getDetails().get(DocumentationMigrationProbe.KEY);
 
         float score = 0.0f;
 
         if (jenkinsfileProbeResult != null && jenkinsfileProbeResult.status().equals(ResultStatus.SUCCESS)) {
-            score += 0.5f;
-        }
-
-        if (contributingGuidelinesProbeResult != null && contributingGuidelinesProbeResult.status().equals(ResultStatus.SUCCESS)) {
-            score += 0.15f;
+            score += 0.65f;
         }
 
         if (documentationMigrationProbeResult != null && documentationMigrationProbeResult.status().equals(ResultStatus.SUCCESS)) {
@@ -96,8 +90,7 @@ public class PluginMaintenanceScoring extends Scoring {
     @Override
     public String description() {
         return """
-            Scores plugin based on Jenkinsfile presence, Contributing Guidelines presence,
-            documentation migration, dependabot and JEP-229 configuration.
+            Scores plugin based on Jenkinsfile presence, documentation migration, dependabot and JEP-229 configuration.
             """;
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -37,7 +37,6 @@ import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
-import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -66,7 +66,6 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "1"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
                 0f
@@ -77,9 +76,7 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-
                 ),
                 0f
             ),
@@ -89,7 +86,6 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
                 1f
@@ -100,10 +96,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, ""),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .5f
+                .65f
             ),
             arguments(// Jenkinsfile and dependabot but with open pull request
                 Map.of(
@@ -111,10 +106,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .5f
+                .65f
             ),
             arguments(// Jenkinsfile and dependabot with no open pull request
                 Map.of(
@@ -122,10 +116,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .65f
+                .8f
             ),
             arguments(// Jenkinsfile and CD
                 Map.of(
@@ -133,21 +126,19 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .55f
+                .7f
             ),
-            arguments(// Jenkinsfile and Contributing guide
+            arguments(// Jenkinsfile and documentation
                 Map.of(
                     JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, ""),
+                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
+                    DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
-                .65f
+                .8f
             ),
             arguments(// Jenkinsfile and CD and dependabot but with open pull request
                 Map.of(
@@ -155,10 +146,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .55f
+                .7f
             ),
             arguments(// Jenkinsfile and CD and dependabot with no open pull request
                 Map.of(
@@ -166,43 +156,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .70f
-            ),
-            arguments(// Jenkinsfile and Contributing guide and dependabot and with no open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-                ),
-                .8f
-            ),
-            arguments(// Jenkinfile and CD and Contributing guild and dependabot but with open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-                ),
-                .70f
-            ),
-            arguments(// Contributing guide only
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, ""),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-                ),
-                .15f
+                .85f
             ),
             arguments(// Dependabot only with no open pull requests
                 Map.of(
@@ -210,32 +166,19 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
                 .15f
             ),
-            arguments(// Contributing guide and Dependabot with no open pull requests
+            arguments(// CD only
                 Map.of(
                     JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-                ),
-                .3f
-            ),
-            arguments(// Dependabot with no open pull request and CD and Contributing guide
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
+                    DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
+                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
-                .35f
+                .05f
             ),
             arguments(// Dependabot with no open pull request and CD
                 Map.of(
@@ -243,32 +186,19 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
                 ),
                 .2f
             ),
-            arguments(// Dependabot but with open pull request and Contributing guide and CD
+            arguments(// Dependabot with no open pull request and documentation
                 Map.of(
                     JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
+                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
+                    ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
+                    DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
-                .2f
-            ),
-            arguments(// Contributing guide and CD
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.failure(DocumentationMigrationProbe.KEY, "")
-                ),
-                .2f
+                .3f
             ),
             arguments(// Documentation migration only
                 Map.of(
@@ -276,21 +206,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
                 .15f
-            ),
-            arguments(// Documentation migration and Jenkinsfile
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
-                ),
-                .65f
             ),
             arguments(// Documentation migration and Dependabot but with open pull requests
                 Map.of(
@@ -298,7 +216,6 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
                 .15f
@@ -309,7 +226,6 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.failure(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
                 .3f
@@ -320,21 +236,9 @@ class PluginMaintenanceScoringTest {
                     DependabotProbe.KEY, ProbeResult.failure(DependabotProbe.KEY, ""),
                     DependabotPullRequestProbe.KEY, ProbeResult.failure(DependabotPullRequestProbe.KEY, "0"),
                     ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
                     DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
                 ),
                 .2f
-            ),
-            arguments(// Documentation migration and Contributing guild
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.failure(JenkinsfileProbe.KEY, ""),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, ""),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0"),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, ""),
-                    ContributingGuidelinesProbe.KEY, ProbeResult.failure(ContributingGuidelinesProbe.KEY, ""),
-                    DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "")
-                ),
-                .35f
             )
         );
     }


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #255.

The Jenkins organization in GitHub has a common `CONTRIBUTING.md` file in https://github.com/jenkinsci/.github. This contributing guide is valid for most of the plugin repositories and is linked to any repository _contribute_ link.

Removing this requirement from the `repository-management` scoring process so that plugin maintainers don't have to add a guide just to get a better grade.
Keeping the probe because it can be a good indication to the same plugin maintainers that they might consider adding a guide in case the plugin development process is not ordinary. 

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
