### PR TITLE
Removed folder path to fix SCMLinkValidationProbe 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,7 +105,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.8.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -102,9 +102,9 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -102,5 +102,10 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.8.6</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
@@ -27,7 +27,6 @@ package io.jenkins.pluginhealth.scoring.probes;
 import static io.jenkins.pluginhealth.scoring.probes.SCMLinkValidationProbe.GH_PATTERN;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
@@ -27,11 +27,13 @@ package io.jenkins.pluginhealth.scoring.probes;
 import static io.jenkins.pluginhealth.scoring.probes.SCMLinkValidationProbe.GH_PATTERN;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -66,14 +68,14 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
         if (!matcher.find()) {
             return ProbeResult.error(key(), "SCM link doesn't match GitHub plugin repositories");
         }
-        final String folder = context.getScmFolderPath();
+        final Optional<Path> folder = context.getScmFolderPath();
         final Set<String> files = new HashSet<>();
-
         final List<String> paths = new ArrayList<>(3);
         paths.add("pom.xml");
-        if (folder != null) {
-            paths.add(folder + "/pom.xml");
-            paths.add(folder + "/src/main");
+
+        if (folder.isPresent()) {
+            paths.add(folder.get() + "/pom.xml");
+            paths.add(folder.get() + "/src/main");
         } else {
             paths.add("src/main");
         }
@@ -123,6 +125,11 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
     }
 
     @Override
+    public String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
+    }
+
+    @Override
     public String key() {
         return KEY;
     }
@@ -140,10 +147,5 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
          * ProbeEngine, is must be `false`.
          */
         return false;
-    }
-
-    @Override
-    public String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
@@ -66,8 +66,7 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
         if (!matcher.find()) {
             return ProbeResult.error(key(), "SCM link doesn't match GitHub plugin repositories");
         }
-
-        final String folder = matcher.group("folder");
+        final String folder = context.getScmFolderPath();
         final Set<String> files = new HashSet<>();
 
         final List<String> paths = new ArrayList<>(3);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
@@ -68,7 +68,7 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
         if (!matcher.find()) {
             return ProbeResult.error(key(), "SCM link doesn't match GitHub plugin repositories");
         }
-        final Optional<Path> folder = context.getScmFolderPath();
+        final Optional<String> folder = context.getScmFolderPath();
         final Set<String> files = new HashSet<>();
         final List<String> paths = new ArrayList<>(3);
         paths.add("pom.xml");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -24,7 +24,6 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.regex.Matcher;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -57,7 +57,7 @@ public class LastCommitDateProbe extends Probe {
             return ProbeResult.failure(key(), "The SCM link is not valid");
         }
         final String repo = String.format("https://%s/%s", matcher.group("server"), matcher.group("repo"));
