### PR TITLE
Using release drafter is not mandatory but a good documentation practice

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbe.java
@@ -38,13 +38,11 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
-@Order(DrafterReleaseProbe.ORDER)
-public class DrafterReleaseProbe extends  Probe {
-
+@Order(ReleaseDrafterProbe.ORDER)
+public class ReleaseDrafterProbe extends Probe {
     public static final String KEY = "release-drafter";
-
     public static final int ORDER = LastCommitDateProbe.ORDER + 100;
-    private static final Logger LOGGER = LoggerFactory.getLogger(DrafterReleaseProbe.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReleaseDrafterProbe.class);
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -33,6 +33,7 @@ import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;
+import io.jenkins.pluginhealth.scoring.probes.ReleaseDrafterProbe;
 
 import org.springframework.stereotype.Component;
 
@@ -118,6 +119,38 @@ public class DocumentationScoring extends Scoring {
                 @Override
                 public int getWeight() {
                     return 8;
+                }
+            },
+            new ScoringComponent() {
+                @Override
+                public String getDescription() {
+                    return "Recommend to setup Release Drafter on the plugin repository.";
+                }
+
+                @Override
+                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                    ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
+                    if (result != null && "Release Drafter is configured.".equals(result.message())) {
+                        return new ScoringComponentResult(
+                            100,
+                            getWeight(),
+                            List.of("Plugin is using Release Drafter.")
+                        );
+                    }
+                    return new ScoringComponentResult(
+                        0,
+                        0,
+                        List.of("Plugin is not using Release Drafter to manage its changelog."),
+                        List.of(new Resolution(
+                            "Plugin could benefit from using Release Drafter.",
+                            "https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc"
+                        ))
+                    );
+                }
+
+                @Override
+                public int getWeight() {
+                    return 0;
                 }
             }
         );

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -57,26 +57,35 @@ public class DocumentationScoring extends Scoring {
 
     @Override
     public List<ScoringComponent> getComponents() {
-        return List.of(new ScoringComponent() {
-            @Override
-            public String getDescription() {
-                return "The plugin has a specific contributing guide.";
-            }
-
-            @Override
-            public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
-                if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
-                    return new ScoringComponentResult(100, getWeight(), List.of("Plugin has a contributing guide."));
+        return List.of(
+            new ScoringComponent() {
+                @Override
+                public String getDescription() {
+                    return "The plugin has a specific contributing guide.";
                 }
-                return new ScoringComponentResult(0, getWeight(), List.of("The plugin relies on the global contributing guide."));
-            }
 
-            @Override
-            public int getWeight() {
-                return 2;
-            }
-        },
+                @Override
+                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                    ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
+                    if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
+                        return new ScoringComponentResult(100, getWeight(), List.of("Plugin has a contributing guide."));
+                    }
+                    return new ScoringComponentResult(
+                        0,
+                        getWeight(),
+                        List.of("The plugin relies on the global contributing guide."),
+                        List.of(new Resolution(
+                            "See why and how to add a contributing guide",
+                            "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-contributing-guide/"
+                        ))
+                    );
+                }
+
+                @Override
+                public int getWeight() {
+                    return 2;
+                }
+            },
             new ScoringComponent() {
                 @Override
                 public String getDescription() {
@@ -110,11 +119,12 @@ public class DocumentationScoring extends Scoring {
                 public int getWeight() {
                     return 8;
                 }
-            });
+            }
+        );
     }
 
     @Override
     public int version() {
-        return 1;
+        return 2;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -31,6 +31,7 @@ import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.Resolution;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
+import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
 import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;
 import io.jenkins.pluginhealth.scoring.probes.ReleaseDrafterProbe;
@@ -129,6 +130,14 @@ public class DocumentationScoring extends Scoring {
 
                 @Override
                 public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                    ProbeResult cdProbe = probeResults.get(ContinuousDeliveryProbe.KEY);
+                    if (cdProbe != null && "JEP-229 workflow definition found.".equals(cdProbe.message())) {
+                        return new ScoringComponentResult(
+                            100,
+                            getWeight(),
+                            List.of("Plugin using Release Drafter because it has CD configured.")
+                        );
+                    }
                     ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
                     if (result != null && "Release Drafter is configured.".equals(result.message())) {
                         return new ScoringComponentResult(

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbeTest.java
@@ -40,10 +40,10 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 
 import org.junit.jupiter.api.Test;
 
-class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
+class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
     @Override
-    DrafterReleaseProbe getSpy() {
-        return spy(DrafterReleaseProbe.class);
+    ReleaseDrafterProbe getSpy() {
+        return spy(ReleaseDrafterProbe.class);
     }
 
     @Test
@@ -59,19 +59,19 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
         when(plugin.getName()).thenReturn("foo");
         when(ctx.getScmRepository()).thenReturn(Optional.empty());
 
-        final DrafterReleaseProbe probe = getSpy();
+        final ReleaseDrafterProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(DrafterReleaseProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
+            .isEqualTo(ProbeResult.error(ReleaseDrafterProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
     }
 
     @Test
     void shouldDetectMissingGithubConfigurationFolder() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DrafterReleaseProbe probe = getSpy();
+        final ReleaseDrafterProbe probe = getSpy();
 
         final Path repo = Files.createTempDirectory("foo");
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
@@ -79,7 +79,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DrafterReleaseProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -87,7 +87,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
     void shouldDetectMissingReleaseDrafterFile() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DrafterReleaseProbe probe = getSpy();
+        final ReleaseDrafterProbe probe = getSpy();
 
         final Path repo = Files.createTempDirectory("foo");
         Files.createDirectories(repo.resolve(".github"));
@@ -96,7 +96,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DrafterReleaseProbe.KEY, "Release Drafter is not configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -104,7 +104,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
     void shouldDetectReleaseDrafterFile() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DrafterReleaseProbe probe = getSpy();
+        final ReleaseDrafterProbe probe = getSpy();
 
         final Path repo = Files.createTempDirectory("foo");
         final Path github = Files.createDirectories(repo.resolve(".github"));
@@ -115,7 +115,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DrafterReleaseProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -123,7 +123,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
     void shouldDetectReleaseDrafterFileWithFullFileExtension() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
-        final DrafterReleaseProbe probe = getSpy();
+        final ReleaseDrafterProbe probe = getSpy();
 
         final Path repo = Files.createTempDirectory("foo");
         final Path github = Files.createDirectories(repo.resolve(".github"));
@@ -134,7 +134,7 @@ class DrafterReleaseProbeTest extends AbstractProbeTest<DrafterReleaseProbe> {
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DrafterReleaseProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #461.

Using Release drafter is not mandatory but encourage.
Not using it does not lower the documentation scoring value but adds a note on how to configure it.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Added a unit test to validate the optional usage of Release Drafter.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
