### PR TITLE
🚧 Fixes false failure on documentation migration 

### DIFF
--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
@@ -153,4 +153,79 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository"));
     }
+
+    @Test
+    void shouldBeAbleToAcceptExtraSlashInDocumentationLink() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final String pluginName = "foo";
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, "")
+        ));
+        when(ctx.getPluginDocumentationLinks()).thenReturn(
+            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/")
+        );
+
+        final DocumentationMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository"));
+    }
+
+    @Test
+    void shouldBeAbleToAcceptTreeReference() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final String pluginName = "foo";
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, "")
+        ));
+        when(ctx.getPluginDocumentationLinks()).thenReturn(
+            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/tree/main")
+        );
+
+        final DocumentationMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository"));
+    }
+
+    @Test
+    void shouldBeAbleToAcceptBlobReference() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final String pluginName = "foo";
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
+        when(plugin.getDetails()).thenReturn(Map.of(
+            SCMLinkValidationProbe.KEY, ProbeResult.success(SCMLinkValidationProbe.KEY, "")
+        ));
+        when(ctx.getPluginDocumentationLinks()).thenReturn(
+            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/blob/main/this/is/documentation/README.md")
+        );
+
+        final DocumentationMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository"));
+    }
 }


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Resolves #285.

Based on https://www.jenkins.io/doc/developer/publishing/documentation/, the documentation can point to other location than the root of the plugin repository. 

This is to make sure the probe is correctly detecting fully migrated documentation.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [ ] If the issue exists, it is well described and linked in the description
- [ ] The description of this pull request is detailed and explain why this pull request is needed
- [ ] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [ ] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [ ] There is no new warnings (checkstyle nor spotbugs) on the code