-        final String folder = matcher.group("folder");
+        final String folder = context.getScmFolderPath();
 
         try (Git git = Git.cloneRepository().setURI(repo).setDirectory(context.getScmRepository().toFile()).call()) {
             final LogCommand logCommand = git.log().setMaxCount(1);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -58,7 +58,7 @@ public class LastCommitDateProbe extends Probe {
             return ProbeResult.failure(key(), "The SCM link is not valid");
         }
         final String repo = String.format("https://%s/%s", matcher.group("server"), matcher.group("repo"));
-        final Optional<Path> folder = context.getScmFolderPath();
+        final Optional<String> folder = context.getScmFolderPath();
 
         try (Git git = Git.cloneRepository().setURI(repo).setDirectory(context.getScmRepository().toFile()).call()) {
             final LogCommand logCommand = git.log().setMaxCount(1);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -24,7 +24,9 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -45,10 +47,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(value = LastCommitDateProbe.ORDER)
 public class LastCommitDateProbe extends Probe {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LastCommitDateProbe.class);
-
     public static final int ORDER = SCMLinkValidationProbe.ORDER + 100;
     public static final String KEY = "last-commit-date";
+    private static final Logger LOGGER = LoggerFactory.getLogger(LastCommitDateProbe.class);
 
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
@@ -57,12 +58,12 @@ public class LastCommitDateProbe extends Probe {
             return ProbeResult.failure(key(), "The SCM link is not valid");
         }
         final String repo = String.format("https://%s/%s", matcher.group("server"), matcher.group("repo"));
-        final String folder = context.getScmFolderPath();
+        final Optional<Path> folder = context.getScmFolderPath();
 
         try (Git git = Git.cloneRepository().setURI(repo).setDirectory(context.getScmRepository().toFile()).call()) {
             final LogCommand logCommand = git.log().setMaxCount(1);
-            if (folder != null) {
-                logCommand.addPath(folder);
+            if (folder.isPresent()) {
+                logCommand.addPath(folder.get().toString());
             }
             final RevCommit commit = logCommand.call().iterator().next();
             if (commit == null) {
@@ -78,6 +79,11 @@ public class LastCommitDateProbe extends Probe {
             LOGGER.error("There was an issue while cloning the plugin repository", ex);
             return ProbeResult.failure(key(), "Could not clone the plugin repository");
         }
+    }
+
+    @Override
+    public String[] getProbeResultRequirement() {
+        return new String[]{SCMLinkValidationProbe.KEY};
     }
 
     @Override
@@ -98,10 +104,5 @@ public class LastCommitDateProbe extends Probe {
          * ProbeEngine, is must be `false`.
          */
         return false;
-    }
-
-    @Override
-    public String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY};
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -109,7 +109,7 @@ public abstract class Probe {
     /**
      * List of probe key to be present in the {@link Plugin#details} map and to be {@link ResultStatus#SUCCESS} in
      * order to consider executing the {@link Probe#doApply(Plugin, ProbeContext)} code.
-     * By default, the requirement is an empty array. I cannot be null.
+     * By default, the requirement is an empty array. It cannot be null.
      *
      * @return array of {@link Probe#key()} to be present in {@link Plugin#details}.
      */

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -45,6 +45,7 @@ public class ProbeContext {
     private GitHub github;
     private ZonedDateTime lastCommitDate;
     private Map<String, String> pluginDocumentationLinks;
+    private String scmFolderPath;
 
     public ProbeContext(String pluginName, UpdateCenter updateCenter) throws IOException {
         this.updateCenter = updateCenter;
@@ -86,6 +87,14 @@ public class ProbeContext {
     public Optional<String> getRepositoryName(String scm) {
         final Matcher match = SCMLinkValidationProbe.GH_PATTERN.matcher(scm);
         return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
+    }
+
+    public String getScmFolderPath() {
+        return scmFolderPath;
+    }
+
+    public void setScmFolderPath(String scmFolderPath) {
+        this.scmFolderPath = scmFolderPath;
     }
 
     /* default */ void cleanUp() throws IOException {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -45,7 +45,7 @@ public class ProbeContext {
     private GitHub github;
     private ZonedDateTime lastCommitDate;
     private Map<String, String> pluginDocumentationLinks;
-    private String scmFolderPath;
+    private Optional<Path> scmFolderPath;
 
     public ProbeContext(String pluginName, UpdateCenter updateCenter) throws IOException {
         this.updateCenter = updateCenter;
@@ -89,11 +89,11 @@ public class ProbeContext {
         return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
     }
 
-    public String getScmFolderPath() {
+    public Optional<Path> getScmFolderPath() {
         return scmFolderPath;
     }
 
-    public void setScmFolderPath(String scmFolderPath) {
+    public void setScmFolderPath(Optional<Path> scmFolderPath) {
         this.scmFolderPath = scmFolderPath;
     }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -45,7 +45,7 @@ public class ProbeContext {
     private GitHub github;
     private ZonedDateTime lastCommitDate;
     private Map<String, String> pluginDocumentationLinks;
-    private Optional<Path> scmFolderPath;
+    private Optional<String> scmFolderPath;
 
     public ProbeContext(String pluginName, UpdateCenter updateCenter) throws IOException {
         this.updateCenter = updateCenter;
@@ -89,11 +89,11 @@ public class ProbeContext {
         return match.find() ? Optional.of(match.group("repo")) : Optional.empty();
     }
 
-    public Optional<Path> getScmFolderPath() {
+    public Optional<String> getScmFolderPath() {
         return scmFolderPath;
     }
 
-    public void setScmFolderPath(Optional<Path> scmFolderPath) {
+    public void setScmFolderPath(Optional<String> scmFolderPath) {
         this.scmFolderPath = scmFolderPath;
     }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -24,7 +24,12 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,11 +128,11 @@ public class SCMLinkValidationProbe extends Probe {
     }
 
     public static String getSCMFolderPath(String filePath, String pluginName) {
-        if(filePath.startsWith("pom.xml")){
+        if (filePath.startsWith("pom.xml")) {
             MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-            try(Reader reader = new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8)) {
+            try (Reader reader = new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8)) {
                 Model model = mavenReader.read(reader);
-                if(model.getPackaging().equals("hpi") && model.getArtifactId().equals(pluginName)) {
+                if (model.getPackaging().equals("hpi") && model.getArtifactId().equals(pluginName)) {
                     return filePath + "/pom.xml";
                 }
             } catch (FileNotFoundException e) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -88,7 +89,13 @@ public class SCMLinkValidationProbe extends Probe {
             String folderPath = pluginPathInRepository
                 .flatMap(path -> Optional.ofNullable(path.getParent()))
                 .map(parent -> parent.getFileName().toString())
-                .orElse(String.valueOf(context.getScmRepository().getParent().getFileName()));
+                .orElseGet(() -> {
+                    Path scmRepository = context.getScmRepository();
+                    String defaultFolderName = scmRepository.getParent() != null
+                        ?  scmRepository.getParent().getFileName().toString()
+                        : "";
+                    return defaultFolderName;
+                });
             context.setScmFolderPath(folderPath);
             return ProbeResult.success(key(), "The plugin SCM link is valid.");
         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -31,7 +31,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -119,15 +118,15 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it valid or return the scm itself
      */
     private String searchPomFiles(Path directory, String pluginName, String scm) {
-        Optional<Path> filteredPath = null;
         try (Stream<Path> paths = Files.find(directory.resolve("pom.xml"), 1, (path, $) ->
             Files.isRegularFile(path) && path.getFileName().toString().equals("pom.xml"))) {
-            filteredPath = paths.findFirst().filter(pom -> pomFileMatchesPlugin(pom, pluginName));
-            System.out.println("filteredPath= "+filteredPath);
+            Optional<Path> filteredPath = paths.findFirst().filter(pom -> pomFileMatchesPlugin(pom, pluginName));
+            System.out.println("filteredPath= " + filteredPath);
+            return filteredPath.toString();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
         }
-        return filteredPath.toString();
+        return null;
     }
 
     private boolean pomFileMatchesPlugin(Path pomFile, String pluginName) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -26,15 +26,10 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +39,6 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.kohsuke.github.GitHubBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -32,8 +32,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -118,8 +121,8 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it valid or return the scm itself
      */
     private String searchPomFiles(Path directory, String pluginName, String scm) {
-        try (Stream<Path> paths = Files.find(directory, 2, (path, $) -> path.getFileName().toString().equals("pom.xml"))) {
-            return paths.filter(pom -> pomFileMatchesPlugin(pom, pluginName)).toString();
+        try (Stream<Path> paths = Files.find(directory.resolve("pom.xml"), 2, (path, $) -> path.getFileName().toString().equals("pom.xml"))) {
+            return paths.filter(pom -> pomFileMatchesPlugin(directory, pluginName)).toString();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -112,6 +112,14 @@ public class SCMLinkValidationProbe extends Probe {
         return new String[]{UpdateCenterPluginPublicationProbe.KEY};
     }
 
+    /**
+     * Searches for Pom files in every directory available in the repository
+     *
+     * @param directory in the scm
+     * @param pluginName the name of the plugin
+     * @param scm the valid scm link
+     * @return folderPath from the scm
+     */
     public static String searchPomFiles(File directory, String pluginName, String scm) {
         File[] files = directory.listFiles();
         if (files == null) {
@@ -130,6 +138,14 @@ public class SCMLinkValidationProbe extends Probe {
         return scm;
     }
 
+    /**
+     * Searches for folder path in the scm. The correct pom file is validated using the value of packaging and artifact id.
+     *
+     * @param filePath the path of the file to validate for the correct pom
+     * @param pluginName the name of the plugin
+     * @param scm the valid scm link
+     * @return filePath if it valid or return the scm itself
+     * */
     public static String getSCMFolderPath(String filePath, String pluginName, String scm) {
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
         try (Reader reader = new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8)) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -123,8 +123,8 @@ public class SCMLinkValidationProbe extends Probe {
             return Optional.empty();
         }
         /*
-         * If the `maxDepth` is more than 3, we will be navigating the `src/main/java/io/jenkins/plugins/artifactId/` folder
-         * A lot of plugins aren't located deeper than <root>/plugins/<pom.xml>.
+         * The `maxDepth` is 3 because a lot of plugins aren't located deeper than <root>/plugins/<pom.xml>.
+         * If the `maxDepth` is more than 3, we will be navigating the `src/main/java/io/jenkins/plugins/artifactId/` folder.
          * */
         try (Stream<Path> paths = Files.find(directory, 3, (path, $) ->
             "pom.xml".equals(path.getFileName().toString()))) {
@@ -150,7 +150,7 @@ public class SCMLinkValidationProbe extends Probe {
             LOGGER.error("Directory {} does not exists during {} probe.", directory, pluginName);
             return Optional.empty();
         }
-//       The `maxDepth` is 1 here because we are looking for the pom file only in root directory.
+        /* The `maxDepth` is 1 here because we are looking for the pom file only in root directory. */
         try (Stream<Path> paths = Files.find(directory.getParent(), 1, (path, $) ->
             "pom.xml".equals(path.getFileName().toString()))) {
             return paths

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 public class SCMLinkValidationProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(SCMLinkValidationProbe.class);
 
-    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)(?:/(?<folder>.*))?";
+    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/)";
     public static final Pattern GH_PATTERN = Pattern.compile(GH_REGEXP);
     public static final int ORDER = UpdateCenterPluginPublicationProbe.ORDER + 100;
     public static final String KEY = "scm";

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -72,7 +72,7 @@ public class SCMLinkValidationProbe extends Probe {
      * Validates the SCM link, and sets {@link ProbeContext#setScmFolderPath(String)}. The value is always the path of the POM file.
      *
      * @param context    Refer {@link ProbeContext}.
-     * @param scm        The SCM link @see {@link Plugin#getScm()}.
+     * @param scm        The SCM link {@link Plugin#getScm()}.
      * @param pluginName The name of the plugin {@link Plugin#getName()}.
      * @return ProbeResult {@link ProbeResult}.
      */

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -98,7 +98,7 @@ public class SCMLinkValidationProbe extends Probe {
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
             Optional<Path> file = searchPomFiles(context.getScmRepository(), pluginName);
-            String folderPath = file.isPresent() ? new File(file.toString()).getParentFile().getName() : null;
+            String folderPath = file.isPresent() ? new File(file.toString()).getParentFile().getName() : "";
             System.out.println("folderPath= " + folderPath);
             context.setScmFolderPath(folderPath);
             return ProbeResult.success(key(), "The plugin SCM link is valid");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -119,9 +119,7 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it valid or return the scm itself
      */
     private String searchPomFiles(Path directory, String pluginName, String scm) {
-        try (Stream<Path> paths = Files.find(directory, 2, (path, $) ->
-            path.getFileName().toString().equals("pom.xml")
-        )) {
+        try (Stream<Path> paths = Files.find(directory, 2, (path, $) -> path.getFileName().toString().equals("pom.xml"))) {
             return paths.filter(pom -> pomFileMatchesPlugin(pom, pluginName)).toString();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
@@ -133,7 +131,7 @@ public class SCMLinkValidationProbe extends Probe {
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
         try (Reader reader = new InputStreamReader(new FileInputStream(pomFile.toFile()), StandardCharsets.UTF_8)) {
             Model model = mavenReader.read(reader);
-            if (model.getPackaging().equals("hpi") && model.getArtifactId().equals(pluginName)) {
+            if ("hpi".equals(model.getPackaging()) && pluginName.equals(model.getArtifactId()) {
                 return true;
             }
         } catch (IOException e) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -69,12 +69,12 @@ public class SCMLinkValidationProbe extends Probe {
     }
 
     /**
-     * Validates the SCM link, and sets the folder path that contains pom.xml.
+     * Validates the SCM link, and sets {@link ProbeContext#setScmFolderPath(String)}. The value is always the path of the POM file.
      *
-     * @param context    @see {@link ProbeContext}.
+     * @param context    Refer {@link ProbeContext}.
      * @param scm        The SCM link @see {@link Plugin#getScm()}.
-     * @param pluginName The name of the plugin @see {@link Plugin#getName()}.
-     * @return ProbeResult @see {@link ProbeResult}.
+     * @param pluginName The name of the plugin {@link Plugin#getName()}.
+     * @return ProbeResult {@link ProbeResult}.
      */
     private ProbeResult fromSCMLink(ProbeContext context, String scm, String pluginName) {
         Matcher matcher = GH_PATTERN.matcher(scm);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -79,7 +79,7 @@ public class SCMLinkValidationProbe extends Probe {
     private ProbeResult fromSCMLink(ProbeContext context, String scm, String pluginName) {
         Matcher matcher = GH_PATTERN.matcher(scm);
         if (!matcher.find()) {
-            LOGGER.atDebug().setMessage(() -> String.format("%s is not respecting the SCM URL Template.", scm));
+            LOGGER.atDebug().log(() -> String.format("%s is not respecting the SCM URL Template.", scm));
             return ProbeResult.failure(key(), "SCM link doesn't match GitHub plugin repositories.");
         }
         try {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -31,12 +31,8 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -121,8 +117,9 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it valid or return the scm itself
      */
     private String searchPomFiles(Path directory, String pluginName, String scm) {
-        try (Stream<Path> paths = Files.find(directory, 2, (path, $) -> directory.getFileName().toString().equals("pom.xml"))) {
-            return paths.filter(pom -> pomFileMatchesPlugin(directory.resolve("pom.xml"), pluginName)).toString();
+        try (Stream<Path> paths = Files.find(directory, 2, (path, $) ->
+            Files.isRegularFile(path.resolve("pom.xml")) && path.getFileName().toString().equals("pom.xml"))) {
+            return paths.filter(pom -> pomFileMatchesPlugin(pom, pluginName)).toString();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -120,7 +120,7 @@ public class SCMLinkValidationProbe extends Probe {
      * @param scm the valid scm link
      * @return folderPath from the scm
      */
-    public static String searchPomFiles(File directory, String pluginName, String scm) {
+    private static String searchPomFiles(File directory, String pluginName, String scm) {
         File[] files = directory.listFiles();
         if (files == null) {
             return scm;
@@ -146,7 +146,7 @@ public class SCMLinkValidationProbe extends Probe {
      * @param scm the valid scm link
      * @return filePath if it valid or return the scm itself
      * */
-    public static String getSCMFolderPath(String filePath, String pluginName, String scm) {
+    private static String getSCMFolderPath(String filePath, String pluginName, String scm) {
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
         try (Reader reader = new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8)) {
             Model model = mavenReader.read(reader);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 public class SCMLinkValidationProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(SCMLinkValidationProbe.class);
 
-    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/)";
+    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)(?:/(?<folder>.*))?";
     public static final Pattern GH_PATTERN = Pattern.compile(GH_REGEXP);
     public static final int ORDER = UpdateCenterPluginPublicationProbe.ORDER + 100;
     public static final String KEY = "scm";
@@ -86,7 +86,7 @@ public class SCMLinkValidationProbe extends Probe {
         }
 
         try {
-            context.getGitHub().getRepository(matcher.group("repo"));
+            context.getGitHub().getRepository(matcher.group("repo").split("/")[0]);
             return ProbeResult.success(key(), "The plugin SCM link is valid");
         } catch (IOException ex) {
             return ProbeResult.failure(key(), "The plugin SCM link is invalid");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -104,7 +104,7 @@ public class SCMLinkValidationProbe extends Probe {
             File directory = new File(scm);
             List <String> folderPaths = searchPomFiles(directory, pluginName);
             for (String path : folderPaths) {
-                context.setGitHub(GitHubBuilder.fromPropertyFile(path));
+                // make the folder paths available to ProbeContext here.
             }
             return ProbeResult.success(key(), "The plugin SCM link is valid");
         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -96,8 +96,7 @@ public class SCMLinkValidationProbe extends Probe {
         }
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
-            String repo = matcher.group("repo").split("/")[1];
-            String folderPath = searchPomFiles(Paths.get(repo), pluginName, scm);
+            String folderPath = searchPomFiles(context.getScmRepository(), pluginName, scm);
             context.setScmFolderPath(folderPath);
             return ProbeResult.success(key(), "The plugin SCM link is valid");
         } catch (IOException ex) {
@@ -131,7 +130,7 @@ public class SCMLinkValidationProbe extends Probe {
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
         try (Reader reader = new InputStreamReader(new FileInputStream(pomFile.toFile()), StandardCharsets.UTF_8)) {
             Model model = mavenReader.read(reader);
-            if ("hpi".equals(model.getPackaging()) && pluginName.equals(model.getArtifactId()) {
+            if ("hpi".equals(model.getPackaging()) && pluginName.equals(model.getArtifactId())) {
                 return true;
             }
         } catch (IOException e) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -32,7 +32,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -121,8 +121,8 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it valid or return the scm itself
      */
     private String searchPomFiles(Path directory, String pluginName, String scm) {
-        try (Stream<Path> paths = Files.find(directory.resolve("pom.xml"), 2, (path, $) -> path.getFileName().toString().equals("pom.xml"))) {
-            return paths.filter(pom -> pomFileMatchesPlugin(directory, pluginName)).toString();
+        try (Stream<Path> paths = Files.find(directory, 2, (path, $) -> directory.getFileName().toString().equals("pom.xml"))) {
+            return paths.filter(pom -> pomFileMatchesPlugin(directory.resolve("pom.xml"), pluginName)).toString();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -99,7 +99,6 @@ public class SCMLinkValidationProbe extends Probe {
             context.getGitHub().getRepository(matcher.group("repo"));
             Optional<Path> file = searchPomFiles(context.getScmRepository(), pluginName);
             String folderPath = file.isPresent() ? new File(file.toString()).getParentFile().getName() : "";
-            System.out.println("folderPath= " + folderPath);
             context.setScmFolderPath(folderPath);
             return ProbeResult.success(key(), "The plugin SCM link is valid");
         } catch (IOException ex) {
@@ -124,7 +123,6 @@ public class SCMLinkValidationProbe extends Probe {
         try (Stream<Path> paths = Files.find(directory, 2, (path, $) ->
             path.getFileName().toString().equals("pom.xml"))) {
             fileName = paths
-                .peek(path -> System.out.println("will filter " + path))
                 .filter(pom -> pomFileMatchesPlugin(pom, pluginName))
                 .findFirst();
         } catch (IOException e) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -79,7 +79,7 @@ public class SCMLinkValidationProbe extends Probe {
     private ProbeResult fromSCMLink(ProbeContext context, String scm, String pluginName) {
         Matcher matcher = GH_PATTERN.matcher(scm);
         if (!matcher.find()) {
-            LOGGER.debug(String.format("%s is not respecting the SCM URL Template.", scm));
+            LOGGER.atDebug().setMessage(() -> String.format("%s is not respecting the SCM URL Template.", scm));
             return ProbeResult.failure(key(), "SCM link doesn't match GitHub plugin repositories.");
         }
         try {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -64,7 +64,7 @@ public class SCMLinkValidationProbe extends Probe {
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
         if (plugin.getScm() == null || plugin.getScm().isBlank()) {
             LOGGER.warn("{} has no SCM link", plugin.getName());
-            return ProbeResult.error(key(), "The plugin SCM link is empty");
+            return ProbeResult.error(key(), "The plugin SCM link is empty.");
         }
         return fromSCMLink(context, plugin.getScm(), plugin.getName());
     }
@@ -91,18 +91,18 @@ public class SCMLinkValidationProbe extends Probe {
         Matcher matcher = GH_PATTERN.matcher(scm);
         if (!matcher.find()) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("{} is not respecting the SCM URL Template", scm);
+                LOGGER.debug("{} is not respecting the SCM URL Template.", scm);
             }
-            return ProbeResult.failure(key(), "SCM link doesn't match GitHub plugin repositories");
+            return ProbeResult.failure(key(), "SCM link doesn't match GitHub plugin repositories.");
         }
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
             Optional<Path> file = searchPomFiles(context.getScmRepository(), pluginName);
             String folderPath = file.isPresent() ? new File(file.toString()).getParentFile().getName() : "";
             context.setScmFolderPath(folderPath);
-            return ProbeResult.success(key(), "The plugin SCM link is valid");
+            return ProbeResult.success(key(), "The plugin SCM link is valid.");
         } catch (IOException ex) {
-            return ProbeResult.failure(key(), "The plugin SCM link is invalid");
+            return ProbeResult.failure(key(), "The plugin SCM link is invalid.");
         }
     }
 
@@ -126,7 +126,7 @@ public class SCMLinkValidationProbe extends Probe {
                 .filter(pom -> pomFileMatchesPlugin(pom, pluginName))
                 .findFirst();
         } catch (IOException e) {
-            LOGGER.error("Could not browse the folder during probe {}", pluginName, e);
+            LOGGER.error("Could not browse the folder during probe {}.", pluginName, e);
         }
         return fileName;
     }
@@ -139,9 +139,9 @@ public class SCMLinkValidationProbe extends Probe {
                 return true;
             }
         } catch (IOException e) {
-            LOGGER.error("Pom file not found for {}", pluginName, e);
+            LOGGER.error("Pom file not found for {}.", pluginName, e);
         } catch (XmlPullParserException e) {
-            LOGGER.error("Could not parse pom file for {}", pluginName, e);
+            LOGGER.error("Could not parse pom file for {}.", pluginName, e);
         }
         return false;
     }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -96,7 +96,7 @@ public class SCMLinkValidationProbe extends Probe {
         }
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
-            String repo = matcher.group("repo");
+            String repo = matcher.group("repo").split("/")[1];
             String folderPath = searchPomFiles(Paths.get(repo), pluginName, scm);
             context.setScmFolderPath(folderPath);
             return ProbeResult.success(key(), "The plugin SCM link is valid");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -121,7 +121,7 @@ public class SCMLinkValidationProbe extends Probe {
      * @return folderPath if it is valid
      */
     private Optional<Path> findPluginPom(Path directory, String pluginName, String rootDirectory) {
-        try (Stream<Path> paths = Files.find(directory, Integer.MAX_VALUE, (path, $) ->
+        try (Stream<Path> paths = Files.find(directory, 3, (path, $) ->
             path.getFileName().toString().equals("pom.xml"))) {
             return paths
                 .filter(pom -> pomFileMatchesPlugin(pom, pluginName))

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -42,6 +44,7 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.kohsuke.github.GitHubBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
@@ -96,11 +99,13 @@ public class SCMLinkValidationProbe extends Probe {
             return ProbeResult.failure(key(), "SCM link doesn't match GitHub plugin repositories");
         }
 
-        File directory = new File(scm);
-        searchPomFiles(directory, pluginName);
-
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
+            File directory = new File(scm);
+            List <String> folderPaths = searchPomFiles(directory, pluginName);
+            for (String path : folderPaths) {
+                context.setGitHub(GitHubBuilder.fromPropertyFile(path));
+            }
             return ProbeResult.success(key(), "The plugin SCM link is valid");
         } catch (IOException ex) {
             return ProbeResult.failure(key(), "The plugin SCM link is invalid");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -69,7 +69,7 @@ public class SCMLinkValidationProbe extends Probe {
     }
 
     /**
-     * Validates the SCM link, and sets {@link ProbeContext#setScmFolderPath(String)}. The value is always the path of the POM file.
+     * Validates the SCM link, and sets {@link ProbeContext#setScmFolderPath(Optional)}. The value is always the path of the POM file.
      *
      * @param context    Refer {@link ProbeContext}.
      * @param scm        The SCM link {@link Plugin#getScm()}.
@@ -85,26 +85,12 @@ public class SCMLinkValidationProbe extends Probe {
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
             Optional<Path> pluginPathInRepository = findPluginPom(context.getScmRepository(), pluginName);
-            /*
-             * If a pom file is found, the parent folder is returned.
-             * If a pom file is not found, we assume that the plugin is a maven plugin,
-             * and return the root path. Because in a maven repository, a pom file always exists in the root.
-             */
-            Path folderPath = pluginPathInRepository
-                .flatMap(path -> Optional.ofNullable(path.getParent()))
-                .map(parent -> parent.getFileName())
-                .orElseGet(() -> {
-                    Path scmRepository = context.getScmRepository();
-                    Optional<Path> pluginPomInRootDirectory = findPluginPomInRootDirectory(context.getScmRepository(), pluginName);
-                    Path defaultFolder = pluginPomInRootDirectory.isPresent()
-                        ? scmRepository.getParent().getFileName()
-                        : Path.of("");
-                    return defaultFolder;
-                });
-            context.setScmFolderPath(folderPath.toString());
-            return folderPath.toString().isBlank()
-                ? ProbeResult.error(key(), String.format("No POM file found in %s plugin.", pluginName))
-                : ProbeResult.success(key(), "The plugin SCM link is valid.");
+            Optional<Path> folderPath = pluginPathInRepository.map(path -> path.getParent());
+            if (folderPath.isEmpty()) {
+                return ProbeResult.error(key(), String.format("No valid POM file found in %s plugin.", pluginName));
+            }
+            context.setScmFolderPath(Optional.of(folderPath.get().getFileName()));
+            return ProbeResult.success(key(), "The plugin SCM link is valid.");
         } catch (IOException ex) {
             return ProbeResult.failure(key(), "The plugin SCM link is invalid.");
         }
@@ -127,31 +113,6 @@ public class SCMLinkValidationProbe extends Probe {
          * If the `maxDepth` is more than 3, we will be navigating the `src/main/java/io/jenkins/plugins/artifactId/` folder.
          * */
         try (Stream<Path> paths = Files.find(directory, 3, (path, $) ->
-            "pom.xml".equals(path.getFileName().toString()))) {
-            return paths
-                .filter(pom -> pomFileMatchesPlugin(pom, pluginName))
-                .findFirst();
-        } catch (IOException e) {
-            LOGGER.error("Could not browse the folder during probe {}. {}", pluginName, e);
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Searches for Pom file only in the root directory of the repository.
-     *
-     * @param directory  root directory path in the scm.
-     * @param pluginName the name of the plugin.
-     * @return an Optional path if pom file is found.
-     */
-
-    private Optional<Path> findPluginPomInRootDirectory(Path directory, String pluginName) {
-        if (!Files.isDirectory(directory)) {
-            LOGGER.error("Directory {} does not exists during {} probe.", directory, pluginName);
-            return Optional.empty();
-        }
-        /* The `maxDepth` is 1 here because we are looking for the pom file only in root directory. */
-        try (Stream<Path> paths = Files.find(directory.getParent(), 1, (path, $) ->
             "pom.xml".equals(path.getFileName().toString()))) {
             return paths
                 .filter(pom -> pomFileMatchesPlugin(pom, pluginName))

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -115,7 +115,10 @@ public class SCMLinkValidationProbe extends Probe {
 
     public static String searchPomFiles(File directory, String pluginName, String scm) {
         File[] files = directory.listFiles();
-        for(File file: files) {
+        if (files == null) {
+            return scm;
+        }
+        for (File file : files) {
             try (Stream<Path> paths = Files.find(file.toPath(), 1, (path, $) ->
                 file.isDirectory())) {
                 return paths.findFirst()
@@ -133,7 +136,7 @@ public class SCMLinkValidationProbe extends Probe {
         try (Reader reader = new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8)) {
             Model model = mavenReader.read(reader);
             if (model.getPackaging().equals("hpi") && model.getArtifactId().equals(pluginName)) {
-                return Paths.get("pom.xml").getParent().toString();
+                return filePath;
             }
         } catch (IOException e) {
             LOGGER.error("Pom file not found for {}", pluginName, e);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -26,7 +26,6 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -128,7 +128,7 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
             LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(repository);
-        when(ctx.getScmFolderPath()).thenReturn(Optional.of(Paths.get("test-folder")));
+        when(ctx.getScmFolderPath()).thenReturn(Optional.of("test-folder"));
 
         when(plugin.getScm()).thenReturn(scmLink);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -26,6 +26,7 @@ package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -126,6 +127,8 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
             LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(repository);
+        when(ctx.getScmFolderPath()).thenReturn("test-folder");
+
         when(plugin.getScm()).thenReturn(scmLink);
 
         final PersonIdent defaultCommitter = new PersonIdent(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -35,9 +35,11 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
@@ -126,7 +128,7 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
             LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, "")
         ));
         when(ctx.getScmRepository()).thenReturn(repository);
-        when(ctx.getScmFolderPath()).thenReturn("test-folder");
+        when(ctx.getScmFolderPath()).thenReturn(Optional.of(Paths.get("test-folder")));
 
         when(plugin.getScm()).thenReturn(scmLink);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -179,4 +179,31 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
         verify(probe, atMostOnce()).doApply(plugin, ctx);
     }
+
+    @Test
+    void shouldNotReturnInCorrectScmFolderPath() throws IOException {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final GitHub github = mock(GitHub.class);
+        final String repositoryName = "jenkinsci/test-repo";
+
+        when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
+        when(plugin.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
+        when(plugin.getName()).thenReturn("test-repo");
+
+        when(ctx.getScmRepository()).thenReturn(Path.of("src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1"));
+        when(ctx.getGitHub()).thenReturn(github);
+        GHRepository repository = mock(GHRepository.class);
+        when(github.getRepository(repositoryName)).thenReturn(repository);
+
+        final SCMLinkValidationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(ctx.getScmFolderPath()).isEqualTo(null);
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+        assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
+        verify(probe, atMostOnce()).doApply(plugin, ctx);
+    }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -135,7 +135,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub gh = mock(GitHub.class);
-        final String repositoryName = "jenkinsci/this-is-not-going-to-work";
+        final String repositoryName = "jenkinsci/";
 
         when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
         when(p1.getDetails()).thenReturn(Map.of(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -32,8 +32,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -157,45 +155,17 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
     void shouldReturnCorrectScmFolderPath() throws IOException {
         final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final GitHub gh = mock(GitHub.class);
+        final GitHub github = mock(GitHub.class);
         final String repositoryName = "jenkinsci/test-repo";
-
-        Path parentDirectory = Files.createTempDirectory("jenkinsci");
-        Path directoryPath = parentDirectory.resolve("test-repo");
-        final Path tempDirectory1 = Files.createDirectories(directoryPath.resolve("nested-directory-1"));
-        final Path pomFile1 = Files.createFile(tempDirectory1.resolve("pom.xml"));
-        final Path tempDirectory2 = Files.createDirectories(directoryPath.resolve("nested-directory-2"));
-        final Path pomFile2 = Files.createFile(tempDirectory2.resolve("pom.xml"));
-
-        Files.write(pomFile1,
-            """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                      <modelVersion>4.0.0</modelVersion>
-                     
-                      <groupId>test-group</groupId>
-                      <artifactId>test-repo</artifactId>
-                      <packaging>pom</packaging>
-                </project>                             
-                """.getBytes()
-        );
-
-        Files.write(pomFile2,
-            """
-                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                      <modelVersion>4.0.0</modelVersion>
-                     
-                      <groupId>test-group</groupId>
-                      <artifactId>test-repo</artifactId>
-                      <packaging>hpi</packaging>
-                </project>                             
-                """.getBytes()
-        );
 
         when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
         when(p1.getDetails()).thenReturn(Map.of(
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
-        when(ctx.getGitHub()).thenReturn(gh);
+        when(ctx.getGitHub()).thenReturn(github);
+        GHRepository repository = ctx.getGitHub().getRepository(repositoryName);
+        when(github.getRepository(repositoryName)).thenReturn(repository);
+
         when(p1.getName()).thenReturn("test-repo");
 
         final SCMLinkValidationProbe probe = getSpy();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -122,8 +122,10 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(p1.getDetails()).thenReturn(Map.of(
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
+        when(ctx.getScmRepository()).thenReturn(Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1"));
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenReturn(new GHRepository());
+        when(p1.getName()).thenReturn("mailer-plugin");
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
@@ -195,8 +197,6 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         when(ctx.getScmRepository()).thenReturn(Path.of("src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1"));
         when(ctx.getGitHub()).thenReturn(github);
-        GHRepository repository = mock(GHRepository.class);
-        when(github.getRepository(repositoryName)).thenReturn(repository);
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -94,7 +94,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         assertThat(r1.status()).isEqualTo(ResultStatus.ERROR);
         assertThat(r2.status()).isEqualTo(ResultStatus.ERROR);
-        assertThat(r1.message()).isEqualTo("The plugin SCM link is empty");
+        assertThat(r1.message()).isEqualTo("The plugin SCM link is empty.");
     }
 
     @Test
@@ -110,7 +110,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);
-        assertThat(r1.message()).isEqualTo("SCM link doesn't match GitHub plugin repositories");
+        assertThat(r1.message()).isEqualTo("SCM link doesn't match GitHub plugin repositories.");
     }
 
     @Test
@@ -133,7 +133,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
-        assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
+        assertThat(r1.message()).isEqualTo("The plugin SCM link is valid.");
     }
 
     @Test
@@ -154,7 +154,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final ProbeResult r1 = probe.apply(p1, ctx);
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);
-        assertThat(r1.message()).isEqualTo("The plugin SCM link is invalid");
+        assertThat(r1.message()).isEqualTo("The plugin SCM link is invalid.");
     }
 
     @Test
@@ -181,8 +181,8 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-nested-dir-2");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
-        assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
-        verify(probe, atMostOnce()).doApply(plugin, contextSpy);
+        assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
+        verify(probe).doApply(plugin, contextSpy);
     }
 
     @Test
@@ -207,7 +207,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         assertThat(contextSpy.getScmFolderPath()).isEqualTo("");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
-        assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
-        verify(probe, atMostOnce()).doApply(plugin, contextSpy);
+        assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
+        verify(probe).doApply(plugin, contextSpy);
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -154,28 +154,28 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
     @Test
     void shouldReturnCorrectScmFolderPath() throws IOException {
-        final Plugin p1 = mock(Plugin.class);
+        final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub github = mock(GitHub.class);
         final String repositoryName = "jenkinsci/test-repo";
 
-        when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
-        when(p1.getDetails()).thenReturn(Map.of(
+        when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
+        when(plugin.getDetails()).thenReturn(Map.of(
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
+        when(plugin.getName()).thenReturn("test-repo");
+
         when(ctx.getScmRepository()).thenReturn(Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1"));
         when(ctx.getGitHub()).thenReturn(github);
         GHRepository repository = mock(GHRepository.class);
         when(github.getRepository(repositoryName)).thenReturn(repository);
 
-        when(p1.getName()).thenReturn("test-repo");
-
         final SCMLinkValidationProbe probe = getSpy();
-        final ProbeResult r1 = probe.apply(p1, ctx);
+        final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
-        assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
-        assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
+        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
+        assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
 
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -135,7 +135,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin p1 = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub gh = mock(GitHub.class);
-        final String repositoryName = "jenkinsci/";
+        final String repositoryName = "jenkinsci/this-is-not-going-to-work";
 
         when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
         when(p1.getDetails()).thenReturn(Map.of(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -163,7 +163,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
         when(ctx.getGitHub()).thenReturn(github);
-        GHRepository repository = ctx.getGitHub().getRepository(repositoryName);
+        GHRepository repository = mock(GHRepository.class);
         when(github.getRepository(repositoryName)).thenReturn(repository);
 
         when(p1.getName()).thenReturn("test-repo");
@@ -171,7 +171,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
 
-        assertThat(ctx.getScmFolderPath()).isEqualTo("test-repo");
+        assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,7 +25,6 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -179,6 +178,5 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
         verify(probe, atMostOnce()).doApply(plugin, ctx);
-
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -201,7 +201,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
-        assertThat(ctx.getScmFolderPath()).isEqualTo(null);
+        assertThat(ctx.getScmFolderPath()).isEqualTo("");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
         verify(probe, atMostOnce()).doApply(plugin, ctx);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,7 +25,6 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -163,7 +163,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(p1.getDetails()).thenReturn(Map.of(
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
-        when(ctx.getScmRepository()).thenReturn(Path.of("core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1"));
+        when(ctx.getScmRepository()).thenReturn(Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1"));
         when(ctx.getGitHub()).thenReturn(github);
         GHRepository repository = mock(GHRepository.class);
         when(github.getRepository(repositoryName)).thenReturn(repository);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -173,7 +173,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
 
-        assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
+        assertThat(ctx.getScmFolderPath()).isEqualTo("src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2");
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,6 +25,8 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -176,6 +178,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid");
+        verify(probe, atMostOnce()).doApply(plugin, ctx);
 
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,6 +25,7 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
@@ -127,6 +129,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenReturn(new GHRepository());
         when(p1.getName()).thenReturn("mailer-plugin");
+        when(ctx.getRepositoryName(anyString())).thenReturn(Optional.of(repositoryName));
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
@@ -203,7 +206,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("");
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-repo");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
         verify(probe).doApply(plugin, contextSpy);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -196,6 +196,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
         when(ctx.getGitHub()).thenReturn(gh);
+        when(p1.getName()).thenReturn("test-repo");
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,6 +25,8 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -175,6 +177,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
+        verify(ctx, atLeast(1)).setScmFolderPath(anyString());
 
         assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
@@ -183,7 +186,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
     }
 
     @Test
-    void shouldNotReturnInCorrectScmFolderPath() throws IOException {
+    void shouldNotReturnInCorrectScmFolderPath() {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub github = mock(GitHub.class);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -162,6 +163,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(p1.getDetails()).thenReturn(Map.of(
             UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
         ));
+        when(ctx.getScmRepository()).thenReturn(Path.of("core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1"));
         when(ctx.getGitHub()).thenReturn(github);
         GHRepository repository = mock(GHRepository.class);
         when(github.getRepository(repositoryName)).thenReturn(repository);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -138,7 +138,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-nested-dir-2")));
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of("test-nested-dir-2"));
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is valid.");
     }
@@ -185,7 +185,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-nested-dir-2")));
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of("test-nested-dir-2"));
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
         verify(probe).doApply(plugin, contextSpy);
@@ -236,7 +236,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-repo")));
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of("test-repo"));
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
         verify(probe).doApply(plugin, contextSpy);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -173,7 +173,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, ctx);
 
-        assertThat(ctx.getScmFolderPath()).isEqualTo("src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2");
+        assertThat(ctx.getScmFolderPath()).isEqualTo("test-nested-dir-2");
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -25,8 +25,6 @@
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -47,7 +45,6 @@ import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-import org.mockito.Mockito;
 
 class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProbe> {
     @Override

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,7 +138,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult r1 = probe.apply(p1, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-nested-dir-2");
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-nested-dir-2")));
         assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is valid.");
     }
@@ -184,7 +185,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-nested-dir-2");
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-nested-dir-2")));
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
         verify(probe).doApply(plugin, contextSpy);
@@ -209,9 +210,9 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-repo");
-        assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
-        assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(null);
+        assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
+        assertThat(result.message()).isEqualTo("No valid POM file found in test-repo plugin.");
         verify(probe).doApply(plugin, contextSpy);
     }
 
@@ -235,7 +236,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("test-repo");
+        assertThat(contextSpy.getScmFolderPath()).isEqualTo(Optional.of(Paths.get("test-repo")));
         assertThat(result.status()).isEqualTo(ResultStatus.SUCCESS);
         assertThat(result.message()).isEqualTo("The plugin SCM link is valid.");
         verify(probe).doApply(plugin, contextSpy);
@@ -246,8 +247,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin plugin = mock(Plugin.class);
         final GitHub github = mock(GitHub.class);
         final String repositoryName = "jenkinsci/test-no-pom-file-repo";
-        ProbeContext ctx = new ProbeContext(plugin.getName(), new UpdateCenter(Map.of(), Map.of(), List.of()));
-        ProbeContext contextSpy = spy(ctx);
+        ProbeContext contextSpy = spy(new ProbeContext(plugin.getName(), new UpdateCenter(Map.of(), Map.of(), List.of())));
 
         when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
         when(plugin.getDetails()).thenReturn(Map.of(
@@ -261,9 +261,8 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, contextSpy);
 
-        assertThat(contextSpy.getScmFolderPath()).isEqualTo("");
         assertThat(result.status()).isEqualTo(ResultStatus.ERROR);
-        assertThat(result.message()).isEqualTo("No POM file found in test-repo plugin.");
+        assertThat(result.message()).isEqualTo("No valid POM file found in test-repo plugin.");
         verify(probe).doApply(plugin, contextSpy);
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -32,6 +32,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -149,5 +152,58 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         assertThat(r1.status()).isEqualTo(ResultStatus.FAILURE);
         assertThat(r1.message()).isEqualTo("The plugin SCM link is invalid");
+    }
+
+    @Test
+    void shouldReturnCorrectScmFolderPath() throws IOException {
+        final Plugin p1 = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final GitHub gh = mock(GitHub.class);
+        final String repositoryName = "jenkinsci/test-repo";
+
+        Path parentDirectory = Files.createTempDirectory("jenkinsci");
+        Path directoryPath = parentDirectory.resolve("test-repo");
+        final Path tempDirectory1 = Files.createDirectories(directoryPath.resolve("nested-directory-1"));
+        final Path pomFile1 = Files.createFile(tempDirectory1.resolve("pom.xml"));
+        final Path tempDirectory2 = Files.createDirectories(directoryPath.resolve("nested-directory-2"));
+        final Path pomFile2 = Files.createFile(tempDirectory2.resolve("pom.xml"));
+
+        Files.write(pomFile1,
+            """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                     
+                      <groupId>test-group</groupId>
+                      <artifactId>test-repo</artifactId>
+                      <packaging>pom</packaging>
+                </project>                             
+                """.getBytes()
+        );
+
+        Files.write(pomFile2,
+            """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                     
+                      <groupId>test-group</groupId>
+                      <artifactId>test-repo</artifactId>
+                      <packaging>hpi</packaging>
+                </project>                             
+                """.getBytes()
+        );
+
+        when(p1.getScm()).thenReturn("https://github.com/" + repositoryName);
+        when(p1.getDetails()).thenReturn(Map.of(
+            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "")
+        ));
+        when(ctx.getGitHub()).thenReturn(gh);
+
+        final SCMLinkValidationProbe probe = getSpy();
+        final ProbeResult r1 = probe.apply(p1, ctx);
+
+        assertThat(ctx.getScmFolderPath()).isEqualTo("test-repo");
+        assertThat(r1.status()).isEqualTo(ResultStatus.SUCCESS);
+        assertThat(r1.message()).isEqualTo("The plugin SCM link is valid");
+
     }
 }

--- a/core/src/test/resources/jenkinsci/test-repo/pom.xml
+++ b/core/src/test/resources/jenkinsci/test-repo/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test-group</groupId>
+	<artifactId>test-repo</artifactId>
+	<packaging>hpi</packaging>
+</project>

--- a/core/src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1/pom.xml
+++ b/core/src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test-group</groupId>
+	<artifactId>test-incorrect-repo</artifactId>
+	<packaging>hpi</packaging>
+</project>

--- a/core/src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1/test-incorrect-nested-dir-2/pom.xml
+++ b/core/src/test/resources/jenkinsci/test-repo/test-incorrect-nested-dir-1/test-incorrect-nested-dir-2/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test-group</groupId>
+	<artifactId>test-repo</artifactId>
+	<packaging>pom</packaging>
+</project>

--- a/core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1/pom.xml
+++ b/core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test-group</groupId>
+	<artifactId>test-repo</artifactId>
+	<packaging>pom</packaging>
+</project>

--- a/core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2/pom.xml
+++ b/core/src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test-group</groupId>
+	<artifactId>test-repo</artifactId>
+	<packaging>hpi</packaging>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-model</artifactId>
+				<version>3.9.2</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -198,7 +198,7 @@
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.13.3</version>
+				<version>1.13.4</version>
 				<executions>
 					<execution>
 						<id>install node and yarn</id>


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

Steps to solve the issue:

1. Remove the `folder` part from Regex expression.
2. Look for `hpi` value in the `<packaging>` tag. 
    - If found, find the value in the `<artifactId>`.
3. If the `<artifactId>` value matches the plugin name
   - Find where the pom lives.
4.  If the pom lives inside the Git repository
    - Store the path to the folder which contains pom file. 
5. Make the folder path available to probe context (that use folders) so that other probes can use the folder and they do not fail.
 
There can be 3 scenarios in the SCM repository:

1. Lonely plugin
2. Plugin code inside module called plugin
3. Bunch of plugins inside modules of git repository


### Description

Closes #340

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done
Did not added new test cases. Modified the existing one.
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->


```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
