### PR TITLE
Protects documentation service against potential null pointer exception

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
@@ -52,11 +52,15 @@ public class PluginDocumentationService {
 
     public Map<String, String> fetchPluginDocumentationUrl() {
         try {
-            final Map<String, Link> foo = objectMapper.readValue(new URL(configuration.jenkins().documentationUrls()), new TypeReference<>() {});
-            return foo.entrySet().stream()
+            final Map<String, Link> documentationUrlsMap = objectMapper.readValue(
+                new URL(configuration.jenkins().documentationUrls()),
+                  new TypeReference<>() {
+                  }
+            );
+            return documentationUrlsMap.entrySet().stream()
                 .collect(Collectors.toMap(
                     Map.Entry::getKey,
-                    e -> e.getValue().url()
+                    e -> e.getValue() == null || e.getValue().url() == null ? "" : e.getValue().url()
                 ));
         } catch (MalformedURLException e) {
             LOGGER.error("URL to documentation link is incorrect.", e);

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
@@ -60,6 +60,24 @@ class PluginDocumentationServiceTest {
     }
 
     @Test
+    void shouldBeAbleToParseFileWithNullValue() {
+        final URL url = PluginDocumentationService.class.getResource("/documentation-urls/plugin-documentation-urls-with-nulls.json");
+        assertThat(url).isNotNull();
+
+        final ApplicationConfiguration config = new ApplicationConfiguration(
+            new ApplicationConfiguration.Jenkins("foo", url.toString()),
+            new ApplicationConfiguration.GitHub("foo", null, "bar")
+        );
+
+        final PluginDocumentationService service = new PluginDocumentationService(objectMapper, config);
+        final Map<String, String> map = service.fetchPluginDocumentationUrl();
+
+        assertThat(map)
+            .contains(entry("foo", "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"))
+            .contains(entry("bar", "https://github.com/jenkinsci/bar-plugin"));
+    }
+
+    @Test
     void shouldSurviveIncorrectlyConfiguredDocumentationURL() {
         final ApplicationConfiguration config = new ApplicationConfiguration(
             new ApplicationConfiguration.Jenkins("foo", "this-is-not-a-correct-url"),

--- a/war/src/test/resources/documentation-urls/plugin-documentation-urls-with-nulls.json
+++ b/war/src/test/resources/documentation-urls/plugin-documentation-urls-with-nulls.json
@@ -1,0 +1,10 @@
+{
+  "foo": {
+    "url": "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"
+  },
+  "bar": {
+    "url": "https://github.com/jenkinsci/bar-plugin"
+  },
+  "test": {
+  }
+}


### PR DESCRIPTION
<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

### Description

In the latest production logs of the application, we could see NPE. 

```
Caused by: java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Unknown Source) ~[na:na]
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Unknown Source) ~[na:na]
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(Unknown Source) ~[na:na]
	at java.base/java.util.Iterator.forEachRemaining(Unknown Source) ~[na:na]
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[na:na]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.collect(Unknown Source) ~[na:na]
	at io.jenkins.pluginhealth.scoring.service.PluginDocumentationService.fetchPluginDocumentationUrl(PluginDocumentationService.java:57) ~[app/:na]
```

So closest to the application code was linked to https://github.com/jenkins-infra/plugin-health-scoring/blob/8c59f974ddd1ddd2acacf005b28bb5935a0e6923/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java#L57

The root problems seemed to be https://github.com/openjdk/jdk/blob/fb4098ff1a7cca5ec42600f9ab753681961bb1ad/src/java.base/share/classes/java/util/stream/Collectors.java#L180.

So, we could believe that in the map, some plugins link is `null`. Here I'm trying to protect the application against that.

However, this couldn't be reproduced locally so it is all hypothetical.

<!-- Comment:
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Nothing as I couldn't reproduce the problem locally.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
