### PR TITLE
Plugin description migration probe

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(PluginDescriptionMigrationProbe.ORDER)
+public class PluginDescriptionMigrationProbe extends Probe {
+    public final static String KEY = "description-migration";
+    public static final int ORDER = DocumentationMigrationProbe.ORDER + 100;
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        return null;
+    }
+
+    @Override
+    public String key() {
+        return KEY;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks if the plugin description is located in the `src/main/resources/index.jelly` file.";
+    }
+
+    @Override
+    public long getVersion() {
+        return 1;
+    }
+}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -52,7 +52,7 @@ public class PluginDescriptionMigrationProbe extends Probe {
         final Path repository = scmRepositoryOpt.get();
         final Path pluginFolder = context.getScmFolderPath().map(repository::resolve).orElse(repository);
 
-        try (final Stream<Path> files = Files.find(
+        try (Stream<Path> files = Files.find(
             pluginFolder.resolve("src").resolve("main").resolve("resources"),
             1,
             (path, attributes) -> "index.jelly".equals(path.getFileName().toString())

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(PluginDescriptionMigrationProbe.ORDER)
 public class PluginDescriptionMigrationProbe extends Probe {
-    public final static String KEY = "description-migration";
+    public static final String KEY = "description-migration";
     public static final int ORDER = DocumentationMigrationProbe.ORDER + 100;
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -55,4 +55,9 @@ public class PluginDescriptionMigrationProbe extends Probe {
     public long getVersion() {
         return 1;
     }
+
+    @Override
+    protected boolean requiresRelease() {
+        return true;
+    }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -34,6 +34,7 @@ import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
 import io.jenkins.pluginhealth.scoring.probes.ContributingGuidelinesProbe;
 import io.jenkins.pluginhealth.scoring.probes.DocumentationMigrationProbe;
+import io.jenkins.pluginhealth.scoring.probes.PluginDescriptionMigrationProbe;
 import io.jenkins.pluginhealth.scoring.probes.ReleaseDrafterProbe;
 
 import org.springframework.stereotype.Component;
@@ -103,15 +104,14 @@ public class DocumentationScoring extends Scoring {
                     return switch (probeResult.message()) {
                         case "Documentation is located in the plugin repository." ->
                             new ScoringComponentResult(100, getWeight(), List.of("Documentation is in plugin repository."));
-                        case "Documentation is not located in the plugin repository." ->
-                            new ScoringComponentResult(
-                                0,
-                                getWeight(),
-                                List.of("Documentation should be migrated in plugin repository."),
-                                List.of(
-                                    new Resolution("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
-                                )
-                            );
+                        case "Documentation is not located in the plugin repository." -> new ScoringComponentResult(
+                            0,
+                            getWeight(),
+                            List.of("Documentation should be migrated in plugin repository."),
+                            List.of(
+                                new Resolution("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
+                            )
+                        );
                         default ->
                             new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration.", probeResult.message()));
                     };
@@ -119,7 +119,7 @@ public class DocumentationScoring extends Scoring {
 
                 @Override
                 public int getWeight() {
-                    return 8;
+                    return 4;
                 }
             },
             new ScoringComponent() {
@@ -160,6 +160,39 @@ public class DocumentationScoring extends Scoring {
                 @Override
                 public int getWeight() {
                     return 0;
+                }
+            },
+            new ScoringComponent() {
+                @Override
+                public String getDescription() {
+                    return "Plugin description should be located in the index.jelly file.";
+                }
+
+                @Override
+                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                    final ProbeResult result = probeResults.get(PluginDescriptionMigrationProbe.KEY);
+                    if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
+                        return new ScoringComponentResult(
+                            0,
+                            getWeight(),
+                            List.of("Cannot determine if the plugin description was correctly migrated.")
+                        );
+                    }
+
+                    final String message = result.message();
+                    if ("Plugin seems to have a correct description.".equals(message)) {
+                        return new ScoringComponentResult(100, getWeight(), List.of(message));
+                    }
+                    return new ScoringComponentResult(0, getWeight(), List.of(message),
+                        List.of(new Resolution(
+                            "Please see how to migrate the plugin description for the plugin.",
+                            "https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/"
+                        )));
+                }
+
+                @Override
+                public int getWeight() {
+                    return 4;
                 }
             }
         );

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
@@ -77,7 +77,7 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         assertThat(result)
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "There is no file `src/main/resources/index.jelly`", 0));
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "There is no `index.jelly` file in `src/main/resources`.", 0));
     }
 
     @Test
@@ -119,6 +119,7 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
             </div>
             """);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+        when(ctx.getScmFolderPath()).thenReturn(Optional.of(module));
 
         final PluginDescriptionMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
@@ -168,6 +169,7 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
             </div>
             """);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+        when(ctx.getScmFolderPath()).thenReturn(Optional.of(module));
 
         final PluginDescriptionMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
@@ -64,11 +64,29 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
     }
 
     @Test
+    void shouldFailWhenPluginRepositoryIsEmpty() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.error(PluginDescriptionMigrationProbe.KEY, "Cannot browse plugin source code folder.", 0));
+    }
+
+    @Test
     void shouldDetectMissingJellyFile() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
         final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        Files.createDirectories(repository.resolve("src").resolve("main").resolve("resources"));
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         final PluginDescriptionMigrationProbe probe = getSpy();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
@@ -1,0 +1,180 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.junit.jupiter.api.Test;
+
+public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<PluginDescriptionMigrationProbe> {
+    @Override
+    PluginDescriptionMigrationProbe getSpy() {
+        return spy(PluginDescriptionMigrationProbe.class);
+    }
+
+    @Test
+    void shouldRequireRelease() {
+        assertThat(getSpy().requiresRelease()).isTrue();
+    }
+
+    @Test
+    void shouldRequiresPluginRepository() {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.error(PluginDescriptionMigrationProbe.KEY, "Cannot access plugin repository.", 0));
+    }
+
+    @Test
+    void shouldDetectMissingJellyFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "There is no file `src/main/resources/index.jelly`", 0));
+    }
+
+    @Test
+    void shouldDetectExampleJellyFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        final Path resources = Files.createDirectories(repository.resolve("src").resolve("main").resolve("resources"));
+        final Path jelly = Files.createFile(resources.resolve("index.jelly"));
+        Files.writeString(jelly, """
+            <div>
+                TODO
+            </div>
+            """);
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 0));
+    }
+
+    @Test
+    void shouldDetectExampleJellyFileWithModule() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        final Path module = Files.createDirectory(repository.resolve("plugin"));
+        final Path resources = Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
+        final Path jelly = Files.createFile(resources.resolve("index.jelly"));
+        Files.writeString(jelly, """
+            <div>
+                TODO
+            </div>
+            """);
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 0));
+    }
+
+    @Test
+    void shouldDetectCorrectJellyFile() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        final Path resources = Files.createDirectories(repository.resolve("src").resolve("main").resolve("resources"));
+        final Path jelly = Files.createFile(resources.resolve("index.jelly"));
+        Files.writeString(jelly, """
+            <div>
+                This is a plugin doing something.
+            </div>
+            """);
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
+    }
+
+    @Test
+    void shouldDetectCorrectJellyFileWithModule() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final Path repository = Files.createTempDirectory(getClass().getSimpleName());
+        final Path module = Files.createDirectory(repository.resolve("plugin"));
+        final Path resources = Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
+        final Path jelly = Files.createFile(resources.resolve("index.jelly"));
+        Files.writeString(jelly, """
+            <div>
+                This is a plugin doing something.
+            </div>
+            """);
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        final PluginDescriptionMigrationProbe probe = getSpy();
+        final ProbeResult result = probe.apply(plugin, ctx);
+
+        assertThat(result)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "message", "status")
+            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
+    }
+}


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Resolves #427.

The idea is to detect plugin still using the `description` tag of their `pom.xml` to hold the plugin description.
This should influence the documentation scoring and help resolving the problem by pointing to https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
