### PR TITLE
Simplifies adoption scoring based on commit and release gap

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -46,7 +46,7 @@ public class AdoptionScoring extends Scoring {
     private static final String KEY = "adoption";
 
     private abstract static class TimeSinceLastCommitScoringComponent implements ScoringComponent {
-        public final Duration getTimeBetweenLastCommitAndDate(String lastCommitDateMessage, ZonedDateTime then) {
+        protected final Duration getTimeBetweenLastCommitAndDate(String lastCommitDateMessage, ZonedDateTime then) {
             final ZonedDateTime commitDate = ZonedDateTime
                 .parse(lastCommitDateMessage, DateTimeFormatter.ISO_DATE_TIME)
                 .withZoneSameInstant(getZone());
@@ -96,27 +96,7 @@ public class AdoptionScoring extends Scoring {
             new TimeSinceLastCommitScoringComponent() {
                 @Override
                 public String getDescription() {
-                    return "There must be less than 6 months between the last commit and the last release.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
-                    }
-
-                    final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
-                    if (days <= Duration.of(6 * 30, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("There is less than 6 months between the last release and the last commit."));
-                    }
-                    return new ScoringComponentResult(0, getWeight(), List.of("There is more than 6 months between the last release and the last release."));
-                }
-            },
-            new TimeSinceLastCommitScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "There must be between 6 months and 1 year between the last commit and the last release.";
+                    return "There must be a reasonable time gap between last release and last commit.";
                 }
 
                 @Override
@@ -126,73 +106,23 @@ public class AdoptionScoring extends Scoring {
                         return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
                     }
                     final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
-                    if (days <= Duration.of(365, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("There is less than a year between the last commit and the last release."));
+                    final String defaultReason = "There are %d days between last release and last commit.".formatted(days);
+                    if (days < Duration.of(30 * 6, ChronoUnit.DAYS).toDays()) {
+                        return new ScoringComponentResult(100, getWeight(), List.of(defaultReason, "Less than 6 months gap between last release and last commit."));
                     }
-                    return new ScoringComponentResult(0, getWeight(), List.of("There is no commit within 6 months to 1 year since the last release."));
-                }
-            },
-            new TimeSinceLastCommitScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "There must be a commit between 1 year and 2 years since the last release.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
+                    if (days < Duration.of(30 * 12 + 1, ChronoUnit.DAYS).toDays()) {
+                        return new ScoringComponentResult(60, getWeight(), List.of(defaultReason, "Less than a year between last release and last commit."));
                     }
-                    final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
-                    if (days <= Duration.of(2 * 365, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("There is less than 2 years between the last commit and the last release."));
+                    if (days < Duration.of(30 * 24 + 1, ChronoUnit.DAYS).toDays()) {
+                        return new ScoringComponentResult(20, getWeight(), List.of(defaultReason, "Less than 2 years between last release and last commit."));
                     }
-                    return new ScoringComponentResult(0, getWeight(), List.of("No commit in the last 2 years."));
-                }
-            },
-            new TimeSinceLastCommitScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "There must be a commit between 2 years and 4 years since the last release.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
+                    if (days < Duration.of(30 * 48 + 1, ChronoUnit.DAYS).toDays()) {
+                        return new ScoringComponentResult(10, 2, List.of(defaultReason, "Less than 4 years between last release and last commit."));
                     }
-                    final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
-                    if (days <= Duration.of(4 * 365, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("There is less than 4 years between the last commit and the last release."));
-                    }
-                    return new ScoringComponentResult(0, getWeight(), List.of("No commit in the last 4 years."));
-                }
-            },
-            new TimeSinceLastCommitScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "It must have less than 4 years between the last commit and the last release.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
-                    }
-                    final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
                     if (days > Duration.of(4 * 365, ChronoUnit.DAYS).toDays()) {
                         return new ScoringComponentResult(-1000, 100, List.of("There is more than 4 years between the last commit and the last release."));
                     }
                     return new ScoringComponentResult(0, getWeight(), List.of("No commit in the last 4 years."));
-
-                }
-
-                @Override
-                public int getWeight() {
-                    return 0;
                 }
             }
         );
@@ -207,7 +137,6 @@ public class AdoptionScoring extends Scoring {
     public float weight() {
         return COEFFICIENT;
     }
-
 
     @Override
     public String description() {


### PR DESCRIPTION
### Description

This is to improve the outcome of the adoption scoring.
Currently, the adoption is evaluating the time gap between the last release of the plugin and its last commit date. 
However, all the milestone gap are evaluated even when a smaller gap was evaluated positively. 

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Kept the existing test working.

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
