### PR TITLE
`scm` probe only executed when the plugin is in update center

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -46,7 +46,7 @@ public class SCMLinkValidationProbe extends Probe {
 
     private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)(?:/(?<folder>.*))?";
     public static final Pattern GH_PATTERN = Pattern.compile(GH_REGEXP);
-    public static final int ORDER = DeprecatedPluginProbe.ORDER + 100;
+    public static final int ORDER = UpdateCenterPluginPublicationProbe.ORDER + 100;
     public static final String KEY = "scm";
 
     @Override
@@ -91,5 +91,10 @@ public class SCMLinkValidationProbe extends Probe {
         } catch (IOException ex) {
             return ProbeResult.failure(key(), "The plugin SCM link is invalid");
         }
+    }
+
+    @Override
+    public String[] getProbeResultRequirement() {
+        return new String[]{UpdateCenterPluginPublicationProbe.KEY};
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -26,10 +26,13 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
@@ -51,6 +54,21 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
     }
 
     @Test
+    void shouldRequirePluginToBeInUpdateCenter() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(plugin.getDetails()).thenReturn(Map.of());
+        final SCMLinkValidationProbe probe = getSpy();
+
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status")
+            .isEqualTo(ProbeResult.error("scm", ""));
+        verify(probe, never()).doApply(plugin, ctx);
+    }
+
+    @Test
     void shouldNotAcceptNullNorEmptyScm() {
         final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctxP1 = mock(ProbeContext.class);
@@ -58,7 +76,13 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final ProbeContext ctxP2 = mock(ProbeContext.class);
         final SCMLinkValidationProbe probe = getSpy();
 
+        when(p1.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(p1.getScm()).thenReturn(null);
+        when(p2.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(p2.getScm()).thenReturn("");
 
         final ProbeResult r1 = probe.apply(p1, ctxP1);
@@ -76,6 +100,9 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
 
         when(p1.getScm()).thenReturn("this-is-not-correct");
+        when(p1.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);
@@ -90,6 +117,9 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final String repositoryName = "jenkinsci/mailer-plugin";
 
         when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
+        when(p1.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenReturn(new GHRepository());
 
@@ -108,6 +138,9 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final String repositoryName = "jenkinsci/this-is-not-going-to-work";
 
         when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
+        when(p1.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenThrow(IOException.class);
 


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #276.

When the plugin is not distributed by the update-center, the SCM value cannot be updated. 
Because of that, we are keeping potentially invalid value for the SCM link of the plugin. 
It's better not to try to validate that URL if that is the case.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [x] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
