### PR TITLE
Force probe execution

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -66,6 +66,9 @@ public abstract class Probe {
                 return false;
             }
         }
+        if (context.isExecutionForced()) {
+            return true;
+        }
 
         final ProbeResult previousResult = plugin.getDetails().get(this.key());
         if (previousResult == null) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -46,9 +46,12 @@ public class ProbeContext {
     private ZonedDateTime lastCommitDate;
     private Map<String, String> pluginDocumentationLinks;
 
-    public ProbeContext(String pluginName, UpdateCenter updateCenter) throws IOException {
+    private final boolean executionForced;
+
+    public ProbeContext(String pluginName, UpdateCenter updateCenter, boolean executionForced) throws IOException {
         this.updateCenter = updateCenter;
         this.scmRepository = Files.createTempDirectory(pluginName);
+        this.executionForced = executionForced;
     }
 
     public UpdateCenter getUpdateCenter() {
@@ -86,6 +89,10 @@ public class ProbeContext {
     public Optional<String> getRepositoryName(String scm) {
         final Matcher match = SCMLinkValidationProbe.GH_PATTERN.matcher(scm);
         return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
+    }
+
+    public boolean isExecutionForced() {
+        return executionForced;
     }
 
     /* default */ void cleanUp() throws IOException {

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
@@ -90,7 +90,11 @@ public class ProbeService {
     }
 
     public ProbeContext getProbeContext(String pluginName, UpdateCenter updateCenter) throws IOException {
-        return new ProbeContext(pluginName, updateCenter);
+        return getProbeContext(pluginName, updateCenter, false);
+    }
+
+    public ProbeContext getProbeContext(String pluginName, UpdateCenter updateCenter, boolean executionForced) throws IOException {
+        return new ProbeContext(pluginName, updateCenter, executionForced);
     }
 
     public Map<String, ProbeView> getProbesView() {


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

This could be the first step to re-execute probes on plugins when there are incorrect probe result like on #297.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [ ] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
