### PR TITLE
Fixes adoption and dependabot / renovate typo

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -57,12 +57,16 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
         try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
             Files.isRegularFile(path) && path.getFileName().toString().startsWith(getBotName()))) {
             return paths.findFirst()
-                .map(file -> this.success(String.format("%s is configured.", getBotName())))
-                .orElseGet(() -> this.success(String.format("%s is not configured.", getBotName())));
+                .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
+                .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
         } catch (IOException ex) {
             LOGGER.error("Could not browse the plugin folder during probe {}", key(), ex);
             return this.error("Could not browse the plugin folder");
         }
+    }
+
+    private String capitalize(String str) {
+        return str.substring(0,1).toUpperCase() + str.substring(1);
     }
 
     /**

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -66,7 +66,7 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
     }
 
     private String capitalize(String str) {
-        return str.substring(0,1).toUpperCase() + str.substring(1);
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 
     /**

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -81,9 +81,9 @@ public class AdoptionScoring extends Scoring {
 
                     return switch (probeResult.message()) {
                         case "This plugin is not up for adoption." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("The plugin is not marked as up for adoption"));
+                            new ScoringComponentResult(100, getWeight(), List.of("The plugin is not marked as up for adoption."));
                         case "This plugin is up for adoption." ->
-                            new ScoringComponentResult(-1000, getWeight(), List.of("The plugin is marked as up for adoption"));
+                            new ScoringComponentResult(-1000, getWeight(), List.of("The plugin is marked as up for adoption."));
                         default -> new ScoringComponentResult(-100, getWeight(), List.of());
                     };
                 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -74,7 +74,7 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
     }
 
     @Test
-    void shouldDetectMissingDependabotFile() throws Exception {
+    void shouldDetectMissingGithubConfigurationFolder() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final DependabotProbe probe = getSpy();
@@ -86,6 +86,23 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
             .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+        verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
+    }
+
+    @Test
+    void shouldDetectMissingDependabotFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DependabotProbe probe = getSpy();
+
+        final Path repo = Files.createTempDirectory("foo");
+        Files.createDirectories(repo.resolve(".github"));
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -104,7 +121,7 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "dependabot is configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
@@ -74,7 +74,7 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "renovate is not configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", probe.getVersion()));
     }
 
     @Test
@@ -92,6 +92,6 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "renovate is configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
     }
 }


### PR DESCRIPTION
### Description

Closes #429.

The adoption scoring phrasing was missing a `.` at the end of the sentence.
Both Dependabot and Renovate probe results were using an all-lowercase syntax, when it is a proper noun. It's not using a capitalized syntax.

All those changes impact the visualization on both plugin-health.jenkins.io and plugins.jenkins.io

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Fixed the tests to reflect the proper syntax. Run those tests locally.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
