### PR TITLE
Add search, sort and pagination feature to probes table

### DIFF
--- a/war/package.json
+++ b/war/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "ionicons": "7.3.1",
-    "simple-datatables": "^9.0.0"
+    "simple-datatables": "9.0.3"
   },
   "browserslist": [
     "defaults",

--- a/war/package.json
+++ b/war/package.json
@@ -24,7 +24,8 @@
     "webpack-remove-empty-scripts": "1.0.4"
   },
   "dependencies": {
-    "ionicons": "7.3.1"
+    "ionicons": "7.3.1",
+    "simple-datatables": "^9.0.0"
   },
   "browserslist": [
     "defaults",

--- a/war/src/main/js/index.js
+++ b/war/src/main/js/index.js
@@ -1,9 +1,19 @@
 import {defineCustomElements} from "ionicons/dist/loader";
+import { DataTable } from "simple-datatables";
 
 defineCustomElements(window, {
   resourcesUrl: '/',
 });
 
+const probesTable = document.getElementById('probes-table');
+if (probesTable !== null) {
+    new DataTable("#probes-table", {
+      perPageSelect: [10, 25, 50],
+      columns: [
+        { select: 1, sortable: false },
+      ]
+    });
+}
 
 const updateCollapseIcon = (container, target) => {
   if (target.classList.contains('show')) {

--- a/war/src/main/less/index.less
+++ b/war/src/main/less/index.less
@@ -7,6 +7,7 @@
 @import './modules/page-footer';
 @import './modules/score';
 @import './modules/table';
+@import '~simple-datatables/src/css/style.css';
 
 html {
   font-size: 16px !important;

--- a/war/src/main/resources/templates/probes/listing.html
+++ b/war/src/main/resources/templates/probes/listing.html
@@ -12,7 +12,7 @@
         Raw results of the probes execution can be found on the
         <a href="" data-th-href="@{/probes/results}">results page</a>.
     </p>
-    <table class="table">
+    <table class="table" id="probes-table">
         <thead>
         <tr>
             <th>ID</th>

--- a/war/yarn.lock
+++ b/war/yarn.lock
@@ -1071,6 +1071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.10":
+  version: 1.11.10
+  resolution: "dayjs@npm:1.11.10"
+  checksum: 27e8f5bc01c0a76f36c656e62ab7f08c2e7b040b09e613cd4844abf03fb258e0350f0a83b02c887b84d771c1f11e092deda0beef8c6df2a1afbc3f6c1fade279
+  languageName: node
+  linkType: hard
+
 "del@npm:^4.1.1":
   version: 4.1.1
   resolution: "del@npm:4.1.1"
@@ -1083,6 +1090,13 @@ __metadata:
     pify: "npm:^4.0.1"
     rimraf: "npm:^2.6.3"
   checksum: 521f7da44bd79da841c06d573923d1f64f423aee8b8219c973478d3150ce1dcc024d03ad605929292adbff56d6448bca60d96dcdd2d8a53b46dbcb27e265c94b
+  languageName: node
+  linkType: hard
+
+"diff-dom@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "diff-dom@npm:5.1.3"
+  checksum: c3eecb6a0487e49b8429474994d9236959805666699e9074cf9c9a7e39f6a11818a9b80a2c4af58ec74496c08bbae7eb53b64184817e79699fba1f8f21a2ffe5
   languageName: node
   linkType: hard
 
@@ -2160,6 +2174,7 @@ __metadata:
     path: "npm:0.12.7"
     postcss: "npm:8.4.38"
     postcss-loader: "npm:8.1.1"
+    simple-datatables: "npm:^9.0.0"
     style-loader: "npm:3.3.4"
     webpack: "npm:5.91.0"
     webpack-cli: "npm:5.1.4"
@@ -2806,6 +2821,16 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"simple-datatables@npm:^9.0.0":
+  version: 9.0.3
+  resolution: "simple-datatables@npm:9.0.3"
+  dependencies:
+    dayjs: "npm:^1.11.10"
+    diff-dom: "npm:^5.1.3"
+  checksum: 0a68e2b124b5c9d8f582b697a8584cca13137834768fd713d8fd07542112389264cbafe9acc23ef486ec65fff0798a77bc8750bfc600aa4253681895dcef4fa0
   languageName: node
   linkType: hard
 

--- a/war/yarn.lock
+++ b/war/yarn.lock
@@ -2174,7 +2174,7 @@ __metadata:
     path: "npm:0.12.7"
     postcss: "npm:8.4.38"
     postcss-loader: "npm:8.1.1"
-    simple-datatables: "npm:^9.0.0"
+    simple-datatables: "npm:9.0.3"
     style-loader: "npm:3.3.4"
     webpack: "npm:5.91.0"
     webpack-cli: "npm:5.1.4"
@@ -2824,7 +2824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-datatables@npm:^9.0.0":
+"simple-datatables@npm:9.0.3":
   version: 9.0.3
   resolution: "simple-datatables@npm:9.0.3"
   dependencies:


### PR DESCRIPTION
Closes #65 

It's been quite a long time since @dheerajodha and @lzeee tried to resolve this issue. This is a continuation of these PRs.

As mentioned by the @alecharp in this [comment](https://github.com/jenkins-infra/plugin-health-scoring/pull/222#issuecomment-1450151243), I tried to fetch the branch from @dheerajodha's repo which ultimately failed.
`git@github.com: Permission denied (publickey).`
Also the branch is too old to work on. So, I started working in a new branch (but major props to @dheerajodha and @lzeee for their contributions)

This PR replaces [datatables](https://datatables.net/) with [simple-datatables](https://github.com/fiduswriter/simple-datatables) which primarily uses plain JS instead of jquery.


Made changes according to the reviews given by @alecharp in the previous PR's. But still I have few doubts in them.

- [Comment-1](https://github.com/jenkins-infra/plugin-health-scoring/pull/109#discussion_r1022497645) 👇
> We have a package manager for front-end libraries and a build system to package everything.
This is not a working solution to me.

From my understanding and previous implementation by @lzeee , I removed the CDN of simple-database and installed the npm package of it, then abstracted the css into a separate file 'simple-datatable.less'. Do I need to change anything else?

- [Comment-2](https://github.com/jenkins-infra/plugin-health-scoring/pull/228#discussion_r1122805024) 👇
> This simple complex. Can we not have a <script> in the correct template and not have this in the global javascript?

As mentioned by @lzeee, we can use 'html-webpack-plugin' I have also researched about the alternatives but this is the most preferrable one. Suggestions are welcomed. also why don't we keep datatable function in the index.js?

Currently the probes page look like this:

https://github.com/jenkins-infra/plugin-health-scoring/assets/107404972/44e90838-deee-4aaa-a6d2-7c45d8e3d0f6

