### PR TITLE
Creates method to get dependency bot name

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -42,17 +42,6 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
     public static final int ORDER = LastCommitDateProbe.ORDER + 100;
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDependencyBotConfigurationProbe.class);
 
-    private final String botName;
-
-    /**
-     * The constructor gets initialized with botName when extended.
-     *
-     * @param botName A "botName" is the name of a dependency bot for ex: dependabot, renovate bot, etc
-     */
-    AbstractDependencyBotConfigurationProbe(String botName) {
-        this.botName = botName;
-    }
-
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final Path scmRepository = context.getScmRepository();
@@ -63,15 +52,23 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
         }
 
         try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
-            Files.isRegularFile(path) && path.getFileName().toString().startsWith(botName))) {
+            Files.isRegularFile(path) && path.getFileName().toString().startsWith(getBotName()))) {
             return paths.findFirst()
-                .map(file -> ProbeResult.success(key(), String.format("%s is configured", botName)))
-                .orElseGet(() -> ProbeResult.failure(key(), String.format("%s is not configured", botName)));
+                .map(file -> ProbeResult.success(key(), String.format("%s is configured", getBotName())))
+                .orElseGet(() -> ProbeResult.failure(key(), String.format("%s is not configured", getBotName())));
         } catch (IOException ex) {
             LOGGER.error("Could not browse the plugin folder during probe {}", key(), ex);
             return ProbeResult.error(key(), "Could not browse the plugin folder");
         }
     }
+
+    /**
+     * Provides the name of the bot.
+     * This is normally the name of the file
+     *
+     * @return a "botName" is the name of a dependency bot for ex: dependabot, renovate bot, etc
+     */
+    protected abstract String getBotName();
 
     @Override
     protected boolean isSourceCodeRelated() {
@@ -80,6 +77,6 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
 
     @Override
     public String[] getProbeResultRequirement() {
-        return new String[]{SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY};
+        return new String[] { SCMLinkValidationProbe.KEY, LastCommitDateProbe.KEY };
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -29,16 +29,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * This probe looks for Dependabot configuration in a plugin.
- *
- * @see io.jenkins.pluginhealth.scoring.probes.AbstractDependencyBotConfigurationProbe
  */
 @Component
 @Order(AbstractDependencyBotConfigurationProbe.ORDER)
 public class DependabotProbe extends AbstractDependencyBotConfigurationProbe {
     public static final String KEY = "dependabot";
 
-    DependabotProbe() {
-        super(KEY);
+    @Override
+    protected String getBotName() {
+        return KEY;
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
@@ -4,17 +4,16 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
-* Looks for Renovate bot configuration in a plugin.
-*
-* @see io.jenkins.pluginhealth.scoring.probes.AbstractDependencyBotConfigurationProbe
-*/
+ * Looks for Renovate bot configuration in a plugin.
+ */
 @Component
 @Order(AbstractDependencyBotConfigurationProbe.ORDER)
 public class RenovateProbe extends AbstractDependencyBotConfigurationProbe {
     public static final String KEY = "renovate";
 
-    RenovateProbe() {
-        super(KEY);
+    @Override
+    protected String getBotName() {
+        return KEY;
     }
 
     @Override


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

This is just to remove constructor requirement for both Dependabot and Renovate probes.

### Testing done

Tests haven't changed.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
