### PR TITLE
Opens actuator entrypoint to everyone

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/SecurityConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/SecurityConfiguration.java
@@ -40,7 +40,13 @@ public class SecurityConfiguration {
             .authorizeHttpRequests(request ->
                 request
                     .requestMatchers(HttpMethod.GET, "/js/*", "/style.css", "/svg/*").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/scores", "/", "/probes", "/probes/*", "/scores", "/scores/*").permitAll()
+                    .requestMatchers(HttpMethod.GET,
+                        "/api/scores",
+                        "/",
+                        "/probes", "/probes/*",
+                        "/scores", "/scores/*",
+                        "/actuator/*"
+                    ).permitAll()
                     .anyRequest().authenticated()
             );
         return http.build();


### PR DESCRIPTION


<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Because the entry points `/actuactor/health/liveness` and `/actuator/health/readiness` are not accessible without authentication, the deployment is seen as failed and so the pod is killed. 

This is important for kubernetes deployment.

Thanks @lemeurherve for finding this.

Problem introduced by https://github.com/jenkins-infra/plugin-health-scoring/pull/310.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [ ] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
