### PR TITLE
Provides resolutions with human readable text

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Resolution.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Resolution.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,20 +24,14 @@
 
 package io.jenkins.pluginhealth.scoring.model;
 
-import java.util.List;
-
-import io.jenkins.pluginhealth.scoring.scores.ScoringComponent;
-
 /**
- * Describes the evaluation from a {@link ScoringComponent} on a specific plugin.
+ * Represents the text and link to be used to guide users and maintainers to resolve an incomplete score.
  *
- * @param score       the score representing the points granted to the plugin, out of 100 (one hundred).
- * @param weight      the weight of the score
- * @param reasons     the list of string explaining the score granted to the plugin
- * @param resolutions a list of {@link Resolution} to help increase the score with human-readable description as key
+ * @param text a human-readable text to be used to point to the guide
+ * @param link the URI of the guide to resolve the problem
  */
-public record ScoringComponentResult(int score, float weight, List<String> reasons, List<Resolution> resolutions) {
-    public ScoringComponentResult(int score, float weight, List<String> reasons) {
-        this(score, weight, reasons, List.of());
+public record Resolution(String text, String link) {
+    public Resolution(String link) {
+        this(link, link);
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoringComponentResult.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoringComponentResult.java
@@ -25,6 +25,7 @@
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.util.List;
+import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.scores.ScoringComponent;
 
@@ -34,10 +35,10 @@ import io.jenkins.pluginhealth.scoring.scores.ScoringComponent;
  * @param score       the score representing the points granted to the plugin, out of 100 (one hundred).
  * @param weight      the weight of the score
  * @param reasons     the list of string explaining the score granted to the plugin
- * @param resolutions the list of link providing help to increase the score
+ * @param resolutions the map of link providing help to increase the score with human-readable description as key
  */
-public record ScoringComponentResult(int score, float weight, List<String> reasons, List<String> resolutions) {
+public record ScoringComponentResult(int score, float weight, List<String> reasons, Map<String, String> resolutions) {
     public ScoringComponentResult(int score, float weight, List<String> reasons) {
-        this(score, weight, reasons, List.of());
+        this(score, weight, reasons, Map.of());
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.LastCommitDateProbe;
 import io.jenkins.pluginhealth.scoring.probes.UpForAdoptionProbe;
@@ -87,7 +88,9 @@ public class AdoptionScoring extends Scoring {
                                 -1000,
                                 getWeight(),
                                 List.of("The plugin is marked as up for adoption."),
-                                Map.of("See adoption guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")
+                                List.of(
+                                    new Resolution("See adoption guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")
+                                )
                             );
                         default -> new ScoringComponentResult(-100, getWeight(), List.of());
                     };

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -87,7 +87,7 @@ public class AdoptionScoring extends Scoring {
                                 -1000,
                                 getWeight(),
                                 List.of("The plugin is marked as up for adoption."),
-                                List.of("https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")
+                                Map.of("See adoption guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")
                             );
                         default -> new ScoringComponentResult(-100, getWeight(), List.of());
                     };
@@ -147,6 +147,6 @@ public class AdoptionScoring extends Scoring {
 
     @Override
     public int version() {
-        return 3;
+        return 4;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.DeprecatedPluginProbe;
 
@@ -61,7 +62,9 @@ public class DeprecatedPluginScoring extends Scoring {
                                 0,
                                 getWeight(),
                                 List.of("Plugin is marked as deprecated."),
-                                Map.of("See deprecation guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")
+                                List.of(
+                                    new Resolution("See deprecation guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")
+                                )
                             );
                         case "This plugin is NOT deprecated." ->
                             new ScoringComponentResult(100, getWeight(), List.of("Plugin is not marked as deprecated."));

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
@@ -61,7 +61,7 @@ public class DeprecatedPluginScoring extends Scoring {
                                 0,
                                 getWeight(),
                                 List.of("Plugin is marked as deprecated."),
-                                List.of("https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")
+                                Map.of("See deprecation guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")
                             );
                         case "This plugin is NOT deprecated." ->
                             new ScoringComponentResult(100, getWeight(), List.of("Plugin is not marked as deprecated."));
@@ -95,6 +95,6 @@ public class DeprecatedPluginScoring extends Scoring {
 
     @Override
     public int version() {
-        return 2;
+        return 3;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;
@@ -96,7 +97,9 @@ public class DocumentationScoring extends Scoring {
                                 0,
                                 getWeight(),
                                 List.of("Documentation should be migrated in plugin repository."),
-                                List.of("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
+                                List.of(
+                                    new Resolution("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
+                                )
                             );
                         default ->
                             new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration.", probeResult.message()));

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -66,7 +66,7 @@ public class PluginMaintenanceScoring extends Scoring {
                                 0,
                                 getWeight(),
                                 List.of("Jenkinsfile not detected in plugin repository."),
-                                List.of("https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")
+                                Map.of("See how to add a Jenkinsfile", "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")
                             );
                         default ->
                             new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the presence of Jenkinsfile.", probeResult.message()));
@@ -105,7 +105,7 @@ public class PluginMaintenanceScoring extends Scoring {
                         0,
                         getWeight(),
                         List.of("No dependency version manager bot are used on the plugin repository."),
-                        List.of("https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")
+                        Map.of("See how to automate the dependencies updates", "https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")
                     );
                 }
 
@@ -121,7 +121,7 @@ public class PluginMaintenanceScoring extends Scoring {
                                 50,
                                 getWeight(),
                                 List.of(dependencyBotResult.message(), "%s open dependency pull request".formatted(dependencyPullRequestResult.message())),
-                                List.of("%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies".formatted(plugin.getScm()))
+                                Map.of("See the open pull requests of the plugin", "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies".formatted(plugin.getScm()))
                             );
                     }
                     return new ScoringComponentResult(

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
 import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
@@ -66,7 +67,9 @@ public class PluginMaintenanceScoring extends Scoring {
                                 0,
                                 getWeight(),
                                 List.of("Jenkinsfile not detected in plugin repository."),
-                                Map.of("See how to add a Jenkinsfile", "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")
+                                List.of(
+                                    new Resolution("See how to add a Jenkinsfile", "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")
+                                )
                             );
                         default ->
                             new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the presence of Jenkinsfile.", probeResult.message()));
@@ -105,7 +108,9 @@ public class PluginMaintenanceScoring extends Scoring {
                         0,
                         getWeight(),
                         List.of("No dependency version manager bot are used on the plugin repository."),
-                        Map.of("See how to automate the dependencies updates", "https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")
+                        List.of(
+                            new Resolution("See how to automate the dependencies updates", "https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")
+                        )
                     );
                 }
 
@@ -121,7 +126,9 @@ public class PluginMaintenanceScoring extends Scoring {
                                 50,
                                 getWeight(),
                                 List.of(dependencyBotResult.message(), "%s open dependency pull request".formatted(dependencyPullRequestResult.message())),
-                                Map.of("See the open pull requests of the plugin", "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies".formatted(plugin.getScm()))
+                                List.of(
+                                    new Resolution("See the open pull requests of the plugin", "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies".formatted(plugin.getScm()))
+                                )
                             );
                     }
                     return new ScoringComponentResult(

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.service.ScoreService;
@@ -92,15 +93,8 @@ public class ScoreAPI {
     }
 
     private record PluginScoreDetailComponent(int value, float weight, List<String> reasons, List<Resolution> resolutions) {
-        private record Resolution(String text, String link) {
-        }
-
         private PluginScoreDetailComponent(ScoringComponentResult result) {
-            this(result.score(), result.weight(), result.reasons(),
-                result.resolutions().entrySet().stream()
-                    .map(entry -> new Resolution(entry.getKey(), entry.getValue()))
-                    .collect(Collectors.toList())
-            );
+            this(result.score(), result.weight(), result.reasons(), result.resolutions());
         }
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
@@ -91,10 +91,16 @@ public class ScoreAPI {
         }
     }
 
+    private record PluginScoreDetailComponent(int value, float weight, List<String> reasons, List<Resolution> resolutions) {
+        private record Resolution(String text, String link) {
+        }
 
-    private record PluginScoreDetailComponent(int value, float weight, List<String> reasons, List<String> resolutions) {
         private PluginScoreDetailComponent(ScoringComponentResult result) {
-            this(result.score(), result.weight(), result.reasons(), result.resolutions());
+            this(result.score(), result.weight(), result.reasons(),
+                result.resolutions().entrySet().stream()
+                    .map(entry -> new Resolution(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList())
+            );
         }
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Follow up of #452.
Will improve UX in https://github.com/jenkins-infra/plugin-site/pull/1592.

This provide a way to have a human readable text with the link to the resolution guide. 
It hides links and if the link is not to a guide, it provides meaning to the link.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Ran the application locally.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
