### PR TITLE
Validates plugin is failing with descrive workflow

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -71,7 +72,9 @@ public class ContinuousDeliveryProbe extends Probe {
                 })
                 .filter(wf -> wf.jobs() != null && !wf.jobs().isEmpty())
                 .flatMap(wf -> wf.jobs().values().stream())
-                .anyMatch(job -> job.uses().startsWith("jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml")) ?
+                .map(WorkflowJobDefinition::uses)
+                .filter(Objects::nonNull)
+                .anyMatch(def -> def.startsWith("jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml")) ?
                 ProbeResult.success(key(), "JEP-229 workflow definition found") :
                 ProbeResult.failure(key(), "Could not find JEP-229 workflow definition");
         } catch (IOException ex) {


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

Fixes a problem in `ContinuousDeliveryProbe` when a GitHub Action workflow description is using a more complex structure than expected. 
In those cases, the workflow description doesn't include `uses` directly in the job.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Submitter checklist

- [ ] If the issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch
  - `feature/` for new feature, or improvements
  - `fix/` for bug fixes
  - `docs/` for any documentation changes
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition
    - If there is no test, include an explanation why in the description
- [x] Run `mvn verify` locally and all tests are passing successfully
  - It is OK to create a pull request which has failing tests if it is created as a draft, is to fix a bug and the first commit is the test to prove the existence of the bug.
- [x] There is no new warnings (checkstyle nor spotbugs) on the code
