### PR TITLE
Better detect dependency bot configuration file in plugin repository

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -24,15 +24,16 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
-import io.jenkins.pluginhealth.scoring.model.Plugin;
-import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An abstract class that looks for bot configuration files in a repository.

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -24,16 +24,15 @@
 
 package io.jenkins.pluginhealth.scoring.probes;
 
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
-
-import io.jenkins.pluginhealth.scoring.model.Plugin;
-import io.jenkins.pluginhealth.scoring.model.ProbeResult;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An abstract class that looks for bot configuration files in a repository.
@@ -55,7 +54,7 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
         }
 
         try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
-            Files.isRegularFile(path) && path.getFileName().toString().startsWith(getBotName()))) {
+            Files.isRegularFile(path) && isPathBotConfigFile(path.getFileName().toString()))) {
             return paths.findFirst()
                 .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
                 .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
@@ -76,6 +75,14 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
      * @return a "botName" is the name of a dependency bot for ex: dependabot, renovate bot, etc
      */
     protected abstract String getBotName();
+
+    /**
+     * Tests if the provided filename is the same as the bot configuration filename.
+     *
+     * @param filename the path
+     * @return true if the filename is the same as the required bot configuration filename.
+     */
+    protected abstract boolean isPathBotConfigFile(String filename);
 
     @Override
     protected boolean isSourceCodeRelated() {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -41,6 +41,11 @@ public class DependabotProbe extends AbstractDependencyBotConfigurationProbe {
     }
 
     @Override
+    protected boolean isPathBotConfigFile(String filename) {
+        return "dependabot.yml".equals(filename) || "dependabot.yaml".equals(filename);
+    }
+
+    @Override
     public String key() {
         return KEY;
     }
@@ -52,6 +57,6 @@ public class DependabotProbe extends AbstractDependencyBotConfigurationProbe {
 
     @Override
     public long getVersion() {
-        return 1;
+        return 2;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
@@ -17,6 +17,11 @@ public class RenovateProbe extends AbstractDependencyBotConfigurationProbe {
     }
 
     @Override
+    protected boolean isPathBotConfigFile(String filename) {
+        return "renovate.json".equals(filename);
+    }
+
+    @Override
     public String key() {
         return KEY;
     }
@@ -28,6 +33,6 @@ public class RenovateProbe extends AbstractDependencyBotConfigurationProbe {
 
     @Override
     public long getVersion() {
-        return 1;
+        return 2;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -142,6 +142,6 @@ public class AdoptionScoring extends Scoring {
 
     @Override
     public int version() {
-        return 1;
+        return 2;
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -124,4 +124,23 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
             .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
+
+    @Test
+    void shouldDetectDependabotFileWithFullFileExtension() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final DependabotProbe probe = getSpy();
+
+        final Path repo = Files.createTempDirectory("foo");
+        final Path github = Files.createDirectories(repo.resolve(".github"));
+
+        Files.createFile(github.resolve("dependabot.yaml"));
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
+        verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
+    }
 }


### PR DESCRIPTION
### Description

Follow up of #437.
When updating scoring and probes, we **must** update the implementation `version`.

For the dependency bots, we were looking for a file which was named as the bot. This could be an invalid assumption. So here we introduce a method on each bot implementation test if any file found in the `.github` folder in the plugin repository could be the bot configuration file.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Added a test on dependabot probe as the configuration file could be `dependabot.yml` or `dependabot.yaml`. 
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
