### PR TITLE
Limits docker agent requirement for build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,7 @@
 #!/usr/bin/env groovy
 
 pipeline {
-  agent {
-    // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
-    label 'docker || linux-amd64-docker'
-  }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '10'))
     skipStagesAfterUnstable()
@@ -13,6 +10,9 @@ pipeline {
 
   stages {
     stage('Build') {
+      agent {
+        label 'docker || linux-amd64-docker'
+      }
       environment {
         JAVA_HOME = '/opt/jdk-17/'
       }


### PR DESCRIPTION
Thanks for the idea @lemeurherve.

### Description

This is only to make sure that we are getting a docker agent when we building the JAR binary of the application.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

None. This is a change in the CI build instructions.

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
