### PR TITLE
Uses newest scoring timestamp as etag header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ node_modules/
 ### IDE
 *.iml
 *.idea
+
+### fetch-report.sh
+etags.txt
+scores.json

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -1,4 +1,4 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+def cronExpr = env.BRANCH_IS_PRIMARY ? 'H * * * *' : ''
 
 pipeline {
   agent any

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -44,7 +44,7 @@ pipeline {
 
     stage('Publish') {
       when {
-        infra.isTrusted()
+        infra.isInfra()
       }
 
       steps {

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -1,5 +1,9 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H * * * *' : ''
 
+def reportsFolder = 'plugin-health-scoring'
+def etagsFile = 'etags.txt'
+def reportFile = 'scores.json'
+
 pipeline {
   agent any
 
@@ -15,20 +19,25 @@ pipeline {
 
   stages {
     stage('Fetch API') {
+      environment {
+        REPORTS_FOLDER = reportsFolder
+        ETAGS_FILE = etagsFile
+        REPORT_FILE = reportFile
+        URL = 'https://plugin-health.jenkins.io/api/scores'
+      }
+
       steps {
         sh '''
-          # TODO: get etags.txt file from previous successful build
-          curl --etag-compare etags.txt \
-            --etag-save etags.txt \
-            -LSs https://plugin-health.jenkins.io/api/scores \
-            -o api.json
-          jq -cM '. + { lastUpdate: (now | todate) }' api.json > plugin-health-scoring.json
+          curl -LSsO https://reports.jenkins.io/${REPORTS_FOLDER}/${ETAGS_FILE} || echo "No previous etags file."
+          bash fetch-report.sh
+          mkdir -p "${reportsFolder}"
+          cp "${reportFile}" "${etagsFile}" "${reportsFolder}"
         '''
       }
 
       post {
         success {
-          archiveArtifacts artifacts: 'plugin-health-scoring.json, etags.txt'
+          archiveArtifacts artifacts: "${reportFile}, ${etagsFile}"
         }
       }
     }
@@ -39,7 +48,7 @@ pipeline {
       }
 
       steps {
-        publishReports([ 'plugin-health-scoring.json' ])
+        publishReports([ "${reportsFolder}/${reportFile}", "${reportsFolder}/${etagsFile}" ])
       }
     }
   }

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -22,7 +22,7 @@ pipeline {
             --etag-save etags.txt \
             -LSs https://plugin-health.jenkins.io/api/scores \
             -o api.json
-          jq '. + { lastUpdate: (now | todate) }' api.json > plugin-health-scoring.json
+          jq -cM '. + { lastUpdate: (now | todate) }' api.json > plugin-health-scoring.json
         '''
       }
 

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -1,0 +1,46 @@
+def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+
+pipeline {
+  agent any
+
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+    timeout(time: 5, unit: 'MINUTES')
+    disableConcurrentBuilds()
+  }
+
+  triggers {
+    cron( cronExpr )
+  }
+
+  stages {
+    stage('Fetch API') {
+      steps {
+        sh '''
+          # TODO: get etags.txt file from previous successful build
+          curl --etag-compare etags.txt \
+            --etag-save etags.txt \
+            -LSs https://plugin-health.jenkins.io/api/scores \
+            -o api.json
+          jq '. + { lastUpdate: (now | todate) }' api.json > plugin-health-scoring.json
+        '''
+      }
+
+      post {
+        success {
+          archiveArtifacts artifacts: 'plugin-health-scoring.json, etags.txt'
+        }
+      }
+    }
+
+    stage('Publish') {
+      when {
+        infra.isTrusted()
+      }
+
+      steps {
+        publishReports([ 'plugin-health-scoring.json' ])
+      }
+    }
+  }
+}

--- a/Jenkinsfile_report
+++ b/Jenkinsfile_report
@@ -3,6 +3,7 @@ def cronExpr = env.BRANCH_IS_PRIMARY ? 'H * * * *' : ''
 def reportsFolder = 'plugin-health-scoring'
 def etagsFile = 'etags.txt'
 def reportFile = 'scores.json'
+def reportLines = 0
 
 pipeline {
   agent any
@@ -27,12 +28,14 @@ pipeline {
       }
 
       steps {
-        sh '''
+        reportLines = sh(returnStdout:true, script: '''
           curl -LSsO https://reports.jenkins.io/${REPORTS_FOLDER}/${ETAGS_FILE} || echo "No previous etags file."
           bash fetch-report.sh
           mkdir -p "${reportsFolder}"
-          cp "${reportFile}" "${etagsFile}" "${reportsFolder}"
-        '''
+          cp ${REPORT_FILE} ${ETAGS_FILE} ${REPORTS_FOLDER}
+
+          wc -l ${REPORT_FILE}
+        ''').trim()
       }
 
       post {
@@ -44,7 +47,9 @@ pipeline {
 
     stage('Publish') {
       when {
-        infra.isInfra()
+        expression {
+          infra.isInfra() && reportLines > 0
+        }
       }
 
       steps {

--- a/fetch-report.sh
+++ b/fetch-report.sh
@@ -25,13 +25,11 @@ set -euxo pipefail
 # SOFTWARE.
 #
 
-curl --etag-compare "${ETAGS_FILE}" \
-    --etag-save "${ETAGS_FILE}" \
-    -LSs "${URL}" \
-    -o api.json
 ###
 # using --compact-output to reduce output file by half.
 # adding report generation date in 'lastUpdate' key of the report.
 ###
-jq --compact-output '. + { lastUpdate: (now | todate) }' api.json > "${REPORT_FILE}"
-rm api.json
+curl --etag-compare "${ETAGS_FILE}" \
+    --etag-save "${ETAGS_FILE}" \
+    -LSs "${URL}" \
+    | jq --compact-output '. + { lastUpdate: (now | todate) }' > "${REPORT_FILE}"

--- a/fetch-report.sh
+++ b/fetch-report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+#
+# MIT License
+#
+# Copyright (c) 2024 Jenkins Infra
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+curl --etag-compare "${ETAGS_FILE}" \
+    --etag-save "${ETAGS_FILE}" \
+    -LSs "${URL}" \
+    -o api.json
+###
+# using --compact-output to reduce output file by half.
+# adding report generation date in 'lastUpdate' key of the report.
+###
+jq --compact-output '. + { lastUpdate: (now | todate) }' api.json > "${REPORT_FILE}"
+rm api.json

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
@@ -24,16 +24,22 @@
 
 package io.jenkins.pluginhealth.scoring.http;
 
+import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import io.jenkins.pluginhealth.scoring.model.Resolution;
+import io.jenkins.pluginhealth.scoring.model.Score;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.service.ScoreService;
 
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,12 +54,19 @@ public class ScoreAPI {
     }
 
     @GetMapping(value = {"", "/"}, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ScoreReport getReport() {
-        final ScoreService.ScoreStatistics stats = scoreService.getScoresStatistics();
+    public ResponseEntity<ScoreReport> getReport() {
+        final Map<String, Score> latestScoresSummaryMap = scoreService.getLatestScoresSummaryMap();
+        final String etag = latestScoresSummaryMap.values().stream()
+            .max(Comparator.comparing(Score::getComputedAt))
+            .map(Score::getComputedAt)
+            .map(ZonedDateTime::toEpochSecond)
+            .map(String::valueOf)
+            .orElse(null);
+
         record Tuple(String name, PluginScoreSummary summary) {
         }
 
-        final Map<String, PluginScoreSummary> plugins = scoreService.getLatestScoresSummaryMap()
+        final Map<String, PluginScoreSummary> plugins = latestScoresSummaryMap
             .entrySet().stream()
             .map(entry -> {
                 final var score = entry.getValue();
@@ -71,7 +84,12 @@ public class ScoreAPI {
                 );
             })
             .collect(Collectors.toMap(Tuple::name, Tuple::summary));
-        return new ScoreReport(plugins, stats);
+
+        return ResponseEntity
+            .ok()
+            .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS))
+            .eTag(etag)
+            .body(new ScoreReport(plugins, scoreService.getScoresStatistics()));
     }
 
     public record ScoreReport(Map<String, PluginScoreSummary> plugins, ScoreService.ScoreStatistics statistics) {

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.pluginhealth.scoring.http;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,9 +54,11 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @ExtendWith({ SpringExtension.class, MockitoExtension.class })
 @ImportAutoConfiguration({ ProjectInfoAutoConfiguration.class, SecurityConfiguration.class })
@@ -72,7 +75,7 @@ class ScoreAPITest {
         final Plugin p1 = mock(Plugin.class);
         final Plugin p2 = mock(Plugin.class);
 
-        ZonedDateTime computedAt = ZonedDateTime.now().minusMinutes(1);
+        final ZonedDateTime computedAt = ZonedDateTime.now().minusMinutes(1);
         final Score scoreP1 = new Score(p1, computedAt);
         scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
             new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
@@ -163,6 +166,62 @@ class ScoreAPITest {
                         }
                     }
                     """, false)
+            );
+    }
+
+    @Test
+    void shouldGet304WhenNoNewScoring() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+
+        final ZonedDateTime computedAt = ZonedDateTime.now().minusHours(2);
+        final Score scoreP1 = new Score(plugin, computedAt);
+        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
+            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
+        ), 1));
+
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
+            "plugin-1", scoreP1
+        ));
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/scores"))
+            .andExpectAll(
+                status().isOk(),
+                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))),
+                content().contentType(MediaType.APPLICATION_JSON)
+            )
+            .andReturn();
+
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        String responseETag = mvcResult.getResponse().getHeader("ETag");
+        assertThat(responseETag).isNotNull();
+        httpHeaders.setIfNoneMatch(responseETag);
+
+        mvcResult = mockMvc.perform(get("/api/scores").headers(httpHeaders))
+            .andExpectAll(
+                status().isNotModified(),
+                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond())))
+            )
+            .andReturn();
+
+        responseETag = mvcResult.getResponse().getHeader("ETag");
+        assertThat(responseETag).isNotNull();
+        httpHeaders.setIfNoneMatch(responseETag);
+
+        final ZonedDateTime newScoreComputedAt = ZonedDateTime.now().minusMinutes(5);
+        final Score newScoreP1 = new Score(plugin, newScoreComputedAt);
+        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
+            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
+        ), 1));
+
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
+            "plugin-1", newScoreP1
+        ));
+
+        mockMvc.perform(get("/api/scores").headers(httpHeaders))
+            .andExpectAll(
+                status().isOk(),
+                header().string("ETag", equalTo("\"%s\"".formatted(newScoreComputedAt.toEpochSecond()))),
+                content().contentType(MediaType.APPLICATION_JSON)
             );
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #373.

Not all scores are computed all the time. For a score to be computed again on a plugin, probe results on the plugin have to be updated (more recent than last execution of the score) and the scoring implementation must have the same version as on its last execution.

Because of that, we know that the most recent score computed, across all the plugins, will determine if the content of the `/scores/api` has changed since the last time it was fetched.

This puts the value of the seconds since epoch of the most recent scoring execution in the `ETag` header of the response.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Adjusted the unit test on the API to validate the presence and value of the `ETag` header.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
