### PR TITLE
data: Updating CONTRIBUTING.adoc

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -13,7 +13,7 @@ When building, Yarn will bundle the front-end files only.
 .. Java 21
 .. Maven 3.9.6
 .. Node 20.10.0 and Yarn 4.0.2 (these should be done in the "war" directory)
-.. Docker installed in your environment
+.. Docker installed & running in your environment
 . Open the project in your favorite IDE.
 
 NOTE: Optionally, you can use the Maven wrapper in the repository.

--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -13,7 +13,7 @@ When building, Yarn will bundle the front-end files only.
 .. Java 21
 .. Maven 3.9.6
 .. Node 20.10.0 and Yarn 4.0.2 (these should be done in the "war" directory)
-.. Optional: have Docker installed in your environment
+.. Docker installed in your environment
 . Open the project in your favorite IDE.
 
 NOTE: Optionally, you can use the Maven wrapper in the repository.

--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -13,7 +13,7 @@ When building, Yarn will bundle the front-end files only.
 .. Java 21
 .. Maven 3.9.6
 .. Node 20.10.0 and Yarn 4.0.2 (these should be done in the "war" directory)
-.. Docker installed & running in your environment
+.. Docker installed and running in your environment
 . Open the project in your favorite IDE.
 
 NOTE: Optionally, you can use the Maven wrapper in the repository.


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Docker as a prerequisite for building the application in the local system is no more optional and gives the below error.

![image](https://github.com/jenkins-infra/plugin-health-scoring/assets/100852245/44489c80-59e5-4642-88df-a8c2e8bcd925)


<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Running `mvn verify` on an environment without Docker available fails. Once Docker is available, there is no more errors.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
