### PR TITLE
Update code coverage step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             allowEmptyResults: false,
             testResults: '**/target/surefire-reports/*.xml, **/target/failsafe-reports/*.xml'
           )
-          publishCoverage adapters: [jacocoAdapter(mergeToOneReport: true, path: '**/target/site/**/jacoco.xml')]
+          recordCoverage(tools: [[parser: 'JACOCO', pattern: '**/target/site/**/jacoco.xml', mergeToOneReport: true]], sourceCodeRetention: 'MODIFIED')
           recordIssues enabledForFailure: true,
             tools: [mavenConsole(), java(), javaDoc()]
           recordIssues enabledForFailure: true,


### PR DESCRIPTION
The `publishCoverage` step is deprecated in favor of `recordCoverage`. Take a look at the pipeline docs of more information: https://www.jenkins.io/doc/pipeline/steps/code-coverage-api/#publishcoverage-publish-coverage-report-deprecated.