### PR TITLE
`jenkins-version` probe requires update-center data

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @Order(JenkinsCoreProbe.ORDER)
 public class JenkinsCoreProbe extends Probe {
     public static final String KEY = "jenkins-version";
-    public static final int ORDER = 0;
+    public static final int ORDER = UpdateCenterPluginPublicationProbe.ORDER + 100;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
@@ -61,5 +61,10 @@ public class JenkinsCoreProbe extends Probe {
     @Override
     protected boolean requiresRelease() {
         return true;
+    }
+
+    @Override
+    public String[] getProbeResultRequirement() {
+        return new String[]{UpdateCenterPluginPublicationProbe.KEY};
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
@@ -26,7 +26,9 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -75,9 +77,9 @@ class JenkinsCoreProbeTest extends AbstractProbeTest<JenkinsCoreProbe> {
         assertThat(result).isNotNull();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).extracting("id").isEqualTo(probe.key());
-            softly.assertThat(result).extracting("status").isEqualTo(ResultStatus.FAILURE);
-            softly.assertThat(result).extracting("message").isEqualTo("Plugin is not in the update-center");
+            softly.assertThat(result).extracting("status").isEqualTo(ResultStatus.ERROR);
         });
+        verify(probe, never()).doApply(plugin, ctx);
     }
 
     @Test
@@ -87,6 +89,9 @@ class JenkinsCoreProbeTest extends AbstractProbeTest<JenkinsCoreProbe> {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
             Map.of(
                 pluginName,


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #277.

When a plugin is removed from the update-center, we shouldn't try to register its jenkins core requirement. 
When doing so, we could be keeping track of old data and it as no effect of the fact that the plugin cannot be installed on Jenkins instances through the Update Center.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
