### PR TITLE
Edit code to comply with spotless

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/config/VersionNumberType.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import java.io.Serializable;
@@ -57,13 +56,16 @@ public class VersionNumberType implements UserType<VersionNumber> {
     }
 
     @Override
-    public VersionNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+    public VersionNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner)
+            throws SQLException {
         final String value = rs.getString(position);
         return Objects.isNull(value) ? null : new VersionNumber(value);
     }
 
     @Override
-    public void nullSafeSet(PreparedStatement st, VersionNumber value, int index, SharedSessionContractImplementor session) throws SQLException {
+    public void nullSafeSet(
+            PreparedStatement st, VersionNumber value, int index, SharedSessionContractImplementor session)
+            throws SQLException {
         if (Objects.isNull(value)) {
             st.setNull(index, SqlTypes.VARCHAR);
         } else {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Plugin.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.time.ZonedDateTime;
@@ -65,8 +64,7 @@ public class Plugin {
     @Type(value = JsonType.class)
     private final Map<String, ProbeResult> details = new HashMap<>();
 
-    public Plugin() {
-    }
+    public Plugin() {}
 
     public Plugin(String name, VersionNumber version, String scm, ZonedDateTime releaseTimestamp) {
         this.name = name;
@@ -111,11 +109,11 @@ public class Plugin {
     }
 
     public Plugin addDetails(ProbeResult newProbeResult) {
-        this.details.compute(newProbeResult.id(), (s, previousProbeResult) ->
-            newProbeResult.status() == ProbeResult.Status.ERROR ?
-                null :
-                Objects.equals(previousProbeResult, newProbeResult) ? previousProbeResult : newProbeResult
-        );
+        this.details.compute(
+                newProbeResult.id(),
+                (s, previousProbeResult) -> newProbeResult.status() == ProbeResult.Status.ERROR
+                        ? null
+                        : Objects.equals(previousProbeResult, newProbeResult) ? previousProbeResult : newProbeResult);
         return this;
     }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.time.ZonedDateTime;
@@ -48,7 +47,10 @@ public record ProbeResult(String id, String message, Status status, ZonedDateTim
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ProbeResult that = (ProbeResult) o;
-        return id.equals(that.id) && message.equals(that.message) && status == that.status && probeVersion == that.probeVersion;
+        return id.equals(that.id)
+                && message.equals(that.message)
+                && status == that.status
+                && probeVersion == that.probeVersion;
     }
 
     @Override
@@ -69,7 +71,8 @@ public record ProbeResult(String id, String message, Status status, ZonedDateTim
      * the execution of the probe.
      */
     public enum Status {
-        SUCCESS, @JsonAlias("FAILURE") ERROR
+        SUCCESS,
+        @JsonAlias("FAILURE")
+        ERROR
     }
 }
-

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Resolution.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Resolution.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 /**

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Score.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/Score.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.time.ZonedDateTime;
@@ -62,8 +61,7 @@ public class Score {
     @Type(JsonType.class)
     private final Set<ScoreResult> details = new HashSet<>();
 
-    public Score() {
-    }
+    public Score() {}
 
     public Score(Plugin plugin, ZonedDateTime computedAt) {
         this.plugin = plugin;
@@ -84,13 +82,13 @@ public class Score {
 
     private void computeValue() {
         var sum = details.stream()
-            .filter(Objects::nonNull)
-            .flatMapToDouble(res -> DoubleStream.of(res.value() * res.weight()))
-            .sum();
+                .filter(Objects::nonNull)
+                .flatMapToDouble(res -> DoubleStream.of(res.value() * res.weight()))
+                .sum();
         var coefficient = details.stream()
-            .filter(Objects::nonNull)
-            .flatMapToDouble(res -> DoubleStream.of(res.weight()))
-            .sum();
+                .filter(Objects::nonNull)
+                .flatMapToDouble(res -> DoubleStream.of(res.weight()))
+                .sum();
         this.value = Math.round((sum / coefficient));
     }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoreResult.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoreResult.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.util.Objects;
@@ -35,7 +34,12 @@ import com.fasterxml.jackson.annotation.JsonAlias;
  * @param weight  the importance of the score facing the others
  * @param componentsResults a list of {@link ScoringComponentResult} which explain the score
  */
-public record ScoreResult(String key, int value, @JsonAlias("coefficient") float weight, Set<ScoringComponentResult> componentsResults, int version) {
+public record ScoreResult(
+        String key,
+        int value,
+        @JsonAlias("coefficient") float weight,
+        Set<ScoringComponentResult> componentsResults,
+        int version) {
     public ScoreResult {
         if (weight > 1) {
             throw new IllegalArgumentException("Value and Coefficient must be less or equal to 1.");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoringComponentResult.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ScoringComponentResult.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import java.util.List;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Deprecation.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Deprecation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
-public record Deprecation(String url) {
-}
+public record Deprecation(String url) {}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Plugin.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/Plugin.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
 import java.time.ZonedDateTime;
@@ -29,10 +28,17 @@ import java.util.List;
 
 import hudson.util.VersionNumber;
 
-public record Plugin(String name, VersionNumber version, String scm,
-                     ZonedDateTime releaseTimestamp, List<String> labels,
-                     int popularity, String requiredCore, String defaultBranch) {
+public record Plugin(
+        String name,
+        VersionNumber version,
+        String scm,
+        ZonedDateTime releaseTimestamp,
+        List<String> labels,
+        int popularity,
+        String requiredCore,
+        String defaultBranch) {
     public io.jenkins.pluginhealth.scoring.model.Plugin toPlugin() {
-        return new io.jenkins.pluginhealth.scoring.model.Plugin(this.name(), this.version(), this.scm(), this.releaseTimestamp());
+        return new io.jenkins.pluginhealth.scoring.model.Plugin(
+                this.name(), this.version(), this.scm(), this.releaseTimestamp());
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarning.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
 import java.util.List;
 
-public record SecurityWarning(
-    String id,
-    String name,
-    List<SecurityWarningVersion> versions
-) {
-}
+public record SecurityWarning(String id, String name, List<SecurityWarningVersion> versions) {}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,13 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
 import hudson.util.VersionNumber;
 
-public record SecurityWarningVersion(
-    VersionNumber lastVersion,
-    String pattern
-) {
-}
+public record SecurityWarningVersion(VersionNumber lastVersion, String pattern) {}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/UpdateCenter.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/UpdateCenter.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
 import java.util.List;
 import java.util.Map;
 
-public record UpdateCenter(Map<String, Plugin> plugins,
-                           Map<String, Deprecation> deprecations,
-                           List<SecurityWarning> warnings
-) {
-}
+public record UpdateCenter(
+        Map<String, Plugin> plugins, Map<String, Deprecation> deprecations, List<SecurityWarning> warnings) {}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -54,11 +53,14 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
             return this.success("No GitHub configuration folder found.");
         }
 
-        try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
-            Files.isRegularFile(path) && isPathBotConfigFile(path.getFileName().toString()))) {
+        try (Stream<Path> paths = Files.find(
+                githubConfig,
+                1,
+                (path, $) -> Files.isRegularFile(path)
+                        && isPathBotConfigFile(path.getFileName().toString()))) {
             return paths.findFirst()
-                .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
-                .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
+                    .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
+                    .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
         } catch (IOException ex) {
             LOGGER.error("Could not browse the plugin folder during probe {}", key(), ex);
             return this.error("Could not browse the plugin folder");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractGitHubWorkflowProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractGitHubWorkflowProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -61,17 +60,14 @@ public abstract class AbstractGitHubWorkflowProbe extends Probe {
         }
 
         try (Stream<Path> files = Files.find(workflowPath, 1, (path, $) -> Files.isRegularFile(path))) {
-            boolean isWorkflowConfigured = files
-                .map(this::parseWorkflowFile)
-                .filter(this::hasWorkflowJobs)
-                .flatMap(workflow -> workflow.jobs().values().stream())
-                .map(WorkflowJobDefinition::uses)
-                .filter(Objects::nonNull)
-                .anyMatch(jobDefinition -> jobDefinition.startsWith(getWorkflowDefinition()));
+            boolean isWorkflowConfigured = files.map(this::parseWorkflowFile)
+                    .filter(this::hasWorkflowJobs)
+                    .flatMap(workflow -> workflow.jobs().values().stream())
+                    .map(WorkflowJobDefinition::uses)
+                    .filter(Objects::nonNull)
+                    .anyMatch(jobDefinition -> jobDefinition.startsWith(getWorkflowDefinition()));
 
-            return isWorkflowConfigured ?
-                this.success(getValidMessage()) :
-                this.success(getInvalidMessage());
+            return isWorkflowConfigured ? this.success(getValidMessage()) : this.success(getInvalidMessage());
         } catch (IOException e) {
             LOGGER.warn("Couldn't not read file for plugin {} during probe {}", plugin.getName(), key(), e);
             return this.error(e.getMessage());
@@ -104,15 +100,13 @@ public abstract class AbstractGitHubWorkflowProbe extends Probe {
      * Partial object mapping of a GitHub workflow YAML file, containing only the "jobs" that are defined in it.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record WorkflowDefinition(Map<String, WorkflowJobDefinition> jobs) {
-    }
+    private record WorkflowDefinition(Map<String, WorkflowJobDefinition> jobs) {}
 
     /**
      * Partial Object mapping of a GitHub workflow job definition, containing only the "uses" field of its YAML content.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record WorkflowJobDefinition(String uses) {
-    }
+    private record WorkflowJobDefinition(String uses) {}
 
     @Override
     protected boolean isSourceCodeRelated() {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -50,7 +49,7 @@ public class CodeCoverageProbe extends Probe {
     private static final Logger LOGGER = LoggerFactory.getLogger(CodeCoverageProbe.class);
 
     private static final String COVERAGE_TITLE_REGEXP =
-        "^Line(?: Coverage)?: (?<line>\\d{1,2}(?:\\.\\d{1,2})?)%(?: \\(.+\\))?. Branch(?: Coverage)?: (?<branch>\\d{1,2}(?:\\.\\d{1,2})?)%(?: \\(.+\\))?\\.?$";
+            "^Line(?: Coverage)?: (?<line>\\d{1,2}(?:\\.\\d{1,2})?)%(?: \\(.+\\))?. Branch(?: Coverage)?: (?<branch>\\d{1,2}(?:\\.\\d{1,2})?)%(?: \\(.+\\))?\\.?$";
     private static final Pattern COVERAGE_TITLE_PATTERN = Pattern.compile(COVERAGE_TITLE_REGEXP);
 
     public static final String KEY = "code-coverage";
@@ -59,7 +58,7 @@ public class CodeCoverageProbe extends Probe {
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
-            context.getUpdateCenter().plugins().get(plugin.getName());
+                context.getUpdateCenter().plugins().get(plugin.getName());
         if (ucPlugin == null) {
             return error("Plugin cannot be found in Update-Center.");
         }
@@ -71,8 +70,9 @@ public class CodeCoverageProbe extends Probe {
             final Optional<String> repositoryName = context.getRepositoryName();
             if (repositoryName.isPresent()) {
                 final GHRepository ghRepository = context.getGitHub().getRepository(repositoryName.get());
-                final List<GHCheckRun> ghCheckRuns =
-                    ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage")).toList();
+                final List<GHCheckRun> ghCheckRuns = ghRepository
+                        .getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage"))
+                        .toList();
                 if (ghCheckRuns.isEmpty()) {
                     return this.success("Could not determine code coverage for the plugin.");
                 }
@@ -80,7 +80,8 @@ public class CodeCoverageProbe extends Probe {
                 double overall_line_coverage = 100;
                 double overall_branch_coverage = 100;
                 for (GHCheckRun checkRun : ghCheckRuns) {
-                    final Matcher matcher = COVERAGE_TITLE_PATTERN.matcher(checkRun.getOutput().getTitle());
+                    final Matcher matcher =
+                            COVERAGE_TITLE_PATTERN.matcher(checkRun.getOutput().getTitle());
                     if (matcher.matches()) {
                         final double line_coverage = Double.parseDouble(matcher.group("line"));
                         final double branch_coverage = Double.parseDouble(matcher.group("branch"));
@@ -89,7 +90,8 @@ public class CodeCoverageProbe extends Probe {
                     }
                 }
 
-                return this.success("Line coverage: " + overall_line_coverage + "%. Branch coverage: " + overall_branch_coverage + "%.");
+                return this.success("Line coverage: " + overall_line_coverage + "%. Branch coverage: "
+                        + overall_branch_coverage + "%.");
             } else {
                 return this.error("Cannot determine plugin repository.");
             }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import org.springframework.core.annotation.Order;
@@ -35,7 +34,8 @@ import org.springframework.stereotype.Component;
 public class ContinuousDeliveryProbe extends AbstractGitHubWorkflowProbe {
     public static final int ORDER = AbstractGitHubWorkflowProbe.ORDER;
     public static final String KEY = "jep-229";
-    private static final String CD_WORKFLOW_IDENTIFIER = "jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml";
+    private static final String CD_WORKFLOW_IDENTIFIER =
+            "jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml";
 
     @Override
     public String key() {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -48,13 +47,17 @@ public class ContributingGuidelinesProbe extends Probe {
         }
 
         final Path repository = context.getScmRepository().get();
-        try (Stream<Path> paths = Files.find(repository, 2,
-            (file, basicFileAttributes) -> Files.isReadable(file)
-                && ("CONTRIBUTING.md".equalsIgnoreCase(file.getFileName().toString())
-                || "CONTRIBUTING.adoc".equalsIgnoreCase(file.getFileName().toString())))) {
+        try (Stream<Path> paths = Files.find(
+                repository,
+                2,
+                (file, basicFileAttributes) -> Files.isReadable(file)
+                        && ("CONTRIBUTING.md"
+                                        .equalsIgnoreCase(file.getFileName().toString())
+                                || "CONTRIBUTING.adoc"
+                                        .equalsIgnoreCase(file.getFileName().toString())))) {
             return paths.findAny()
-                .map(file -> this.success("Contributing guidelines found."))
-                .orElseGet(() -> this.success("No contributing guidelines found."));
+                    .map(file -> this.success("Contributing guidelines found."))
+                    .orElseGet(() -> this.success("No contributing guidelines found."));
         } catch (IOException e) {
             return this.error(e.getMessage());
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import org.springframework.core.annotation.Order;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -52,12 +51,13 @@ public class DependabotPullRequestProbe extends Probe {
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         try {
             final GitHub gh = context.getGitHub();
-            final GHRepository repository = gh.getRepository(context.getRepositoryName().orElseThrow());
+            final GHRepository repository =
+                    gh.getRepository(context.getRepositoryName().orElseThrow());
             final List<GHPullRequest> pullRequests = repository.getPullRequests(GHIssueState.OPEN);
 
             final long count = pullRequests.stream()
-                .filter(pr -> pr.getLabels().stream().anyMatch(label -> "dependencies".equals(label.getName())))
-                .count();
+                    .filter(pr -> pr.getLabels().stream().anyMatch(label -> "dependencies".equals(label.getName())))
+                    .count();
 
             return this.success("%d".formatted(count));
         } catch (NoSuchElementException | IOException e) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -44,15 +43,17 @@ public class DeprecatedPluginProbe extends Probe {
     public ProbeResult doApply(Plugin plugin, ProbeContext ctx) {
         final UpdateCenter updateCenter = ctx.getUpdateCenter();
         if (updateCenter.deprecations().containsKey(plugin.getName())) {
-            return this.success(updateCenter.deprecations().get(plugin.getName()).url());
+            return this.success(
+                    updateCenter.deprecations().get(plugin.getName()).url());
         }
-        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin updateCenterPlugin = updateCenter.plugins().get(plugin.getName());
+        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin updateCenterPlugin =
+                updateCenter.plugins().get(plugin.getName());
         if (updateCenterPlugin == null) {
             return this.error("This plugin is not in update-center.");
         }
-        return updateCenterPlugin.labels().contains("deprecated") ?
-            this.success("This plugin is marked as deprecated.") :
-            this.success("This plugin is NOT deprecated.");
+        return updateCenterPlugin.labels().contains("deprecated")
+                ? this.success("This plugin is marked as deprecated.")
+                : this.success("This plugin is NOT deprecated.");
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.util.Map;
@@ -50,11 +49,11 @@ public class DocumentationMigrationProbe extends Probe {
         }
         final String linkDocumentationForPlugin = pluginDocumentationLinks.get(plugin.getName());
 
-        return linkDocumentationForPlugin == null ?
-            this.error("Plugin is not listed in documentation migration source.") :
-            linkDocumentationForPlugin.contains(scm) ?
-                this.success("Documentation is located in the plugin repository.") :
-                this.success("Documentation is not located in the plugin repository.");
+        return linkDocumentationForPlugin == null
+                ? this.error("Plugin is not listed in documentation migration source.")
+                : linkDocumentationForPlugin.contains(scm)
+                        ? this.success("Documentation is located in the plugin repository.")
+                        : this.success("Documentation is not located in the plugin repository.");
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -92,11 +91,10 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
                     RevCommit parent = revCommit.getParent(0);
                     DiffFormatter diffFormatter = new DiffFormatter(DisabledOutputStream.INSTANCE);
                     diffFormatter.setRepository(git.getRepository());
-                    diffFormatter.scan(parent.getTree(), revCommit.getTree())
-                        .stream()
-                        .map(diffEntry -> diffEntry.getPath(DiffEntry.Side.NEW))
-                        .filter(s -> paths.stream().anyMatch(s::startsWith))
-                        .forEach(files::add);
+                    diffFormatter.scan(parent.getTree(), revCommit.getTree()).stream()
+                            .map(diffEntry -> diffEntry.getPath(DiffEntry.Side.NEW))
+                            .filter(s -> paths.stream().anyMatch(s::startsWith))
+                            .forEach(files::add);
 
                 } else {
                     TreeWalk treeWalk = new TreeWalk(git.getRepository());
@@ -114,10 +112,10 @@ public class HasUnreleasedProductionChangesProbe extends Probe {
                 }
             }
 
-            return files.isEmpty() ?
-                this.success("All production modifications were released.") :
-                this.success("Unreleased production modifications might exist in the plugin source code at "
-                    + files.stream().sorted(Comparator.naturalOrder()).collect(Collectors.joining(", ")));
+            return files.isEmpty()
+                    ? this.success("All production modifications were released.")
+                    : this.success("Unreleased production modifications might exist in the plugin source code at "
+                            + files.stream().sorted(Comparator.naturalOrder()).collect(Collectors.joining(", ")));
         } catch (IOException | GitAPIException ex) {
             return this.error(ex.getMessage());
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -40,10 +39,11 @@ public class InstallationStatProbe extends Probe {
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final UpdateCenter updateCenter = context.getUpdateCenter();
-        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin = updateCenter.plugins().get(plugin.getName());
-        return ucPlugin != null ?
-            this.success("%d".formatted(ucPlugin.popularity())) :
-            this.error("Could not find plugin " + plugin.getName() + " in Update Center.");
+        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
+                updateCenter.plugins().get(plugin.getName());
+        return ucPlugin != null
+                ? this.success("%d".formatted(ucPlugin.popularity()))
+                : this.error("Could not find plugin " + plugin.getName() + " in Update Center.");
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JSR305Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JSR305Probe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -59,20 +58,25 @@ public class JSR305Probe extends Probe {
         final Path scmRepository = context.getScmRepository().get();
 
         /* The "maxDepth" is set to Integer.MAX_VALUE because a repository can have multiple modules with class files in it. We do not want to miss any ".java" file.  */
-        try (Stream<Path> javaFiles = Files.find(scmRepository, Integer.MAX_VALUE, (path, $) -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".java"))) {
+        try (Stream<Path> javaFiles = Files.find(
+                scmRepository,
+                Integer.MAX_VALUE,
+                (path, $) -> Files.isRegularFile(path)
+                        && path.getFileName().toString().endsWith(".java"))) {
             Set<String> javaFilesWithDetectedImports = javaFiles
-                .filter(this::containsImports)
-                .map(javaFile -> javaFile.getFileName().toString())
-                .collect(Collectors.toSet());
+                    .filter(this::containsImports)
+                    .map(javaFile -> javaFile.getFileName().toString())
+                    .collect(Collectors.toSet());
 
             return javaFilesWithDetectedImports.isEmpty()
-                ? this.success(String.format("%s at %s plugin.", getValidMessage(), plugin.getName()))
-                : this.success(String.format(
-                    "%s at %s plugin for %s",
-                    getInvalidMessage(),
-                    plugin.getName(),
-                    javaFilesWithDetectedImports.stream().sorted(Comparator.naturalOrder()).collect(Collectors.joining(", "))
-            ));
+                    ? this.success(String.format("%s at %s plugin.", getValidMessage(), plugin.getName()))
+                    : this.success(String.format(
+                            "%s at %s plugin for %s",
+                            getInvalidMessage(),
+                            plugin.getName(),
+                            javaFilesWithDetectedImports.stream()
+                                    .sorted(Comparator.naturalOrder())
+                                    .collect(Collectors.joining(", "))));
         } catch (IOException ex) {
             LOGGER.error("Could not browse the plugin folder during {} probe.", key(), ex);
             return this.error(String.format("Could not browse the plugin folder during %s probe.", plugin.getName()));
@@ -96,7 +100,9 @@ public class JSR305Probe extends Probe {
      * @return a List with imports is returned when imports are found. Otherwise, an empty list is returned.
      */
     private List<String> getAllImportsInTheFile(Path javaFile) {
-        try (Stream<String> importStatements = Files.lines(javaFile).filter(line -> line.startsWith("import")).map(this::getFullyQualifiedImportName)) {
+        try (Stream<String> importStatements = Files.lines(javaFile)
+                .filter(line -> line.startsWith("import"))
+                .map(this::getFullyQualifiedImportName)) {
             return importStatements.toList();
         } catch (IOException ex) {
             LOGGER.error("Could not browse the {} plugin folder during probe.", key(), ex);

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -40,10 +39,11 @@ public class JenkinsCoreProbe extends Probe {
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final UpdateCenter uc = context.getUpdateCenter();
-        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin = uc.plugins().get(plugin.getName());
-        return ucPlugin != null ?
-            this.success(ucPlugin.requiredCore()) :
-            this.error("Could not find plugin " + plugin.getName() + " in Update Center.");
+        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
+                uc.plugins().get(plugin.getName());
+        return ucPlugin != null
+                ? this.success(ucPlugin.requiredCore())
+                : this.error("Could not find plugin " + plugin.getName() + " in Update Center.");
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -48,11 +47,14 @@ public class JenkinsfileProbe extends Probe {
         }
 
         final Path repository = context.getScmRepository().get();
-        try (Stream<Path> paths = Files.find(repository, 1, (file, $) ->
-            Files.isReadable(file) && "Jenkinsfile".equals(file.getFileName().toString()))) {
+        try (Stream<Path> paths = Files.find(
+                repository,
+                1,
+                (file, $) -> Files.isReadable(file)
+                        && "Jenkinsfile".equals(file.getFileName().toString()))) {
             return paths.findFirst()
-                .map(file -> this.success("Jenkinsfile found"))
-                .orElseGet(() -> this.success("No Jenkinsfile found"));
+                    .map(file -> this.success("Jenkinsfile found"))
+                    .orElseGet(() -> this.success("No Jenkinsfile found"));
         } catch (IOException e) {
             return this.error(e.getMessage());
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.util.List;
@@ -46,21 +45,19 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final List<SecurityWarning> warnings = context.getUpdateCenter().warnings();
         final String issues = warnings.stream()
-            .filter(w -> w.name().equals(plugin.getName()))
-            .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
-                if (securityWarningVersion.lastVersion() != null) {
-                    return plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion());
-                }
-                final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());
-                final Matcher matcher = pattern.matcher(plugin.getVersion().toString());
-                return matcher.find();
-            }))
-            .map(SecurityWarning::id)
-            .collect(Collectors.joining(", "));
+                .filter(w -> w.name().equals(plugin.getName()))
+                .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
+                    if (securityWarningVersion.lastVersion() != null) {
+                        return plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion());
+                    }
+                    final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());
+                    final Matcher matcher = pattern.matcher(plugin.getVersion().toString());
+                    return matcher.find();
+                }))
+                .map(SecurityWarning::id)
+                .collect(Collectors.joining(", "));
 
-        return !issues.isBlank() ?
-            this.success(issues) :
-            this.success("No known security vulnerabilities.");
+        return !issues.isBlank() ? this.success(issues) : this.success("No known security vulnerabilities.");
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/LastCommitDateProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -72,10 +71,10 @@ public class LastCommitDateProbe extends Probe {
                 return this.error("Last commit cannot be extracted. Please validate sub-folder if any.");
             }
             final ZonedDateTime commitDate = ZonedDateTime.ofInstant(
-                    commit.getAuthorIdent().getWhenAsInstant(),
-                    commit.getAuthorIdent().getZoneId()
-                ).withZoneSameInstant(ZoneId.of("UTC"))
-                .truncatedTo(ChronoUnit.SECONDS);
+                            commit.getAuthorIdent().getWhenAsInstant(),
+                            commit.getAuthorIdent().getZoneId())
+                    .withZoneSameInstant(ZoneId.of("UTC"))
+                    .truncatedTo(ChronoUnit.SECONDS);
             context.setLastCommitDate(commitDate);
             return this.success(commitDate.format(DateTimeFormatter.ISO_DATE_TIME));
         } catch (IOException | GitAPIException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -50,21 +49,20 @@ public class PluginDescriptionMigrationProbe extends Probe {
         }
 
         final Path repository = scmRepositoryOpt.get();
-        final Path pluginFolder = context.getScmFolderPath().map(repository::resolve).orElse(repository);
+        final Path pluginFolder =
+                context.getScmFolderPath().map(repository::resolve).orElse(repository);
 
         try (Stream<Path> files = Files.find(
-            pluginFolder.resolve("src").resolve("main").resolve("resources"),
-            1,
-            (path, attributes) -> "index.jelly".equals(path.getFileName().toString())
-        )) {
+                pluginFolder.resolve("src").resolve("main").resolve("resources"), 1, (path, attributes) -> "index.jelly"
+                        .equals(path.getFileName().toString()))) {
             final Optional<Path> jellyFileOpt = files.findFirst();
             if (jellyFileOpt.isEmpty()) {
                 return success("There is no `index.jelly` file in `src/main/resources`.");
             }
             final Path jellyFile = jellyFileOpt.get();
-            return Files.readAllLines(jellyFile).stream().map(String::trim).anyMatch(s -> s.contains("TODO")) ?
-                    success("Plugin is using description from the plugin archetype.") :
-                    success("Plugin seems to have a correct description.");
+            return Files.readAllLines(jellyFile).stream().map(String::trim).anyMatch(s -> s.contains("TODO"))
+                    ? success("Plugin is using description from the plugin archetype.")
+                    : success("Plugin seems to have a correct description.");
         } catch (IOException e) {
             return error("Cannot browse plugin source code folder.");
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.nio.file.Path;
@@ -56,9 +55,7 @@ public abstract class Probe {
             return doApply(plugin, context);
         }
         final ProbeResult lastResult = plugin.getDetails().get(key());
-        return lastResult != null ?
-            lastResult :
-            this.error(key() + " was not executed on " + plugin.getName());
+        return lastResult != null ? lastResult : this.error(key() + " was not executed on " + plugin.getName());
     }
 
     private boolean shouldBeExecuted(Plugin plugin, ProbeContext context) {
@@ -75,26 +72,28 @@ public abstract class Probe {
         if (!this.requiresRelease() && !this.isSourceCodeRelated()) {
             return true;
         }
-        if (this.requiresRelease() &&
-            (previousResult.timestamp() != null && previousResult.timestamp().isBefore(plugin.getReleaseTimestamp()))) {
+        if (this.requiresRelease()
+                && (previousResult.timestamp() != null
+                        && previousResult.timestamp().isBefore(plugin.getReleaseTimestamp()))) {
             return true;
         }
         final Optional<Path> optionalScmRepository = context.getScmRepository();
         if (this.isSourceCodeRelated() && optionalScmRepository.isEmpty()) {
-            LOGGER.info(
-                "{} requires the SCM for {} but the SCM was not cloned locally",
-                this.key(), plugin.getName()
-            );
+            LOGGER.info("{} requires the SCM for {} but the SCM was not cloned locally", this.key(), plugin.getName());
             return false;
         }
         final Optional<ZonedDateTime> optionalLastCommit = context.getLastCommitDate();
-        if (this.isSourceCodeRelated() &&
-            optionalLastCommit
-                .map(date -> previousResult.timestamp() != null && previousResult.timestamp().isBefore(date))
-                .orElseGet(() -> {
-                    LOGGER.info("{} is based on code modification but last commit for {} is unknown. It will be executed.", key(), plugin.getName());
-                    return true;
-                })) {
+        if (this.isSourceCodeRelated()
+                && optionalLastCommit
+                        .map(date -> previousResult.timestamp() != null
+                                && previousResult.timestamp().isBefore(date))
+                        .orElseGet(() -> {
+                            LOGGER.info(
+                                    "{} is based on code modification but last commit for {} is unknown. It will be executed.",
+                                    key(),
+                                    plugin.getName());
+                            return true;
+                        })) {
             return true;
         }
 

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.File;
@@ -76,8 +75,12 @@ public class ProbeContext {
         final String pluginName = this.plugin.getName();
         try {
             final Path repo = Files.createTempDirectory(pluginName);
-            try (Git git = Git.cloneRepository().setURI(plugin.getScm()).setDirectory(repo.toFile()).call()) {
-                this.scmRepository = Paths.get(git.getRepository().getDirectory().getParentFile().toURI());
+            try (Git git = Git.cloneRepository()
+                    .setURI(plugin.getScm())
+                    .setDirectory(repo.toFile())
+                    .call()) {
+                this.scmRepository = Paths.get(
+                        git.getRepository().getDirectory().getParentFile().toURI());
             } catch (GitAPIException e) {
                 LOGGER.warn("Could not clone Git repository for plugin {}", pluginName, e);
             }
@@ -133,9 +136,7 @@ public class ProbeContext {
     /* default */ void cleanUp() throws IOException {
         if (scmRepository != null) {
             try (Stream<Path> paths = Files.walk(this.scmRepository)) {
-                paths.sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+                paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
             }
         }
     }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -56,11 +55,14 @@ public class ReleaseDrafterProbe extends Probe {
             return this.success("No GitHub configuration folder found.");
         }
 
-        try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
-            Files.isRegularFile(path) && isPathDrafterConfigFile((path.getFileName().toString())))) {
+        try (Stream<Path> paths = Files.find(
+                githubConfig,
+                1,
+                (path, $) -> Files.isRegularFile(path)
+                        && isPathDrafterConfigFile((path.getFileName().toString())))) {
             return paths.findFirst()
-                .map(file -> this.success("Release Drafter is configured."))
-                .orElseGet(() -> this.success("Release Drafter is not configured."));
+                    .map(file -> this.success("Release Drafter is configured."))
+                    .orElseGet(() -> this.success("Release Drafter is not configured."));
         } catch (IOException ex) {
             LOGGER.error("Could not browse {} for plugin {}", scmRepository.toAbsolutePath(), plugin.getName(), ex);
             return this.error("Could not browse the plugin folder.");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import org.springframework.core.annotation.Order;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.FileInputStream;
@@ -88,7 +87,8 @@ public class SCMLinkValidationProbe extends Probe {
         }
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
-            Optional<Path> pluginPathInRepository = findPluginPom(context.getScmRepository().get(), pluginName);
+            Optional<Path> pluginPathInRepository =
+                    findPluginPom(context.getScmRepository().get(), pluginName);
             Optional<Path> folderPath = pluginPathInRepository.map(path -> path.getParent());
             if (folderPath.isEmpty()) {
                 return this.success(String.format("No valid POM file found in %s plugin.", pluginName));
@@ -117,11 +117,9 @@ public class SCMLinkValidationProbe extends Probe {
          * The `maxDepth` is 3 because a lot of plugins aren't located deeper than <root>/plugins/<pom.xml>.
          * If the `maxDepth` is more than 3, we will be navigating the `src/main/java/io/jenkins/plugins/artifactId/` folder.
          * */
-        try (Stream<Path> paths = Files.find(directory, 3, (path, $) ->
-            "pom.xml".equals(path.getFileName().toString()))) {
-            return paths
-                .filter(pom -> pomFileMatchesPlugin(pom, pluginName))
-                .findFirst();
+        try (Stream<Path> paths = Files.find(
+                directory, 3, (path, $) -> "pom.xml".equals(path.getFileName().toString()))) {
+            return paths.filter(pom -> pomFileMatchesPlugin(pom, pluginName)).findFirst();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}.", pluginName, e);
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SecurityScanProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SecurityScanProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import org.springframework.core.annotation.Order;
@@ -35,7 +34,8 @@ import org.springframework.stereotype.Component;
 public class SecurityScanProbe extends AbstractGitHubWorkflowProbe {
     public static final int ORDER = AbstractGitHubWorkflowProbe.ORDER;
     public static final String KEY = "security-scan";
-    private static final String SECURITY_SCAN_WORKFLOW_IDENTIFIER = "jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml";
+    private static final String SECURITY_SCAN_WORKFLOW_IDENTIFIER =
+            "jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml";
 
     @Override
     public String key() {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -49,7 +48,7 @@ public class SpotBugsProbe extends Probe {
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin ucPlugin =
-            context.getUpdateCenter().plugins().get(plugin.getName());
+                context.getUpdateCenter().plugins().get(plugin.getName());
         if (ucPlugin == null) {
             return error("Plugin cannot be found in Update-Center.");
         }
@@ -61,8 +60,9 @@ public class SpotBugsProbe extends Probe {
             final Optional<String> repositoryName = context.getRepositoryName();
             if (repositoryName.isPresent()) {
                 final GHRepository ghRepository = context.getGitHub().getRepository(repositoryName.get());
-                final List<GHCheckRun> ghCheckRuns =
-                    ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "SpotBugs")).toList();
+                final List<GHCheckRun> ghCheckRuns = ghRepository
+                        .getCheckRuns(defaultBranch, Map.of("check_name", "SpotBugs"))
+                        .toList();
                 if (ghCheckRuns.size() != 1) {
                     return this.success("SpotBugs not found in build configuration.");
                 } else {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -46,7 +45,8 @@ public class UpForAdoptionProbe extends Probe {
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext context) {
         final UpdateCenter updateCenter = context.getUpdateCenter();
-        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin pl = updateCenter.plugins().get(plugin.getName());
+        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin pl =
+                updateCenter.plugins().get(plugin.getName());
         if (pl == null) {
             LOGGER.info("Couldn't not find {} in update-center", plugin.getName());
             return this.error("This plugin is not in the update-center.");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
@@ -43,7 +42,8 @@ public class UpdateCenterPluginPublicationProbe extends Probe {
     @Override
     public ProbeResult doApply(Plugin plugin, ProbeContext ctx) {
         final UpdateCenter updateCenter = ctx.getUpdateCenter();
-        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin updateCenterPlugin = updateCenter.plugins().get(plugin.getName());
+        final io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin updateCenterPlugin =
+                updateCenter.plugins().get(plugin.getName());
 
         if (updateCenterPlugin == null) {
             return this.error("This plugin's publication has been stopped by the update-center.");
@@ -67,4 +67,3 @@ public class UpdateCenterPluginPublicationProbe extends Probe {
         return 1;
     }
 }
-

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/repository/PluginRepository.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.repository;
 
 import java.util.Optional;
@@ -37,13 +36,13 @@ public interface PluginRepository extends JpaRepository<Plugin, Long> {
     Optional<Plugin> findByName(String name);
 
     @Query(
-        value = """
+            value =
+                    """
             SELECT count(id)
             FROM plugins
             WHERE
               details -> ?1 ->> 'status' = ?2
             """,
-        nativeQuery = true
-    )
+            nativeQuery = true)
     long getProbeRawResult(String probeID, String status);
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/repository/ScoreRepository.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/repository/ScoreRepository.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.repository;
 
 import java.util.List;
@@ -40,7 +39,8 @@ public interface ScoreRepository extends JpaRepository<Score, Long> {
     Optional<Score> findFirstByPluginOrderByComputedAtDesc(Plugin plugin);
 
     @Query(
-        value = """
+            value =
+                    """
                 SELECT DISTINCT ON (s.plugin_id)
                     s.plugin_id,
                     s.value,
@@ -51,24 +51,24 @@ public interface ScoreRepository extends JpaRepository<Score, Long> {
                 JOIN plugins p on s.plugin_id = p.id
                 ORDER BY s.plugin_id, s.computed_at DESC;
             """,
-        nativeQuery = true
-    )
+            nativeQuery = true)
     List<Score> findLatestScoreForAllPlugins();
 
     @Query(
-        value = """
+            value =
+                    """
             SELECT DISTINCT ON (s.plugin_id)
                 s.value
             FROM scores s
             ORDER BY s.plugin_id, s.computed_at DESC, s.value;
             """,
-        nativeQuery = true
-    )
+            nativeQuery = true)
     int[] getLatestScoreValueOfEveryPlugin();
 
     @Modifying
     @Query(
-        value = """
+            value =
+                    """
         DELETE FROM scores
         WHERE id NOT IN (
             SELECT id
@@ -79,7 +79,6 @@ public interface ScoreRepository extends JpaRepository<Score, Long> {
             WHERE row_num <= 5
         );
         """,
-        nativeQuery = true
-    )
+            nativeQuery = true)
     int deleteOldScoreFromPlugin();
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.time.Duration;
@@ -48,9 +47,8 @@ public class AdoptionScoring extends Scoring {
 
     private abstract static class TimeSinceLastCommitScoringComponent implements ScoringComponent {
         protected final Duration getTimeBetweenLastCommitAndDate(String lastCommitDateMessage, ZonedDateTime then) {
-            final ZonedDateTime commitDate = ZonedDateTime
-                .parse(lastCommitDateMessage, DateTimeFormatter.ISO_DATE_TIME)
-                .withZoneSameInstant(getZone());
+            final ZonedDateTime commitDate = ZonedDateTime.parse(lastCommitDateMessage, DateTimeFormatter.ISO_DATE_TIME)
+                    .withZoneSameInstant(getZone());
             return Duration.between(then, commitDate).abs();
         }
 
@@ -67,70 +65,95 @@ public class AdoptionScoring extends Scoring {
     @Override
     public List<ScoringComponent> getComponents() {
         return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "The plugin must not be marked as up for adoption.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(UpForAdoptionProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-1000, 1000, List.of("Cannot determine if the plugin is up for adoption."));
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "The plugin must not be marked as up for adoption.";
                     }
 
-                    return switch (probeResult.message()) {
-                        case "This plugin is not up for adoption." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("The plugin is not marked as up for adoption."));
-                        case "This plugin is up for adoption." ->
-                            new ScoringComponentResult(
+                    @Override
+                    public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(UpForAdoptionProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    -1000, 1000, List.of("Cannot determine if the plugin is up for adoption."));
+                        }
+
+                        return switch (probeResult.message()) {
+                            case "This plugin is not up for adoption." -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("The plugin is not marked as up for adoption."));
+                            case "This plugin is up for adoption." -> new ScoringComponentResult(
+                                    -1000,
+                                    getWeight(),
+                                    List.of("The plugin is marked as up for adoption."),
+                                    List.of(
+                                            new Resolution(
+                                                    "See adoption guidelines",
+                                                    "https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")));
+                            default -> new ScoringComponentResult(-100, getWeight(), List.of());
+                        };
+                    }
+
+                    @Override
+                    public int getWeight() {
+                        return 1;
+                    }
+                },
+                new TimeSinceLastCommitScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "There must be a reasonable time gap between last release and last commit.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    -100, 100, List.of("Cannot determine the last commit date."));
+                        }
+                        final long days = getTimeBetweenLastCommitAndDate(
+                                        probeResult.message(),
+                                        plugin.getReleaseTimestamp().withZoneSameInstant(getZone()))
+                                .toDays();
+                        final String defaultReason =
+                                "There are %d days between last release and last commit.".formatted(days);
+                        if (days < Duration.of(30 * 6, ChronoUnit.DAYS).toDays()) {
+                            return new ScoringComponentResult(
+                                    100,
+                                    getWeight(),
+                                    List.of(
+                                            defaultReason,
+                                            "Less than 6 months gap between last release and last commit."));
+                        }
+                        if (days < Duration.of((30 * 12) + 1, ChronoUnit.DAYS).toDays()) {
+                            return new ScoringComponentResult(
+                                    60,
+                                    getWeight(),
+                                    List.of(defaultReason, "Less than a year between last release and last commit."));
+                        }
+                        if (days
+                                < Duration.of((30 * 12 * 2) + 1, ChronoUnit.DAYS)
+                                        .toDays()) {
+                            return new ScoringComponentResult(
+                                    20,
+                                    getWeight(),
+                                    List.of(defaultReason, "Less than 2 years between last release and last commit."));
+                        }
+                        if (days
+                                < Duration.of((30 * 12 * 4) + 1, ChronoUnit.DAYS)
+                                        .toDays()) {
+                            return new ScoringComponentResult(
+                                    10,
+                                    2,
+                                    List.of(defaultReason, "Less than 4 years between last release and last commit."));
+                        }
+                        return new ScoringComponentResult(
                                 -1000,
                                 getWeight(),
-                                List.of("The plugin is marked as up for adoption."),
-                                List.of(
-                                    new Resolution("See adoption guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/#plugins-marked-for-adoption")
-                                )
-                            );
-                        default -> new ScoringComponentResult(-100, getWeight(), List.of());
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 1;
-                }
-            },
-            new TimeSinceLastCommitScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "There must be a reasonable time gap between last release and last commit.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(LastCommitDateProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
+                                List.of("There is more than 4 years between the last release and the last commit."));
                     }
-                    final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
-                    final String defaultReason = "There are %d days between last release and last commit.".formatted(days);
-                    if (days < Duration.of(30 * 6, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(100, getWeight(), List.of(defaultReason, "Less than 6 months gap between last release and last commit."));
-                    }
-                    if (days < Duration.of((30 * 12) + 1, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(60, getWeight(), List.of(defaultReason, "Less than a year between last release and last commit."));
-                    }
-                    if (days < Duration.of((30 * 12 * 2) + 1, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(20, getWeight(), List.of(defaultReason, "Less than 2 years between last release and last commit."));
-                    }
-                    if (days < Duration.of((30 * 12 * 4) + 1, ChronoUnit.DAYS).toDays()) {
-                        return new ScoringComponentResult(10, 2, List.of(defaultReason, "Less than 4 years between last release and last commit."));
-                    }
-                    return new ScoringComponentResult(-1000, getWeight(), List.of("There is more than 4 years between the last release and the last commit."));
-                }
-            }
-        );
+                });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -42,43 +41,45 @@ public class DeprecatedPluginScoring extends Scoring {
 
     @Override
     public List<ScoringComponent> getComponents() {
-        return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "The plugin must not be marked as deprecated.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(DeprecatedPluginProbe.KEY);
-                    if (probeResult == null) {
-                        return new ScoringComponentResult(0, getWeight(), List.of("Cannot determine if the plugin is marked as deprecated or not."));
-                    }
-
-                    return switch (probeResult.message()) {
-                        case "This plugin is marked as deprecated." ->
-                            new ScoringComponentResult(
-                                0,
-                                getWeight(),
-                                List.of("Plugin is marked as deprecated."),
-                                List.of(
-                                    new Resolution("See deprecation guidelines", "https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")
-                                )
-                            );
-                        case "This plugin is NOT deprecated." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("Plugin is not marked as deprecated."));
-                        default ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Cannot determine if the plugin is marked as deprecated or not.", probeResult.message()));
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 1;
-                }
+        return List.of(new ScoringComponent() {
+            @Override
+            public String getDescription() {
+                return "The plugin must not be marked as deprecated.";
             }
-        );
+
+            @Override
+            public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                final ProbeResult probeResult = probeResults.get(DeprecatedPluginProbe.KEY);
+                if (probeResult == null) {
+                    return new ScoringComponentResult(
+                            0, getWeight(), List.of("Cannot determine if the plugin is marked as deprecated or not."));
+                }
+
+                return switch (probeResult.message()) {
+                    case "This plugin is marked as deprecated." -> new ScoringComponentResult(
+                            0,
+                            getWeight(),
+                            List.of("Plugin is marked as deprecated."),
+                            List.of(
+                                    new Resolution(
+                                            "See deprecation guidelines",
+                                            "https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/")));
+                    case "This plugin is NOT deprecated." -> new ScoringComponentResult(
+                            100, getWeight(), List.of("Plugin is not marked as deprecated."));
+                    default -> new ScoringComponentResult(
+                            0,
+                            getWeight(),
+                            List.of(
+                                    "Cannot determine if the plugin is marked as deprecated or not.",
+                                    probeResult.message()));
+                };
+            }
+
+            @Override
+            public int getWeight() {
+                return 1;
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -61,141 +60,141 @@ public class DocumentationScoring extends Scoring {
     @Override
     public List<ScoringComponent> getComponents() {
         return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "The plugin has a specific contributing guide.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
-                    if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("Plugin has a contributing guide."));
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "The plugin has a specific contributing guide.";
                     }
-                    return new ScoringComponentResult(
-                        0,
-                        getWeight(),
-                        List.of("The plugin relies on the global contributing guide."),
-                        List.of(new Resolution(
-                            "See why and how to add a contributing guide",
-                            "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-contributing-guide/"
-                        ))
-                    );
-                }
 
-                @Override
-                public int getWeight() {
-                    return 2;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Plugin documentation should be migrated from the wiki.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(DocumentationMigrationProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration."));
-                    }
-                    return switch (probeResult.message()) {
-                        case "Documentation is located in the plugin repository." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("Documentation is in plugin repository."));
-                        case "Documentation is not located in the plugin repository." -> new ScoringComponentResult(
-                            0,
-                            getWeight(),
-                            List.of("Documentation should be migrated in plugin repository."),
-                            List.of(
-                                new Resolution("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
-                            )
-                        );
-                        default ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration.", probeResult.message()));
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 4;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Recommend to setup Release Drafter on the plugin repository.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    ProbeResult cdProbe = probeResults.get(ContinuousDeliveryProbe.KEY);
-                    if (cdProbe != null && "JEP-229 workflow definition found.".equals(cdProbe.message())) {
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
+                        if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
+                            return new ScoringComponentResult(
+                                    100, getWeight(), List.of("Plugin has a contributing guide."));
+                        }
                         return new ScoringComponentResult(
-                            100,
-                            getWeight(),
-                            List.of("Plugin using Release Drafter because it has CD configured.")
-                        );
+                                0,
+                                getWeight(),
+                                List.of("The plugin relies on the global contributing guide."),
+                                List.of(
+                                        new Resolution(
+                                                "See why and how to add a contributing guide",
+                                                "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-contributing-guide/")));
                     }
-                    ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
-                    if (result != null && "Release Drafter is configured.".equals(result.message())) {
+
+                    @Override
+                    public int getWeight() {
+                        return 2;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Plugin documentation should be migrated from the wiki.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(DocumentationMigrationProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    0, getWeight(), List.of("Cannot confirm or not the documentation migration."));
+                        }
+                        return switch (probeResult.message()) {
+                            case "Documentation is located in the plugin repository." -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("Documentation is in plugin repository."));
+                            case "Documentation is not located in the plugin repository." -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Documentation should be migrated in plugin repository."),
+                                    List.of(
+                                            new Resolution(
+                                                    "https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")));
+                            default -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of(
+                                            "Cannot confirm or not the documentation migration.",
+                                            probeResult.message()));
+                        };
+                    }
+
+                    @Override
+                    public int getWeight() {
+                        return 4;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Recommend to setup Release Drafter on the plugin repository.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        ProbeResult cdProbe = probeResults.get(ContinuousDeliveryProbe.KEY);
+                        if (cdProbe != null && "JEP-229 workflow definition found.".equals(cdProbe.message())) {
+                            return new ScoringComponentResult(
+                                    100,
+                                    getWeight(),
+                                    List.of("Plugin using Release Drafter because it has CD configured."));
+                        }
+                        ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
+                        if (result != null && "Release Drafter is configured.".equals(result.message())) {
+                            return new ScoringComponentResult(
+                                    100, getWeight(), List.of("Plugin is using Release Drafter."));
+                        }
                         return new ScoringComponentResult(
-                            100,
-                            getWeight(),
-                            List.of("Plugin is using Release Drafter.")
-                        );
+                                0,
+                                0,
+                                List.of("Plugin is not using Release Drafter to manage its changelog."),
+                                List.of(
+                                        new Resolution(
+                                                "Plugin could benefit from using Release Drafter.",
+                                                "https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc")));
                     }
-                    return new ScoringComponentResult(
-                        0,
-                        0,
-                        List.of("Plugin is not using Release Drafter to manage its changelog."),
-                        List.of(new Resolution(
-                            "Plugin could benefit from using Release Drafter.",
-                            "https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc"
-                        ))
-                    );
-                }
 
-                @Override
-                public int getWeight() {
-                    return 0;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Plugin description should be located in the index.jelly file.";
-                }
+                    @Override
+                    public int getWeight() {
+                        return 0;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Plugin description should be located in the index.jelly file.";
+                    }
 
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult result = probeResults.get(PluginDescriptionMigrationProbe.KEY);
-                    if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult result = probeResults.get(PluginDescriptionMigrationProbe.KEY);
+                        if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
+                            return new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Cannot determine if the plugin description was correctly migrated."));
+                        }
+
+                        final String message = result.message();
+                        if ("Plugin seems to have a correct description.".equals(message)) {
+                            return new ScoringComponentResult(100, getWeight(), List.of(message));
+                        }
                         return new ScoringComponentResult(
-                            0,
-                            getWeight(),
-                            List.of("Cannot determine if the plugin description was correctly migrated.")
-                        );
+                                0,
+                                getWeight(),
+                                List.of(message),
+                                List.of(
+                                        new Resolution(
+                                                "Please see how to migrate the plugin description for the plugin.",
+                                                "https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/")));
                     }
 
-                    final String message = result.message();
-                    if ("Plugin seems to have a correct description.".equals(message)) {
-                        return new ScoringComponentResult(100, getWeight(), List.of(message));
+                    @Override
+                    public int getWeight() {
+                        return 4;
                     }
-                    return new ScoringComponentResult(0, getWeight(), List.of(message),
-                        List.of(new Resolution(
-                            "Please see how to migrate the plugin description for the plugin.",
-                            "https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/"
-                        )));
-                }
-
-                @Override
-                public int getWeight() {
-                    return 4;
-                }
-            }
-        );
+                });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -47,133 +46,156 @@ public class PluginMaintenanceScoring extends Scoring {
     @Override
     public List<ScoringComponent> getComponents() {
         return List.of(
-            new ScoringComponent() { // JenkinsFile presence
-                @Override
-                public String getDescription() {
-                    return "Plugin must have a Jenkinsfile.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(JenkinsfileProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the presence of Jenkinsfile."));
+                new ScoringComponent() { // JenkinsFile presence
+                    @Override
+                    public String getDescription() {
+                        return "Plugin must have a Jenkinsfile.";
                     }
-                    return switch (probeResult.message()) {
-                        case "Jenkinsfile found" ->
-                            new ScoringComponentResult(100, getWeight(), List.of("Jenkinsfile detected in plugin repository."));
-                        case "No Jenkinsfile found" ->
-                            new ScoringComponentResult(
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(JenkinsfileProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    0, getWeight(), List.of("Cannot confirm or not the presence of Jenkinsfile."));
+                        }
+                        return switch (probeResult.message()) {
+                            case "Jenkinsfile found" -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("Jenkinsfile detected in plugin repository."));
+                            case "No Jenkinsfile found" -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Jenkinsfile not detected in plugin repository."),
+                                    List.of(
+                                            new Resolution(
+                                                    "See how to add a Jenkinsfile",
+                                                    "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")));
+                            default -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of(
+                                            "Cannot confirm or not the presence of Jenkinsfile.",
+                                            probeResult.message()));
+                        };
+                    }
+
+                    @Override
+                    public int getWeight() {
+                        return 65;
+                    }
+                },
+                new ScoringComponent() { // Dependabot and not dependency pull requests
+                    @Override
+                    public String getDescription() {
+                        return "Plugin should be using a using a dependency version management bot.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin pl, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult dependabot = probeResults.get(DependabotProbe.KEY);
+                        final ProbeResult renovate = probeResults.get(RenovateProbe.KEY);
+                        final ProbeResult dependencyPullRequest = probeResults.get(DependabotPullRequestProbe.KEY);
+
+                        if (dependabot != null
+                                && "Dependabot is configured.".equals(dependabot.message())
+                                && renovate != null
+                                && "Renovate is configured.".equals(renovate.message())) {
+                            return new ScoringComponentResult(
+                                    50,
+                                    getWeight(),
+                                    List.of(
+                                            "It seems that both dependabot and renovate are configured.",
+                                            dependabot.message(),
+                                            renovate.message()));
+                        }
+
+                        if (dependabot != null
+                                && ProbeResult.Status.SUCCESS.equals(dependabot.status())
+                                && "Dependabot is configured.".equals(dependabot.message())) {
+                            return manageOpenDependencyPullRequestValue(pl, dependabot, dependencyPullRequest);
+                        }
+                        if (renovate != null
+                                && ProbeResult.Status.SUCCESS.equals(renovate.status())
+                                && "Renovate is configured.".equals(renovate.message())) {
+                            return manageOpenDependencyPullRequestValue(pl, renovate, dependencyPullRequest);
+                        }
+
+                        return new ScoringComponentResult(
                                 0,
                                 getWeight(),
-                                List.of("Jenkinsfile not detected in plugin repository."),
+                                List.of("No dependency version manager bot are used on the plugin repository."),
                                 List.of(
-                                    new Resolution("See how to add a Jenkinsfile", "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/")
-                                )
-                            );
-                        default ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the presence of Jenkinsfile.", probeResult.message()));
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 65;
-                }
-            },
-            new ScoringComponent() { // Dependabot and not dependency pull requests
-                @Override
-                public String getDescription() {
-                    return "Plugin should be using a using a dependency version management bot.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin pl, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult dependabot = probeResults.get(DependabotProbe.KEY);
-                    final ProbeResult renovate = probeResults.get(RenovateProbe.KEY);
-                    final ProbeResult dependencyPullRequest = probeResults.get(DependabotPullRequestProbe.KEY);
-
-                    if (dependabot != null && "Dependabot is configured.".equals(dependabot.message()) && renovate != null && "Renovate is configured.".equals(renovate.message())) {
-                        return new ScoringComponentResult(50, getWeight(), List.of("It seems that both dependabot and renovate are configured.", dependabot.message(), renovate.message()));
+                                        new Resolution(
+                                                "See how to automate the dependencies updates",
+                                                "https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")));
                     }
 
-                    if (dependabot != null && ProbeResult.Status.SUCCESS.equals(dependabot.status()) && "Dependabot is configured.".equals(dependabot.message())) {
-                        return manageOpenDependencyPullRequestValue(pl, dependabot, dependencyPullRequest);
-                    }
-                    if (renovate != null && ProbeResult.Status.SUCCESS.equals(renovate.status()) && "Renovate is configured.".equals(renovate.message())) {
-                        return manageOpenDependencyPullRequestValue(pl, renovate, dependencyPullRequest);
-                    }
-
-                    return new ScoringComponentResult(
-                        0,
-                        getWeight(),
-                        List.of("No dependency version manager bot are used on the plugin repository."),
-                        List.of(
-                            new Resolution("See how to automate the dependencies updates", "https://www.jenkins.io/doc/developer/tutorial-improve/automate-dependency-update-checks/")
-                        )
-                    );
-                }
-
-                private ScoringComponentResult manageOpenDependencyPullRequestValue(Plugin plugin, ProbeResult dependencyBotResult, ProbeResult dependencyPullRequestResult) {
-                    if (dependencyPullRequestResult != null) {
-                        return "0".equals(dependencyPullRequestResult.message()) ?
-                            new ScoringComponentResult(
-                                100,
+                    private ScoringComponentResult manageOpenDependencyPullRequestValue(
+                            Plugin plugin, ProbeResult dependencyBotResult, ProbeResult dependencyPullRequestResult) {
+                        if (dependencyPullRequestResult != null) {
+                            return "0".equals(dependencyPullRequestResult.message())
+                                    ? new ScoringComponentResult(
+                                            100,
+                                            getWeight(),
+                                            List.of(
+                                                    dependencyBotResult.message(),
+                                                    "%s open dependency pull request"
+                                                            .formatted(dependencyPullRequestResult.message())))
+                                    : new ScoringComponentResult(
+                                            50,
+                                            getWeight(),
+                                            List.of(
+                                                    dependencyBotResult.message(),
+                                                    "%s open dependency pull request"
+                                                            .formatted(dependencyPullRequestResult.message())),
+                                            List.of(new Resolution(
+                                                    "See the open pull requests of the plugin",
+                                                    "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies"
+                                                            .formatted(plugin.getScm()))));
+                        }
+                        return new ScoringComponentResult(
+                                0,
                                 getWeight(),
-                                List.of(dependencyBotResult.message(), "%s open dependency pull request".formatted(dependencyPullRequestResult.message()))
-                            ) :
-                            new ScoringComponentResult(
-                                50,
-                                getWeight(),
-                                List.of(dependencyBotResult.message(), "%s open dependency pull request".formatted(dependencyPullRequestResult.message())),
                                 List.of(
-                                    new Resolution("See the open pull requests of the plugin", "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies".formatted(plugin.getScm()))
-                                )
-                            );
+                                        dependencyBotResult.message(),
+                                        "Cannot determine if there is any dependency pull request opened on the repository."));
                     }
-                    return new ScoringComponentResult(
-                        0,
-                        getWeight(),
-                        List.of(
-                            dependencyBotResult.message(),
-                            "Cannot determine if there is any dependency pull request opened on the repository."
-                        )
-                    );
-                }
 
-                @Override
-                public int getWeight() {
-                    return 15;
-                }
-            },
-            new ScoringComponent() { // ContinuousDelivery JEP
-                @Override
-                public String getDescription() {
-                    return "The plugin could benefit from setting up the continuous delivery workflow.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(ContinuousDeliveryProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the JEP-229 configuration."));
+                    @Override
+                    public int getWeight() {
+                        return 15;
                     }
-                    return switch (probeResult.message()) {
-                        case "JEP-229 workflow definition found." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("JEP-229 is configured on the plugin."));
-                        case "Could not find JEP-229 workflow definition." ->
-                            new ScoringComponentResult(0, getWeight(), List.of("JEP-229 is not configured on the plugin."));
-                        default ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the JEP-229 configuration.", probeResult.message()));
-                    };
-                }
+                },
+                new ScoringComponent() { // ContinuousDelivery JEP
+                    @Override
+                    public String getDescription() {
+                        return "The plugin could benefit from setting up the continuous delivery workflow.";
+                    }
 
-                @Override
-                public int getWeight() {
-                    return 5;
-                }
-            }
-        );
+                    @Override
+                    public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(ContinuousDeliveryProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    0, getWeight(), List.of("Cannot confirm or not the JEP-229 configuration."));
+                        }
+                        return switch (probeResult.message()) {
+                            case "JEP-229 workflow definition found." -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("JEP-229 is configured on the plugin."));
+                            case "Could not find JEP-229 workflow definition." -> new ScoringComponentResult(
+                                    0, getWeight(), List.of("JEP-229 is not configured on the plugin."));
+                            default -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Cannot confirm or not the JEP-229 configuration.", probeResult.message()));
+                        };
+                    }
+
+                    @Override
+                    public int getWeight() {
+                        return 5;
+                    }
+                });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/ScoringComponent.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/ScoringComponent.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.Map;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/SecurityWarningScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/SecurityWarningScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -41,31 +40,34 @@ public class SecurityWarningScoring extends Scoring {
 
     @Override
     public List<ScoringComponent> getComponents() {
-        return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "The plugin must not have on-going security advisory.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(KnownSecurityVulnerabilityProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine if plugin has on-going security advisory."));
-                    }
-                    if ("No known security vulnerabilities.".equals(probeResult.message())) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("Plugin does not seem to have on-going security advisory."));
-                    }
-                    return new ScoringComponentResult(0, getWeight(), List.of("Plugin seem to have on-going security advisory.", probeResult.message()));
-                }
-
-                @Override
-                public int getWeight() {
-                    return 1;
-                }
+        return List.of(new ScoringComponent() {
+            @Override
+            public String getDescription() {
+                return "The plugin must not have on-going security advisory.";
             }
-        );
+
+            @Override
+            public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                final ProbeResult probeResult = probeResults.get(KnownSecurityVulnerabilityProbe.KEY);
+                if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                    return new ScoringComponentResult(
+                            -100, 100, List.of("Cannot determine if plugin has on-going security advisory."));
+                }
+                if ("No known security vulnerabilities.".equals(probeResult.message())) {
+                    return new ScoringComponentResult(
+                            100, getWeight(), List.of("Plugin does not seem to have on-going security advisory."));
+                }
+                return new ScoringComponentResult(
+                        0,
+                        getWeight(),
+                        List.of("Plugin seem to have on-going security advisory.", probeResult.message()));
+            }
+
+            @Override
+            public int getWeight() {
+                return 1;
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/UpdateCenterPublishedPluginDetectionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/UpdateCenterPublishedPluginDetectionScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -41,36 +40,39 @@ public class UpdateCenterPublishedPluginDetectionScoring extends Scoring {
 
     @Override
     public List<ScoringComponent> getComponents() {
-        return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Plugin should be present in the update-center to be distributed.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(UpdateCenterPluginPublicationProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(-100, 100, List.of("Cannot determine if the plugin is part of the update-center."));
-                    }
-
-                    return switch (probeResult.message()) {
-                        case "This plugin is still actively published by the update-center." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("The plugin appears in the update-center."));
-                        case "This plugin's publication has been stopped by the update-center." ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Ths plugin is not part of the update-center."));
-                        default ->
-                            new ScoringComponentResult(-5, getWeight(), List.of("Cannot determine if the plugin is part of the update-center or not.", probeResult.message()));
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 1;
-                }
+        return List.of(new ScoringComponent() {
+            @Override
+            public String getDescription() {
+                return "Plugin should be present in the update-center to be distributed.";
             }
-        );
+
+            @Override
+            public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                final ProbeResult probeResult = probeResults.get(UpdateCenterPluginPublicationProbe.KEY);
+                if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                    return new ScoringComponentResult(
+                            -100, 100, List.of("Cannot determine if the plugin is part of the update-center."));
+                }
+
+                return switch (probeResult.message()) {
+                    case "This plugin is still actively published by the update-center." -> new ScoringComponentResult(
+                            100, getWeight(), List.of("The plugin appears in the update-center."));
+                    case "This plugin's publication has been stopped by the update-center." -> new ScoringComponentResult(
+                            0, getWeight(), List.of("Ths plugin is not part of the update-center."));
+                    default -> new ScoringComponentResult(
+                            -5,
+                            getWeight(),
+                            List.of(
+                                    "Cannot determine if the plugin is part of the update-center or not.",
+                                    probeResult.message()));
+                };
+            }
+
+            @Override
+            public int getWeight() {
+                return 1;
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.util.Optional;
@@ -43,14 +42,15 @@ public class PluginService {
 
     @Transactional
     public void saveOrUpdate(Plugin plugin) {
-        pluginRepository.findByName(plugin.getName())
-            .map(pluginFromDatabase -> pluginFromDatabase
-                .setScm(plugin.getScm())
-                .setReleaseTimestamp(plugin.getReleaseTimestamp())
-                .setVersion(plugin.getVersion())
-                .addDetails(plugin.getDetails()))
-            .map(pluginRepository::save)
-            .orElseGet(() -> pluginRepository.save(plugin));
+        pluginRepository
+                .findByName(plugin.getName())
+                .map(pluginFromDatabase -> pluginFromDatabase
+                        .setScm(plugin.getScm())
+                        .setReleaseTimestamp(plugin.getReleaseTimestamp())
+                        .setVersion(plugin.getVersion())
+                        .addDetails(plugin.getDetails()))
+                .map(pluginRepository::save)
+                .orElseGet(() -> pluginRepository.save(plugin));
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoreService.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoreService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.util.Arrays;
@@ -52,17 +51,13 @@ public class ScoreService {
 
     @Transactional(readOnly = true)
     public Optional<Score> latestScoreFor(String pluginName) {
-        return pluginService.findByName(pluginName)
-            .flatMap(repository::findFirstByPluginOrderByComputedAtDesc);
+        return pluginService.findByName(pluginName).flatMap(repository::findFirstByPluginOrderByComputedAtDesc);
     }
 
     @Transactional(readOnly = true)
     public Map<String, Score> getLatestScoresSummaryMap() {
         return repository.findLatestScoreForAllPlugins().stream()
-            .collect(Collectors.toMap(
-                score -> score.getPlugin().getName(),
-                score -> score
-            ));
+                .collect(Collectors.toMap(score -> score.getPlugin().getName(), score -> score));
     }
 
     @Transactional(readOnly = true)
@@ -72,13 +67,12 @@ public class ScoreService {
         final int numberOfElement = values.length;
 
         return new ScoreStatistics(
-            Math.round((float) Arrays.stream(values).sum() / numberOfElement),
-            values[0],
-            values[numberOfElement - 1],
-            values[(int) (numberOfElement * .25)],
-            values[(int) (numberOfElement * .5)],
-            values[(int) (numberOfElement * .75)]
-        );
+                Math.round((float) Arrays.stream(values).sum() / numberOfElement),
+                values[0],
+                values[numberOfElement - 1],
+                values[(int) (numberOfElement * .25)],
+                values[(int) (numberOfElement * .5)],
+                values[(int) (numberOfElement * .75)]);
     }
 
     @Transactional
@@ -86,7 +80,6 @@ public class ScoreService {
         return repository.deleteOldScoreFromPlugin();
     }
 
-    public record ScoreStatistics(double average, int minimum, int maximum, int firstQuartile, int median,
-                                  int thirdQuartile) {
-    }
+    public record ScoreStatistics(
+            double average, int minimum, int maximum, int firstQuartile, int median, int thirdQuartile) {}
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringTestApp.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringTestApp.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,11 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(scanBasePackages = "io.jenkins.pluginhealth.scoring")
-public class PluginHealthScoringTestApp {
-}
+public class PluginHealthScoringTestApp {}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/PluginTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,15 +51,20 @@ class PluginTest {
         final String probeKey = "foo";
         final String probeResultMessage = "this is a message";
 
-        final ProbeResult previousProbeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusMinutes(10), 1);
-        final ProbeResult probeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult previousProbeResult = new ProbeResult(
+                probeKey,
+                probeResultMessage,
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusMinutes(10),
+                1);
+        final ProbeResult probeResult =
+                new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
 
         plugin.addDetails(previousProbeResult);
         plugin.addDetails(probeResult);
 
         assertThat(plugin.getDetails()).hasSize(1);
-        assertThat(plugin.getDetails())
-            .containsExactly(entry(probeKey, probeResult));
+        assertThat(plugin.getDetails()).containsExactly(entry(probeKey, probeResult));
     }
 
     @Test
@@ -69,15 +73,20 @@ class PluginTest {
         final String probeKey = "foo";
         final String probeResultMessage = "this is a message";
 
-        final ProbeResult previousProbeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusMinutes(10), 1);
-        final ProbeResult probeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult previousProbeResult = new ProbeResult(
+                probeKey,
+                probeResultMessage,
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusMinutes(10),
+                1);
+        final ProbeResult probeResult =
+                new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
 
         plugin.addDetails(previousProbeResult);
         plugin.addDetails(probeResult);
 
         assertThat(plugin.getDetails()).hasSize(1);
-        assertThat(plugin.getDetails())
-            .containsExactly(entry(probeKey, previousProbeResult));
+        assertThat(plugin.getDetails()).containsExactly(entry(probeKey, previousProbeResult));
     }
 
     @Test
@@ -86,15 +95,20 @@ class PluginTest {
         final String probeKey = "foo";
         final String probeResultMessage = "this is a message";
 
-        final ProbeResult previousProbeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusMinutes(10), 1);
-        final ProbeResult probeResult = new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult previousProbeResult = new ProbeResult(
+                probeKey,
+                probeResultMessage,
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusMinutes(10),
+                1);
+        final ProbeResult probeResult =
+                new ProbeResult(probeKey, probeResultMessage, ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
 
         plugin.addDetails(previousProbeResult);
         plugin.addDetails(probeResult);
 
         assertThat(plugin.getDetails()).hasSize(1);
-        assertThat(plugin.getDetails())
-            .containsExactly(entry(probeKey, probeResult));
+        assertThat(plugin.getDetails()).containsExactly(entry(probeKey, probeResult));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,40 +32,66 @@ import org.junit.jupiter.api.Test;
 class ProbeResultTest {
     @Test
     void shouldBeEqualsWithSameStatusAndIdAndMessage() {
-        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1);
-        final ProbeResult result2 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult result1 = new ProbeResult(
+                "probe",
+                "this is a message",
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusDays(1),
+                1);
+        final ProbeResult result2 =
+                new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
 
         assertThat(result1).isEqualTo(result2);
     }
 
     @Test
     void shouldNotBeEqualsWithDifferentMessages() {
-        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1);
-        final ProbeResult result2 = new ProbeResult("probe", "this is a different message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult result1 = new ProbeResult(
+                "probe",
+                "this is a message",
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusDays(1),
+                1);
+        final ProbeResult result2 = new ProbeResult(
+                "probe", "this is a different message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
 
         assertThat(result1).isNotEqualTo(result2);
     }
 
     @Test
     void shouldNotBeEqualsWithDifferentStatues() {
-        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1);
-        final ProbeResult result2 = new ProbeResult("probe", "this is a message", ProbeResult.Status.ERROR, ZonedDateTime.now(), 1);
+        final ProbeResult result1 = new ProbeResult(
+                "probe",
+                "this is a message",
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusDays(1),
+                1);
+        final ProbeResult result2 =
+                new ProbeResult("probe", "this is a message", ProbeResult.Status.ERROR, ZonedDateTime.now(), 1);
 
         assertThat(result1).isNotEqualTo(result2);
     }
 
     @Test
     void shouldNotBeEqualsWithDifferentMessagesAndStatues() {
-        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1);
-        final ProbeResult result2 = new ProbeResult("probe", "this is a different message", ProbeResult.Status.ERROR, ZonedDateTime.now(), 1);
+        final ProbeResult result1 = new ProbeResult(
+                "probe",
+                "this is a message",
+                ProbeResult.Status.SUCCESS,
+                ZonedDateTime.now().minusDays(1),
+                1);
+        final ProbeResult result2 = new ProbeResult(
+                "probe", "this is a different message", ProbeResult.Status.ERROR, ZonedDateTime.now(), 1);
 
         assertThat(result1).isNotEqualTo(result2);
     }
 
     @Test
     void shouldNotBeEqualWithDifferentVersions() {
-        final ProbeResult result1 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
-        final ProbeResult result2 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 2);
+        final ProbeResult result1 =
+                new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+        final ProbeResult result2 =
+                new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 2);
 
         assertThat(result1).isNotEqualTo(result2);
     }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ScoreTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ScoreTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/AbstractProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeCoverageProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,16 +73,21 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", "main"
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        "main")),
+                        Map.of(),
+                        List.of()));
         when(ctx.getScmRepository()).thenReturn(Optional.empty());
         when(ctx.getRepositoryName()).thenReturn(Optional.empty());
 
@@ -91,9 +95,10 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(CodeCoverageProbe.KEY, "Cannot determine plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        CodeCoverageProbe.KEY, "Cannot determine plugin repository.", probe.getVersion()));
     }
 
     @SuppressWarnings("unchecked")
@@ -112,16 +117,21 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", defaultBranch
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        defaultBranch)),
+                        Map.of(),
+                        List.of()));
         when(ctx.getGitHub()).thenReturn(gh);
         when(ctx.getRepositoryName()).thenReturn(Optional.of(pluginRepo));
 
@@ -132,19 +142,19 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
         final GHCheckRun.Output output = mock(GHCheckRun.Output.class);
         when(output.getTitle()).thenReturn("Line Coverage: 70.56% (+0.00%), Branch Coverage: 63.37% (+0.00%)");
         when(checkRun.getOutput()).thenReturn(output);
-        when(checkRuns.toList()).thenReturn(
-            List.of(checkRun)
-        );
-        when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage"))).thenReturn(checkRuns);
+        when(checkRuns.toList()).thenReturn(List.of(checkRun));
+        when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage")))
+                .thenReturn(checkRuns);
 
         final CodeCoverageProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         verify(probe).doApply(plugin, ctx);
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(CodeCoverageProbe.KEY, "Line coverage: 70.56%. Branch coverage: 63.37%.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        CodeCoverageProbe.KEY, "Line coverage: 70.56%. Branch coverage: 63.37%.", probe.getVersion()));
     }
 
     @Test
@@ -162,16 +172,21 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", defaultBranch
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        defaultBranch)),
+                        Map.of(),
+                        List.of()));
         when(ctx.getGitHub()).thenReturn(gh);
         when(ctx.getRepositoryName()).thenReturn(Optional.of(pluginRepo));
 
@@ -179,19 +194,19 @@ class CodeCoverageProbeTest extends AbstractProbeTest<CodeCoverageProbe> {
 
         final PagedIterable<GHCheckRun> checkRuns = (PagedIterable<GHCheckRun>) mock(PagedIterable.class);
         when(checkRuns.toList()).thenReturn(List.of());
-        when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage"))).thenReturn(checkRuns);
+        when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "Code Coverage")))
+                .thenReturn(checkRuns);
 
         final CodeCoverageProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         verify(probe).doApply(plugin, ctx);
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(
-                CodeCoverageProbe.KEY,
-                "Could not determine code coverage for the plugin.",
-                probe.getVersion()
-            ));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        CodeCoverageProbe.KEY,
+                        "Could not determine code coverage for the plugin.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContinuousDeliveryProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,9 +64,10 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "Plugin has no GitHub Action configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY, "Plugin has no GitHub Action configured.", probe.getVersion()));
     }
 
     @Test
@@ -81,9 +81,12 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY,
+                        "Could not find JEP-229 workflow definition.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -97,20 +100,22 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path cdWorkflowDef = Files.createFile(workflows.resolve("continuous-delivery.yml"));
 
-        Files.write(cdWorkflowDef, List.of(
-            "name: Probably CD",
-            "jobs:",
-            "  maven-cd:",
-            "    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v0"
-        ));
+        Files.write(
+                cdWorkflowDef,
+                List.of(
+                        "name: Probably CD",
+                        "jobs:",
+                        "  maven-cd:",
+                        "    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v0"));
 
         final ContinuousDeliveryProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", probe.getVersion()));
     }
 
     @Test
@@ -124,20 +129,22 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path cdWorkflowDef = Files.createFile(workflows.resolve("continuous-delivery.yml"));
 
-        Files.write(cdWorkflowDef, List.of(
-            "name: Probably CD",
-            "jobs:",
-            "  another-name:",
-            "    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v32"
-        ));
+        Files.write(
+                cdWorkflowDef,
+                List.of(
+                        "name: Probably CD",
+                        "jobs:",
+                        "  another-name:",
+                        "    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v32"));
 
         final ContinuousDeliveryProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", probe.getVersion()));
     }
 
     @Test
@@ -151,20 +158,24 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path cdWorkflowDef = Files.createFile(workflows.resolve("cd.yml"));
 
-        Files.write(cdWorkflowDef, List.of(
-            "name: Probably Not CD",
-            "jobs:",
-            "  another-name:",
-            "    uses: this-is-not-the-workflow-you-are-looking-for"
-        ));
+        Files.write(
+                cdWorkflowDef,
+                List.of(
+                        "name: Probably Not CD",
+                        "jobs:",
+                        "  another-name:",
+                        "    uses: this-is-not-the-workflow-you-are-looking-for"));
 
         final ContinuousDeliveryProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY,
+                        "Could not find JEP-229 workflow definition.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -178,17 +189,18 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path cdWorkflowDef = Files.createFile(workflows.resolve("cd.yml"));
 
-        Files.write(cdWorkflowDef, List.of(
-            "name: Probably Not CD"
-        ));
+        Files.write(cdWorkflowDef, List.of("name: Probably Not CD"));
 
         final ContinuousDeliveryProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY,
+                        "Could not find JEP-229 workflow definition.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -202,21 +214,25 @@ class ContinuousDeliveryProbeTest extends AbstractProbeTest<ContinuousDeliveryPr
         final Path workflows = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path cdWorkflowDef = Files.createFile(workflows.resolve("cd.yml"));
 
-        Files.write(cdWorkflowDef, List.of(
-            "name: Probably Not CD",
-            "jobs:",
-            "  build:",
-            "    runs-on: ubuntu",
-            "    steps:",
-            "      - users: foo-bar"
-        ));
+        Files.write(
+                cdWorkflowDef,
+                List.of(
+                        "name: Probably Not CD",
+                        "jobs:",
+                        "  build:",
+                        "    runs-on: ubuntu",
+                        "    steps:",
+                        "      - users: foo-bar"));
 
         final ContinuousDeliveryProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContinuousDeliveryProbe.KEY,
+                        "Could not find JEP-229 workflow definition.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,9 +65,10 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", probe.getVersion()));
     }
 
     @Test
@@ -83,9 +83,10 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
     }
 
     @Test
@@ -100,8 +101,9 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,9 +67,12 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         final DependabotProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(DependabotProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.error(
+                        DependabotProbe.KEY,
+                        "There is no local repository for plugin " + plugin.getName() + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -83,9 +85,10 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        DependabotProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -100,9 +103,10 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(
+                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -119,9 +123,9 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -138,9 +142,9 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotPullRequestProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,12 +67,14 @@ class DependabotPullRequestProbeTest extends AbstractProbeTest<DependabotPullReq
 
         final DependabotPullRequestProbe probe = getSpy();
 
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status")
-            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "", probe.getVersion()));
-        assertThat(probe.apply(plugin, ctx)).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status")
-            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "", probe.getVersion()));
+        assertThat(probe.apply(plugin, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status")
+                .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "", probe.getVersion()));
+        assertThat(probe.apply(plugin, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status")
+                .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "", probe.getVersion()));
     }
 
     @Test
@@ -96,16 +97,15 @@ class DependabotPullRequestProbeTest extends AbstractProbeTest<DependabotPullReq
         final GHPullRequest pr_1 = mock(GHPullRequest.class);
         final GHPullRequest pr_2 = mock(GHPullRequest.class);
         final GHPullRequest pr_3 = mock(GHPullRequest.class);
-        when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(
-            List.of(pr_1, pr_2, pr_3)
-        );
+        when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(List.of(pr_1, pr_2, pr_3));
 
         final DependabotPullRequestProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
-        assertThat(result).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DependabotPullRequestProbe.KEY, "0", probe.getVersion()));
+        assertThat(result)
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(DependabotPullRequestProbe.KEY, "0", probe.getVersion()));
     }
 
     @Test
@@ -132,16 +132,15 @@ class DependabotPullRequestProbeTest extends AbstractProbeTest<DependabotPullReq
         when(pr_3.getLabels()).thenReturn(List.of(dependenciesLabel));
         final GHPullRequest pr_4 = mock(GHPullRequest.class);
         final GHPullRequest pr_5 = mock(GHPullRequest.class);
-        when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(
-            List.of(pr_1, pr_2, pr_3, pr_4, pr_5)
-        );
+        when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(List.of(pr_1, pr_2, pr_3, pr_4, pr_5));
 
         final DependabotPullRequestProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
-        assertThat(result).usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DependabotPullRequestProbe.KEY, "2", probe.getVersion()));
+        assertThat(result)
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(DependabotPullRequestProbe.KEY, "2", probe.getVersion()));
     }
 
     @Test
@@ -161,8 +160,11 @@ class DependabotPullRequestProbeTest extends AbstractProbeTest<DependabotPullReq
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DependabotPullRequestProbe.KEY, "Could not count dependabot pull requests.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        DependabotPullRequestProbe.KEY,
+                        "Could not count dependabot pull requests.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DeprecatedPluginProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,17 +61,27 @@ class DeprecatedPluginProbeTest extends AbstractProbeTest<DeprecatedPluginProbe>
         final String pluginName = "foo";
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(pluginName, new Plugin(pluginName, new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList(), 0, "", "main")),
-            Map.of("bar", new Deprecation("find-the-reason-here")),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        "scm",
+                                        ZonedDateTime.now().minusDays(1),
+                                        Collections.emptyList(),
+                                        0,
+                                        "",
+                                        "main")),
+                        Map.of("bar", new Deprecation("find-the-reason-here")),
+                        Collections.emptyList()));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is NOT deprecated.", probe.getVersion()));
-
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DeprecatedPluginProbe.KEY, "This plugin is NOT deprecated.", probe.getVersion()));
     }
 
     @Test
@@ -83,16 +92,30 @@ class DeprecatedPluginProbeTest extends AbstractProbeTest<DeprecatedPluginProbe>
 
         final String pluginName = "foo";
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(pluginName, new Plugin(pluginName, new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusDays(1), Collections.emptyList(), 0, "", "main")),
-            Map.of("bar", new Deprecation("find-the-reason-here-for-plugin-bar"), pluginName, new Deprecation("this-is-the-reason")),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        "scm",
+                                        ZonedDateTime.now().minusDays(1),
+                                        Collections.emptyList(),
+                                        0,
+                                        "",
+                                        "main")),
+                        Map.of(
+                                "bar",
+                                new Deprecation("find-the-reason-here-for-plugin-bar"),
+                                pluginName,
+                                new Deprecation("this-is-the-reason")),
+                        Collections.emptyList()));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DeprecatedPluginProbe.KEY, "this-is-the-reason", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(DeprecatedPluginProbe.KEY, "this-is-the-reason", probe.getVersion()));
     }
 
     @Test
@@ -102,21 +125,30 @@ class DeprecatedPluginProbeTest extends AbstractProbeTest<DeprecatedPluginProbe>
         final String pluginName = "foo";
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new Plugin(pluginName, new VersionNumber("1.0"), "", ZonedDateTime.now(), List.of("deprecated"), 0, "2.361", "main")
-            ),
-            Map.of(),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        "",
+                                        ZonedDateTime.now(),
+                                        List.of("deprecated"),
+                                        0,
+                                        "2.361",
+                                        "main")),
+                        Map.of(),
+                        Collections.emptyList()));
 
         final DeprecatedPluginProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is marked as deprecated.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DeprecatedPluginProbe.KEY, "This plugin is marked as deprecated.", probe.getVersion()));
     }
 
     @Test
@@ -126,17 +158,14 @@ class DeprecatedPluginProbeTest extends AbstractProbeTest<DeprecatedPluginProbe>
         final String pluginName = "foo";
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), Collections.emptyList()));
 
         final DeprecatedPluginProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DeprecatedPluginProbe.KEY, "This plugin is not in update-center.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        DeprecatedPluginProbe.KEY, "This plugin is not in update-center.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DocumentationMigrationProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,22 +59,26 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn("foo");
         when(plugin.getScm()).thenReturn("this-is-fine-for-now");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(),
-            Map.of("something-else", "not-what-we-are-looking-for")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(), Map.of("something-else", "not-what-we-are-looking-for"));
 
         final DocumentationMigrationProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, "No link to documentation can be confirmed.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        DocumentationMigrationProbe.KEY,
+                        "No link to documentation can be confirmed.",
+                        probe.getVersion()));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(DocumentationMigrationProbe.KEY, "Plugin is not listed in documentation migration source.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        DocumentationMigrationProbe.KEY,
+                        "Plugin is not listed in documentation migration source.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -87,17 +90,19 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(pluginName, "https://wiki.jenkins-ci.org/DISPLAY/foo-plugin")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(pluginName, "https://wiki.jenkins-ci.org/DISPLAY/foo-plugin"));
 
         final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DocumentationMigrationProbe.KEY,
+                        "Documentation is not located in the plugin repository.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -109,17 +114,19 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin"));
 
         final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DocumentationMigrationProbe.KEY,
+                        "Documentation is located in the plugin repository.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -131,17 +138,19 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/"));
 
         final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DocumentationMigrationProbe.KEY,
+                        "Documentation is located in the plugin repository.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -153,17 +162,19 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/tree/main")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/tree/main"));
 
         final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DocumentationMigrationProbe.KEY,
+                        "Documentation is located in the plugin repository.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -175,16 +186,20 @@ class DocumentationMigrationProbeTest extends AbstractProbeTest<DocumentationMig
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/foo-plugin");
-        when(ctx.getPluginDocumentationLinks()).thenReturn(
-            Map.of(pluginName, "https://github.com/jenkinsci/foo-plugin/blob/main/this/is/documentation/README.md")
-        );
+        when(ctx.getPluginDocumentationLinks())
+                .thenReturn(Map.of(
+                        pluginName,
+                        "https://github.com/jenkinsci/foo-plugin/blob/main/this/is/documentation/README.md"));
 
         final DocumentationMigrationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        DocumentationMigrationProbe.KEY,
+                        "Documentation is located in the plugin repository.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/HasUnreleasedProductionChangesProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,13 +63,12 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         final HasUnreleasedProductionChangesProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(
-                HasUnreleasedProductionChangesProbe.KEY,
-                "There is no local repository for plugin " + pluginName + ".",
-                probe.getVersion()
-            ));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        HasUnreleasedProductionChangesProbe.KEY,
+                        "There is no local repository for plugin " + pluginName + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -84,33 +82,42 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
             final Path srcMainResources = Files.createDirectories(
-                repository.resolve("src").resolve("main").resolve("resources")
-            );
+                    repository.resolve("src").resolve("main").resolve("resources"));
             Files.createFile(srcMainResources.resolve("index.jelly"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
 
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             git.add().addFilepattern("src/main").call();
-            git.commit().setMessage("Imports production files").setSign(false).setCommitter(committer).call();
-
+            git.commit()
+                    .setMessage("Imports production files")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
         }
         final HasUnreleasedProductionChangesProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "Unreleased production modifications might exist in the plugin source code at pom.xml, src/main/resources/index.jelly", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        HasUnreleasedProductionChangesProbe.KEY,
+                        "Unreleased production modifications might exist in the plugin source code at pom.xml, src/main/resources/index.jelly",
+                        probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -128,38 +135,43 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
 
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
             Files.createFile(module.resolve("pom.xml"));
             final Path srcMainResources = Files.createDirectories(
-                module.resolve("src").resolve("main").resolve("resources")
-            );
+                    module.resolve("src").resolve("main").resolve("resources"));
             Files.createFile(srcMainResources.resolve("index.jelly"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
 
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             git.add().addFilepattern("test-folder").call();
-            git.commit().setMessage("Imports module files").setSign(false).setCommitter(committer).call();
-
+            git.commit()
+                    .setMessage("Imports module files")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
         }
         final HasUnreleasedProductionChangesProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(
-                HasUnreleasedProductionChangesProbe.KEY,
-                "Unreleased production modifications might exist in the plugin source code at pom.xml, test-folder/pom.xml, test-folder/src/main/resources/index.jelly",
-                probe.getVersion()
-            ));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        HasUnreleasedProductionChangesProbe.KEY,
+                        "Unreleased production modifications might exist in the plugin source code at pom.xml, test-folder/pom.xml, test-folder/src/main/resources/index.jelly",
+                        probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -176,26 +188,33 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
 
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
         }
 
         final HasUnreleasedProductionChangesProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "All production modifications were released.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        HasUnreleasedProductionChangesProbe.KEY,
+                        "All production modifications were released.",
+                        probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -210,25 +229,32 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("README.md"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
 
             git.add().addFilepattern("README.md").call();
-            git.commit().setMessage("Updated README.md file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Updated README.md file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
 
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "status", "message")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "All production modifications were released.", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "status", "message")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "All production modifications were released.",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -244,27 +270,34 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
-            final Path srcMainResources = Files.createDirectories(repository.resolve("src").resolve("main")
-                .resolve("resources"));
+            final Path srcMainResources = Files.createDirectories(
+                    repository.resolve("src").resolve("main").resolve("resources"));
             Files.createFile(srcMainResources.resolve("test.txt"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
 
             git.add().addFilepattern("src/main").call();
-            git.commit().setMessage("Imports production files").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports production files")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
 
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "All production modifications were released.", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "All production modifications were released.",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -282,25 +315,32 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(7).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(7).toInstant()));
 
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
 
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "Unreleased production modifications might exist in the plugin source code at pom.xml", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at pom.xml",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -316,28 +356,34 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             final Path srcMainResources = Files.createDirectories(
-                repository.resolve("src").resolve("main").resolve("resources")
-            );
+                    repository.resolve("src").resolve("main").resolve("resources"));
             Files.createFile(srcMainResources.resolve("index.jelly"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
 
             git.add().addFilepattern("src/main").call();
-            git.commit().setMessage("Imports production files").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports production files")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
 
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "Unreleased production modifications might exist in the plugin source code at src/main/resources/index.jelly", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at src/main/resources/index.jelly",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -353,25 +399,32 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("README.md"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().minusHours(1).toInstant()));
 
             git.add().addFilepattern("README.md").call();
-            git.commit().setMessage("Updated README.md file").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Updated README.md file")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
 
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "status", "message")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "All production modifications were released.", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "status", "message")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "All production modifications were released.",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -387,26 +440,34 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getScm()).thenReturn(scmLink);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
-            final Path srcTestJava = Files.createDirectories(repository.resolve("src").resolve("test").resolve("java"));
+            final Path srcTestJava = Files.createDirectories(
+                    repository.resolve("src").resolve("test").resolve("java"));
             Files.createFile(srcTestJava.resolve("TestA.java"));
 
-            PersonIdent committer = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(1).toInstant()));
 
             git.add().addFilepattern("src/test").call();
-            git.commit().setMessage("Import test").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Import test")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
             final ProbeResult result = probe.apply(plugin, ctx);
 
             assertThat(result)
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "status", "message")
-                .isEqualTo(ProbeResult.success(HasUnreleasedProductionChangesProbe.KEY, "All production modifications were released.", probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "status", "message")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "All production modifications were released.",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -424,36 +485,54 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
-            PersonIdent committer = new PersonIdent(defaultCommitter, plugin.getReleaseTimestamp().minusHours(3).toInstant().getEpochSecond(), 0);
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    plugin.getReleaseTimestamp().minusHours(3).toInstant().getEpochSecond(),
+                    0);
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file before commit date").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file before commit date")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
-            final Path srcMainJava = Files.createDirectories(repository.resolve("src").resolve("main").resolve("java"));
+            final Path srcMainJava = Files.createDirectories(
+                    repository.resolve("src").resolve("main").resolve("java"));
             Files.createFile(srcMainJava.resolve("Hello.java"));
-            PersonIdent committer2 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(3).toInstant()));
+            PersonIdent committer2 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(3).toInstant()));
             git.add().addFilepattern("src/main").call();
-            git.commit().setMessage("Import main after commit  date").setSign(false).setCommitter(committer2).call();
+            git.commit()
+                    .setMessage("Import main after commit  date")
+                    .setSign(false)
+                    .setCommitter(committer2)
+                    .call();
 
             Files.createFile(repository.resolve("README.md"));
-            PersonIdent committer3 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusHours(3).toInstant()));
+            PersonIdent committer3 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusHours(3).toInstant()));
             git.add().addFilepattern("README.md").call();
-            git.commit().setMessage("Updated README.md file after commit date").setSign(false).setCommitter(committer3).call();
+            git.commit()
+                    .setMessage("Updated README.md file after commit date")
+                    .setSign(false)
+                    .setCommitter(committer3)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(
-                    HasUnreleasedProductionChangesProbe.KEY,
-                    "Unreleased production modifications might exist in the plugin source code at src/main/java/Hello.java",
-                    probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at src/main/java/Hello.java",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -471,33 +550,46 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
-            PersonIdent committer = new PersonIdent(defaultCommitter, plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(), 0);
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(),
+                    0);
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file before commit date").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file before commit date")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
-            final Path srcMainJava = Files.createDirectories(repository.resolve("src").resolve("main").resolve("java"));
+            final Path srcMainJava = Files.createDirectories(
+                    repository.resolve("src").resolve("main").resolve("java"));
             Files.createFile(srcMainJava.resolve("Hello.java"));
-            final Path srcTestJava = Files.createDirectories(repository.resolve("src").resolve("test").resolve("java"));
+            final Path srcTestJava = Files.createDirectories(
+                    repository.resolve("src").resolve("test").resolve("java"));
             Files.createFile(srcTestJava.resolve("HelloTest.java"));
-            PersonIdent committer2 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
+            PersonIdent committer2 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
             git.add().addFilepattern("src").call();
-            git.commit().setMessage("Import class and test like for a bugfix").setSign(false).setCommitter(committer2).call();
+            git.commit()
+                    .setMessage("Import class and test like for a bugfix")
+                    .setSign(false)
+                    .setCommitter(committer2)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(
-                    HasUnreleasedProductionChangesProbe.KEY,
-                    "Unreleased production modifications might exist in the plugin source code at src/main/java/Hello.java",
-                    probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at src/main/java/Hello.java",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
@@ -515,44 +607,64 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("pom.xml"));
-            PersonIdent committer = new PersonIdent(defaultCommitter, plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(), 0);
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(),
+                    0);
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file before commit date").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file before commit date")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
-            final Path srcMainJava = Files.createDirectories(repository.resolve("src").resolve("main").resolve("java"));
+            final Path srcMainJava = Files.createDirectories(
+                    repository.resolve("src").resolve("main").resolve("java"));
             Files.createFile(srcMainJava.resolve("Hello.java"));
-            final Path srcTestJava = Files.createDirectories(repository.resolve("src").resolve("test").resolve("java"));
+            final Path srcTestJava = Files.createDirectories(
+                    repository.resolve("src").resolve("test").resolve("java"));
             Files.createFile(srcTestJava.resolve("HelloTest.java"));
-            PersonIdent committer2 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
+            PersonIdent committer2 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
             git.add().addFilepattern("src").call();
-            git.commit().setMessage("Import class and test like for a bugfix").setSign(false).setCommitter(committer2).call();
+            git.commit()
+                    .setMessage("Import class and test like for a bugfix")
+                    .setSign(false)
+                    .setCommitter(committer2)
+                    .call();
 
             Files.createFile(srcMainJava.resolve("AnotherClass.java"));
-            PersonIdent committer3 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(5).toInstant()));
+            PersonIdent committer3 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(5).toInstant()));
             git.add().addFilepattern("src").call();
-            git.commit().setMessage("New class for new feature").setSign(false).setCommitter(committer3).call();
+            git.commit()
+                    .setMessage("New class for new feature")
+                    .setSign(false)
+                    .setCommitter(committer3)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(
-                    HasUnreleasedProductionChangesProbe.KEY,
-                    "Unreleased production modifications might exist in the plugin source code at src/main/java/AnotherClass.java, src/main/java/Hello.java",
-                    probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at src/main/java/AnotherClass.java, src/main/java/Hello.java",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }
 
     @Test
-    void shouldBeAbleToDisplayProductionFilesInDifferentCommitsWithIntermediateCommits() throws IOException, GitAPIException {
+    void shouldBeAbleToDisplayProductionFilesInDifferentCommitsWithIntermediateCommits()
+            throws IOException, GitAPIException {
         final Path repository = Files.createTempDirectory("test-foo-bar");
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
@@ -564,48 +676,79 @@ class HasUnreleasedProductionChangesProbeTest extends AbstractProbeTest<HasUnrel
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getScm()).thenReturn(scmLink);
 
-        final PersonIdent defaultCommitter = new PersonIdent(
-            "Not real person", "this is not a real email"
-        );
+        final PersonIdent defaultCommitter = new PersonIdent("Not real person", "this is not a real email");
 
         try (Git git = Git.init().setDirectory(repository.toFile()).call()) {
 
             Files.createFile(repository.resolve("LICENSE"));
-            PersonIdent committer0 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(4).toInstant()));
+            PersonIdent committer0 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(4).toInstant()));
             git.add().addFilepattern("LICENSE").call();
-            git.commit().setMessage("Import license file").setSign(false).setCommitter(committer0).call();
+            git.commit()
+                    .setMessage("Import license file")
+                    .setSign(false)
+                    .setCommitter(committer0)
+                    .call();
 
             Files.createFile(repository.resolve("pom.xml"));
-            PersonIdent committer = new PersonIdent(defaultCommitter, plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(), 0);
+            PersonIdent committer = new PersonIdent(
+                    defaultCommitter,
+                    plugin.getReleaseTimestamp().minusDays(3).toInstant().getEpochSecond(),
+                    0);
             git.add().addFilepattern("pom.xml").call();
-            git.commit().setMessage("Imports pom.xml file before commit date").setSign(false).setCommitter(committer).call();
+            git.commit()
+                    .setMessage("Imports pom.xml file before commit date")
+                    .setSign(false)
+                    .setCommitter(committer)
+                    .call();
 
-            final Path srcMainJava = Files.createDirectories(repository.resolve("src").resolve("main").resolve("java"));
+            final Path srcMainJava = Files.createDirectories(
+                    repository.resolve("src").resolve("main").resolve("java"));
             Files.createFile(srcMainJava.resolve("Hello.java"));
-            final Path srcTestJava = Files.createDirectories(repository.resolve("src").resolve("test").resolve("java"));
+            final Path srcTestJava = Files.createDirectories(
+                    repository.resolve("src").resolve("test").resolve("java"));
             Files.createFile(srcTestJava.resolve("HelloTest.java"));
-            PersonIdent committer2 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
+            PersonIdent committer2 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(3).toInstant()));
             git.add().addFilepattern("src").call();
-            git.commit().setMessage("Import class and test like for a bugfix").setSign(false).setCommitter(committer2).call();
+            git.commit()
+                    .setMessage("Import class and test like for a bugfix")
+                    .setSign(false)
+                    .setCommitter(committer2)
+                    .call();
 
             Files.createFile(repository.resolve("README.adoc"));
-            PersonIdent committer3 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(4).toInstant()));
+            PersonIdent committer3 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(4).toInstant()));
             git.add().addFilepattern("README.adoc").call();
-            git.commit().setMessage("Import readme file").setSign(false).setCommitter(committer3).call();
+            git.commit()
+                    .setMessage("Import readme file")
+                    .setSign(false)
+                    .setCommitter(committer3)
+                    .call();
 
             Files.createFile(srcMainJava.resolve("AnotherClass.java"));
-            PersonIdent committer4 = new PersonIdent(defaultCommitter, Date.from(plugin.getReleaseTimestamp().plusDays(5).toInstant()));
+            PersonIdent committer4 = new PersonIdent(
+                    defaultCommitter,
+                    Date.from(plugin.getReleaseTimestamp().plusDays(5).toInstant()));
             git.add().addFilepattern("src").call();
-            git.commit().setMessage("New class for new feature").setSign(false).setCommitter(committer4).call();
+            git.commit()
+                    .setMessage("New class for new feature")
+                    .setSign(false)
+                    .setCommitter(committer4)
+                    .call();
 
             final HasUnreleasedProductionChangesProbe probe = getSpy();
             assertThat(probe.apply(plugin, ctx))
-                .usingRecursiveComparison()
-                .comparingOnlyFields("id", "message", "status")
-                .isEqualTo(ProbeResult.success(
-                    HasUnreleasedProductionChangesProbe.KEY,
-                    "Unreleased production modifications might exist in the plugin source code at src/main/java/AnotherClass.java, src/main/java/Hello.java",
-                    probe.getVersion()));
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(
+                            HasUnreleasedProductionChangesProbe.KEY,
+                            "Unreleased production modifications might exist in the plugin source code at src/main/java/AnotherClass.java, src/main/java/Hello.java",
+                            probe.getVersion()));
             verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
         }
     }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/IncrementalBuildDetectionProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/IncrementalBuildDetectionProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,89 +57,129 @@ public class IncrementalBuildDetectionProbeTest extends AbstractProbeTest<Increm
 
     @Test
     void shouldReturnASuccessfulCheckWhenIncrementalBuildConfiguredInBothFiles() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-correct-configuration")));
+        when(ctx.getScmRepository())
+                .thenReturn(
+                        Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-correct-configuration")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldReturnFailureWhenIncrementalBuildIsConfiguredOnlyInExtensionsXML() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-missing-maven-config-file")));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(
+                        Path.of("src/test/resources/jenkinsci/plugin-repo-with-missing-maven-config-file")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldReturnFailureWhenIncrementalBuildIsConfiguredOnlyInMavenConfig() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-missing-extensions-file")));
+        when(ctx.getScmRepository())
+                .thenReturn(
+                        Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-missing-extensions-file")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldFailWhenIncrementalBuildIsIncorrectlyConfiguredInBothFiles() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/plugin-repo-with-incorrect-configuration-lines-in-both-files")));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(Path.of(
+                        "src/test/resources/jenkinsci/plugin-repo-with-incorrect-configuration-lines-in-both-files")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldFailWhenIncrementalBuildIsIncorrectlyConfiguredInExtensionsXML() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-plugin-incorrect-extensions-configuration")));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(
+                        Path.of("src/test/resources/jenkinsci/test-plugin-incorrect-extensions-configuration")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldFailWhenIncrementalBuildLinesAreIncorrectInMavenConfig() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-plugin-incorrect-maven-configuration")));
+        when(ctx.getScmRepository())
+                .thenReturn(
+                        Optional.of(Path.of("src/test/resources/jenkinsci/test-plugin-incorrect-maven-configuration")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldFailWhenIncrementalBuildLinesAreMissingInMavenConfig() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-plugin-with-missing-lines-maven-configuration")));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(
+                        Path.of("src/test/resources/jenkinsci/test-plugin-with-missing-lines-maven-configuration")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(IncrementalBuildDetectionProbe.KEY, "Incremental Build is not configured in the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Incremental Build is not configured in the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 
     @Test
     void shouldFailWhenMavenFolderIsNotFound() {
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-repo-without-mvn-should-not-be-found")));
+        when(ctx.getScmRepository())
+                .thenReturn(
+                        Optional.of(Path.of("src/test/resources/jenkinsci/test-repo-without-mvn-should-not-be-found")));
         when(plugin.getName()).thenReturn("foo");
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(IncrementalBuildDetectionProbe.KEY, "Could not find Maven configuration folder for the foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.error(
+                        IncrementalBuildDetectionProbe.KEY,
+                        "Could not find Maven configuration folder for the foo plugin.",
+                        probe.getVersion()));
         verify(probe).doApply(plugin, ctx);
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/InstallationStatProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,17 +61,16 @@ class InstallationStatProbeTest extends AbstractProbeTest<InstallationStatProbe>
 
         final String pluginName = "foo";
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), List.of()));
 
         final InstallationStatProbe probe = spy(InstallationStatProbe.class);
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(InstallationStatProbe.KEY, "Could not find plugin " + pluginName + " in Update Center.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        InstallationStatProbe.KEY,
+                        "Could not find plugin " + pluginName + " in Update Center.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -83,14 +81,14 @@ class InstallationStatProbeTest extends AbstractProbeTest<InstallationStatProbe>
 
         final String pluginName = "plugin";
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName,
-                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(pluginName, null, null, null, List.of(), 100, "", "main")
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName, null, null, null, List.of(), 100, "", "main")),
+                        Map.of(),
+                        List.of()));
 
         final ProbeResult result = probe.apply(plugin, ctx);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JSR305ProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JSR305ProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,50 +65,46 @@ public class JSR305ProbeTest extends AbstractProbeTest<JSR305Probe> {
         Path directory = Files.createDirectories(repo.resolve("src/main/java"));
         final Path javaFileWithAllDeprecatedAnnotation = Files.createFile(directory.resolve("test-class-1.java"));
         final Path javaFileWithNonnullDeprecatedAnnotation = Files.createFile(directory.resolve("test-class-2.java"));
-        final Path javaFileWithCheckForNullDeprecatedAnnotation = Files.createFile(directory.resolve("test-class-3.java"));
+        final Path javaFileWithCheckForNullDeprecatedAnnotation =
+                Files.createFile(directory.resolve("test-class-3.java"));
         final Path javaFileWithNoDeprecatedAnnotation = Files.createFile(directory.resolve("test-class-4.java"));
         final Path txtFileShouldNotBeFound = Files.createFile(directory.resolve("file.txt"));
         Files.createFile(directory.resolve("test-dummy-class-should-not-be-returned.java"));
 
-        Files.write(javaFileWithAllDeprecatedAnnotation, List.of(
-            "package test;",
-            "",
-            "import javax.annotation.Nonnull;",
-            "import javax.annotation.CheckForNull;",
-            "",
-            "import java.util.HashMap;",
-            "import java.util.Map;"
-        ));
+        Files.write(
+                javaFileWithAllDeprecatedAnnotation,
+                List.of(
+                        "package test;",
+                        "",
+                        "import javax.annotation.Nonnull;",
+                        "import javax.annotation.CheckForNull;",
+                        "",
+                        "import java.util.HashMap;",
+                        "import java.util.Map;"));
 
-        Files.write(javaFileWithNonnullDeprecatedAnnotation, List.of(
-            "package test;",
-            "",
-            "import javax.annotation.Nonnull;"
-        ));
+        Files.write(
+                javaFileWithNonnullDeprecatedAnnotation,
+                List.of("package test;", "", "import javax.annotation.Nonnull;"));
 
-        Files.write(javaFileWithCheckForNullDeprecatedAnnotation, List.of(
-            "package test;",
-            "",
-            "import javax.annotation.CheckForNull;"
-        ));
+        Files.write(
+                javaFileWithCheckForNullDeprecatedAnnotation,
+                List.of("package test;", "", "import javax.annotation.CheckForNull;"));
 
-        Files.write(javaFileWithNoDeprecatedAnnotation, List.of(
-            "package test;"
-        ));
+        Files.write(javaFileWithNoDeprecatedAnnotation, List.of("package test;"));
 
-        Files.write(txtFileShouldNotBeFound, List.of(
-            "This-file-should-not-returned."
-        ));
+        Files.write(txtFileShouldNotBeFound, List.of("This-file-should-not-returned."));
 
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
         when(plugin.getName()).thenReturn("foo");
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(JSR305Probe.KEY, "Deprecated imports found at foo plugin for test-class-1.java, test-class-2.java, test-class-3.java", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        JSR305Probe.KEY,
+                        "Deprecated imports found at foo plugin for test-class-1.java, test-class-2.java, test-class-3.java",
+                        probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
-
     }
 
     @Test
@@ -119,23 +114,25 @@ public class JSR305ProbeTest extends AbstractProbeTest<JSR305Probe> {
         final Path javaFileWithUpdatedAnnotation = Files.createFile(directory.resolve("test-class-3.java"));
         Files.createFile(directory.resolve("test-dummy-class-should-not-be-returned.java"));
 
-        Files.write(javaFileWithUpdatedAnnotation, List.of(
-            "package test;",
-            "",
-            "import edu.umd.cs.findbugs.annotations.NonNull;",
-            "import edu.umd.cs.findbugs.annotations.CheckForNull;",
-            "",
-            "import java.util.HashMap;",
-            "import java.util.Map;"
-        ));
+        Files.write(
+                javaFileWithUpdatedAnnotation,
+                List.of(
+                        "package test;",
+                        "",
+                        "import edu.umd.cs.findbugs.annotations.NonNull;",
+                        "import edu.umd.cs.findbugs.annotations.CheckForNull;",
+                        "",
+                        "import java.util.HashMap;",
+                        "import java.util.Map;"));
 
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
         when(plugin.getName()).thenReturn("foo");
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(JSR305Probe.KEY, "Latest version of imports found at foo plugin.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        JSR305Probe.KEY, "Latest version of imports found at foo plugin.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsCoreProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,19 +60,19 @@ class JenkinsCoreProbeTest extends AbstractProbeTest<JenkinsCoreProbe> {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), List.of()));
 
         final JenkinsCoreProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(JenkinsCoreProbe.KEY, "Could not find plugin " + pluginName + " in Update Center.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        JenkinsCoreProbe.KEY,
+                        "Could not find plugin " + pluginName + " in Update Center.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -83,25 +82,23 @@ class JenkinsCoreProbeTest extends AbstractProbeTest<JenkinsCoreProbe> {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName,
-                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, null, null, null, List.of(), 0, "2.361.1", "main"
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName, null, null, null, List.of(), 0, "2.361.1", "main")),
+                        Map.of(),
+                        List.of()));
 
         final JenkinsCoreProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result).isNotNull();
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(JenkinsCoreProbe.KEY, "2.361.1", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(JenkinsCoreProbe.KEY, "2.361.1", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/JenkinsfileProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,10 +65,13 @@ class JenkinsfileProbeTest extends AbstractProbeTest<JenkinsfileProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.empty());
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(JenkinsfileProbe.KEY, "There is no local repository for plugin " + pluginName + ".", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        JenkinsfileProbe.KEY,
+                        "There is no local repository for plugin " + pluginName + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -82,10 +84,10 @@ class JenkinsfileProbeTest extends AbstractProbeTest<JenkinsfileProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", probe.getVersion()));
     }
 
     @Test
@@ -99,9 +101,9 @@ class JenkinsfileProbeTest extends AbstractProbeTest<JenkinsfileProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,47 +59,42 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
         final ProbeContext ctx = mock(ProbeContext.class);
         final KnownSecurityVulnerabilityProbe probe = getSpy();
 
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                Collections.emptyList()
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList()));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
     }
 
     @Test
     void shouldBeOKWithWarningOnDifferentPlugin() {
         final String pluginName = "foo-bar";
         final VersionNumber pluginVersion = new VersionNumber("1.0");
-        final var pluginInUC = new Plugin(pluginName, pluginVersion, "scm", ZonedDateTime.now().minusHours(1), List.of(), 0, "", "main");
+        final var pluginInUC = new Plugin(
+                pluginName, pluginVersion, "scm", ZonedDateTime.now().minusHours(1), List.of(), 0, "", "main");
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final KnownSecurityVulnerabilityProbe probe = getSpy();
 
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Map.of(pluginName, pluginInUC),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning("SECURITY-1", "wiz", List.of(new SecurityWarningVersion(null, ".*")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(pluginName, pluginInUC),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                "SECURITY-1", "wiz", List.of(new SecurityWarningVersion(null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
     }
 
     @Test
@@ -114,24 +108,22 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning("SECURITY-1", pluginName, List.of(
-                        new SecurityWarningVersion(new VersionNumber("1.0"), "0\\.*")
-                    ))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                "SECURITY-1",
+                                pluginName,
+                                List.of(new SecurityWarningVersion(new VersionNumber("1.0"), "0\\.*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
     }
 
     @Test
@@ -146,22 +138,19 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning(warningId, pluginName, List.of(new SecurityWarningVersion(pluginVersion, "1.0")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId, pluginName, List.of(new SecurityWarningVersion(pluginVersion, "1.0"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId, probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId, probe.getVersion()));
     }
 
     @Test
@@ -176,22 +165,19 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning(warningId, pluginName, List.of(new SecurityWarningVersion(null, ".*")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId, pluginName, List.of(new SecurityWarningVersion(null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId, probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId, probe.getVersion()));
     }
 
     @Test
@@ -207,23 +193,25 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning(warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
-                    new SecurityWarning(warningId2, pluginName, List.of(new SecurityWarningVersion(null, ".*")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(
+                                new SecurityWarning(
+                                        warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
+                                new SecurityWarning(
+                                        warningId2, pluginName, List.of(new SecurityWarningVersion(null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "%s, %s".formatted(warningId1, warningId2), probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY,
+                        "%s, %s".formatted(warningId1, warningId2),
+                        probe.getVersion()));
     }
 
     @Test
@@ -239,23 +227,24 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning(warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
-                    new SecurityWarning(warningId2, pluginName, List.of(new SecurityWarningVersion(new VersionNumber("1.1"), ".*")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(
+                                new SecurityWarning(
+                                        warningId1, pluginName, List.of(new SecurityWarningVersion(null, ".*"))),
+                                new SecurityWarning(
+                                        warningId2,
+                                        pluginName,
+                                        List.of(new SecurityWarningVersion(new VersionNumber("1.1"), ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId1, probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, warningId1, probe.getVersion()));
     }
 
     @Test
@@ -269,21 +258,19 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
         when(plugin.getName()).thenReturn(pluginName);
         when(plugin.getVersion()).thenReturn(pluginVersion);
-        when(ctx.getUpdateCenter()).thenReturn(
-            new UpdateCenter(
-                Collections.emptyMap(),
-                Collections.emptyMap(),
-                List.of(
-                    new SecurityWarning("SECURITY-1", pluginName, List.of(new SecurityWarningVersion(null, "[0-1]\\..*")))
-                )
-            )
-        );
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                "SECURITY-1", pluginName, List.of(new SecurityWarningVersion(null, "[0-1]\\..*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,9 +57,10 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(PluginDescriptionMigrationProbe.KEY, "Cannot access plugin repository.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(
+                        ProbeResult.error(PluginDescriptionMigrationProbe.KEY, "Cannot access plugin repository.", 0));
     }
 
     @Test
@@ -75,9 +75,10 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(PluginDescriptionMigrationProbe.KEY, "Cannot browse plugin source code folder.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.error(
+                        PluginDescriptionMigrationProbe.KEY, "Cannot browse plugin source code folder.", 0));
     }
 
     @Test
@@ -93,9 +94,12 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "There is no `index.jelly` file in `src/main/resources`.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        PluginDescriptionMigrationProbe.KEY,
+                        "There is no `index.jelly` file in `src/main/resources`.",
+                        0));
     }
 
     @Test
@@ -104,7 +108,8 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeContext ctx = mock(ProbeContext.class);
 
         final Path repository = Files.createTempDirectory(getClass().getSimpleName());
-        final Path resources = Files.createDirectories(repository.resolve("src").resolve("main").resolve("resources"));
+        final Path resources = Files.createDirectories(
+                repository.resolve("src").resolve("main").resolve("resources"));
         final Path jelly = Files.createFile(resources.resolve("index.jelly"));
         Files.writeString(jelly, """
             <div>
@@ -117,9 +122,12 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        PluginDescriptionMigrationProbe.KEY,
+                        "Plugin is using description from the plugin archetype.",
+                        0));
     }
 
     @Test
@@ -129,7 +137,8 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
 
         final Path repository = Files.createTempDirectory(getClass().getSimpleName());
         final Path module = Files.createDirectory(repository.resolve("plugin"));
-        final Path resources = Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
+        final Path resources =
+                Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
         final Path jelly = Files.createFile(resources.resolve("index.jelly"));
         Files.writeString(jelly, """
             <div>
@@ -143,9 +152,12 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        PluginDescriptionMigrationProbe.KEY,
+                        "Plugin is using description from the plugin archetype.",
+                        0));
     }
 
     @Test
@@ -154,9 +166,12 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeContext ctx = mock(ProbeContext.class);
 
         final Path repository = Files.createTempDirectory(getClass().getSimpleName());
-        final Path resources = Files.createDirectories(repository.resolve("src").resolve("main").resolve("resources"));
+        final Path resources = Files.createDirectories(
+                repository.resolve("src").resolve("main").resolve("resources"));
         final Path jelly = Files.createFile(resources.resolve("index.jelly"));
-        Files.writeString(jelly, """
+        Files.writeString(
+                jelly,
+                """
             <div>
                 This is a plugin doing something.
             </div>
@@ -167,9 +182,10 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
     }
 
     @Test
@@ -179,9 +195,12 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
 
         final Path repository = Files.createTempDirectory(getClass().getSimpleName());
         final Path module = Files.createDirectory(repository.resolve("plugin"));
-        final Path resources = Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
+        final Path resources =
+                Files.createDirectories(module.resolve("src").resolve("main").resolve("resources"));
         final Path jelly = Files.createFile(resources.resolve("index.jelly"));
-        Files.writeString(jelly, """
+        Files.writeString(
+                jelly,
+                """
             <div>
                 This is a plugin doing something.
             </div>
@@ -193,8 +212,9 @@ public class PluginDescriptionMigrationProbeTest extends AbstractProbeTest<Plugi
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 0));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/PullRequestProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,9 +68,12 @@ class PullRequestProbeTest extends AbstractProbeTest<PullRequestProbe> {
 
         final PullRequestProbe probe = getSpy();
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(PullRequestProbe.KEY, "Plugin SCM is unknown, cannot fetch the number of open pull requests.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        PullRequestProbe.KEY,
+                        "Plugin SCM is unknown, cannot fetch the number of open pull requests.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -86,11 +88,8 @@ class PullRequestProbeTest extends AbstractProbeTest<PullRequestProbe> {
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/mailer-plugin");
         when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/mailer-plugin"));
         when(gh.getRepository(anyString())).thenReturn(ghRepository);
-        final List<GHPullRequest> ghPullRequests = List.of(
-            new GHPullRequest(),
-            new GHPullRequest(),
-            new GHPullRequest()
-        );
+        final List<GHPullRequest> ghPullRequests =
+                List.of(new GHPullRequest(), new GHPullRequest(), new GHPullRequest());
         when(ghRepository.getPullRequests(GHIssueState.OPEN)).thenReturn(ghPullRequests);
 
         final PullRequestProbe probe = getSpy();
@@ -100,9 +99,10 @@ class PullRequestProbeTest extends AbstractProbeTest<PullRequestProbe> {
         verify(gh.getRepository(anyString())).getPullRequests(GHIssueState.OPEN);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(PullRequestProbe.KEY, "%d".formatted(ghPullRequests.size()), probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        PullRequestProbe.KEY, "%d".formatted(ghPullRequests.size()), probe.getVersion()));
     }
 
     @Test
@@ -123,8 +123,9 @@ class PullRequestProbeTest extends AbstractProbeTest<PullRequestProbe> {
         verify(ctx).getGitHub();
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(PullRequestProbe.KEY, "Cannot access repository " + plugin.getScm(), probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        PullRequestProbe.KEY, "Cannot access repository " + plugin.getScm(), probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ReleaseDrafterProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +61,12 @@ class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
         final ReleaseDrafterProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(ReleaseDrafterProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.error(
+                        ReleaseDrafterProbe.KEY,
+                        "There is no local repository for plugin " + plugin.getName() + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -77,9 +79,10 @@ class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        ReleaseDrafterProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -94,9 +97,10 @@ class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is not configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        ReleaseDrafterProbe.KEY, "Release Drafter is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -113,9 +117,10 @@ class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -132,9 +137,10 @@ class ReleaseDrafterProbeTest extends AbstractProbeTest<ReleaseDrafterProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        ReleaseDrafterProbe.KEY, "Release Drafter is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,10 +63,13 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
 
         final RenovateProbe probe = getSpy();
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(RenovateProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        RenovateProbe.KEY,
+                        "There is no local repository for plugin " + plugin.getName() + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -80,9 +82,10 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(
+                        RenovateProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
     }
 
     @Test
@@ -96,9 +99,9 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", probe.getVersion()));
     }
 
     @Test
@@ -114,8 +117,8 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,22 +57,22 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(plugin.getScm()).thenReturn(
-            null, ""
-        );
+        when(plugin.getScm()).thenReturn(null, "");
         final SCMLinkValidationProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SCMLinkValidationProbe.KEY, "The plugin SCM link is empty.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        SCMLinkValidationProbe.KEY, "The plugin SCM link is empty.", probe.getVersion()));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SCMLinkValidationProbe.KEY, "The plugin SCM link is empty.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        SCMLinkValidationProbe.KEY, "The plugin SCM link is empty.", probe.getVersion()));
     }
 
     @Test
@@ -85,10 +84,13 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(plugin.getScm()).thenReturn("this-is-not-correct");
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SCMLinkValidationProbe.KEY, "SCM link doesn't match GitHub plugin repositories.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        SCMLinkValidationProbe.KEY,
+                        "SCM link doesn't match GitHub plugin repositories.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -100,19 +102,20 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
 
         when(plugin.getName()).thenReturn("test-repo");
         when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
-        when(ctx.getScmRepository()).thenReturn(Optional.of(
-            Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2")
-        ));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(
+                        Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1/test-nested-dir-2")));
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository(repositoryName)).thenReturn(new GHRepository());
 
         final SCMLinkValidationProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SCMLinkValidationProbe.KEY, "The plugin SCM link is valid.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SCMLinkValidationProbe.KEY, "The plugin SCM link is valid.", probe.getVersion()));
     }
 
     @Test
@@ -132,10 +135,10 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final SCMLinkValidationProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success("scm", "The plugin SCM link is invalid.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success("scm", "The plugin SCM link is invalid.", probe.getVersion()));
     }
 
     @Test
@@ -149,9 +152,8 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/this-is-fine");
         when(plugin.getName()).thenReturn("test-repo");
 
-        when(ctx.getScmRepository()).thenReturn(Optional.of(
-            Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1")
-        ));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1")));
         when(ctx.getGitHub()).thenReturn(gh);
         when(gh.getRepository("jenkinsci/this-is-fine")).thenReturn(ghRepo);
 
@@ -159,9 +161,9 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(probe.key(), "The plugin SCM link is valid.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(probe.key(), "The plugin SCM link is valid.", probe.getVersion()));
 
         verify(ctx).setScmFolderPath(Path.of("test-nested-dir-2"));
     }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SecurityScanProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SecurityScanProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,10 +63,11 @@ class SecurityScanProbeTest extends AbstractProbeTest<SecurityScanProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SecurityScanProbe.KEY, "Plugin has no GitHub Action configured.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SecurityScanProbe.KEY, "Plugin has no GitHub Action configured.", probe.getVersion()));
     }
 
     @Test
@@ -77,10 +77,13 @@ class SecurityScanProbeTest extends AbstractProbeTest<SecurityScanProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SecurityScanProbe.KEY, "GitHub workflow security scan is not configured in the plugin.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SecurityScanProbe.KEY,
+                        "GitHub workflow security scan is not configured in the plugin.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -89,19 +92,23 @@ class SecurityScanProbeTest extends AbstractProbeTest<SecurityScanProbe> {
         Path workflowPath = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path workflowFile = Files.createFile(workflowPath.resolve("jenkins-security-scan.yaml"));
 
-        Files.write(workflowFile, List.of(
-            "name: Test Security Scan Job",
-            "jobs:",
-            "  security-scan-name:",
-            "    uses: this-is-not-the-workflow-we-are-looking-for"
-        ));
+        Files.write(
+                workflowFile,
+                List.of(
+                        "name: Test Security Scan Job",
+                        "jobs:",
+                        "  security-scan-name:",
+                        "    uses: this-is-not-the-workflow-we-are-looking-for"));
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SecurityScanProbe.KEY, "GitHub workflow security scan is not configured in the plugin.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SecurityScanProbe.KEY,
+                        "GitHub workflow security scan is not configured in the plugin.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -110,19 +117,23 @@ class SecurityScanProbeTest extends AbstractProbeTest<SecurityScanProbe> {
         Path workflowPath = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path workflowFile = Files.createFile(workflowPath.resolve("jenkins-security-scan.yaml"));
 
-        Files.write(workflowFile, List.of(
-            "name: Test Security Scan Job",
-            "jobs:",
-            "  this-is-a-valid-security-scan:",
-            "    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml"
-        ));
+        Files.write(
+                workflowFile,
+                List.of(
+                        "name: Test Security Scan Job",
+                        "jobs:",
+                        "  this-is-a-valid-security-scan:",
+                        "    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml"));
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SecurityScanProbe.KEY, "GitHub workflow security scan is configured in the plugin.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SecurityScanProbe.KEY,
+                        "GitHub workflow security scan is configured in the plugin.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -131,18 +142,22 @@ class SecurityScanProbeTest extends AbstractProbeTest<SecurityScanProbe> {
         Path workflowPath = Files.createDirectories(repo.resolve(".github/workflows"));
         final Path workflowFile = Files.createFile(workflowPath.resolve("jenkins-security-scan.yaml"));
 
-        Files.write(workflowFile, List.of(
-            "name: Test Security Scan Job",
-            "jobs:",
-            "  security-scan:",
-            "    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v42"
-        ));
+        Files.write(
+                workflowFile,
+                List.of(
+                        "name: Test Security Scan Job",
+                        "jobs:",
+                        "  security-scan:",
+                        "    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v42"));
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SecurityScanProbe.KEY, "GitHub workflow security scan is configured in the plugin.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SecurityScanProbe.KEY,
+                        "GitHub workflow security scan is configured in the plugin.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SpotBugsProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,26 +75,32 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
 
         when(plugin.getName()).thenReturn(pluginName);
 
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", defaultBranch
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        defaultBranch)),
+                        Map.of(),
+                        List.of()));
         when(ctx.getRepositoryName()).thenReturn(Optional.empty());
 
         final SpotBugsProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(SpotBugsProbe.KEY, "Cannot determine plugin repository.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        SpotBugsProbe.KEY, "Cannot determine plugin repository.", probe.getVersion()));
     }
 
     @SuppressWarnings("unchecked")
@@ -113,35 +118,39 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
         final GHRepository ghRepository = mock(GHRepository.class);
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", defaultBranch
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        defaultBranch)),
+                        Map.of(),
+                        List.of()));
         when(ctx.getGitHub()).thenReturn(gh);
         when(ctx.getRepositoryName()).thenReturn(Optional.of(pluginRepo));
 
         when(gh.getRepository(pluginRepo)).thenReturn(ghRepository);
         final PagedIterable<GHCheckRun> checkRuns = (PagedIterable<GHCheckRun>) mock(PagedIterable.class);
         final GHCheckRun checkRun = mock(GHCheckRun.class);
-        when(checkRuns.toList()).thenReturn(
-            List.of(checkRun)
-        );
+        when(checkRuns.toList()).thenReturn(List.of(checkRun));
         when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "SpotBugs")))
-            .thenReturn(checkRuns);
+                .thenReturn(checkRuns);
 
         final SpotBugsProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SpotBugsProbe.KEY, "SpotBugs found in build configuration.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SpotBugsProbe.KEY, "SpotBugs found in build configuration.", probe.getVersion()));
     }
 
     @SuppressWarnings("unchecked")
@@ -159,30 +168,36 @@ class SpotBugsProbeTest extends AbstractProbeTest<SpotBugsProbe> {
         final GHRepository ghRepository = mock(GHRepository.class);
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(
-                pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                    pluginName, new VersionNumber("1.0"), scmLink, ZonedDateTime.now(), List.of(), 0,
-                    "42", defaultBranch
-                )
-            ),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName,
+                                        new VersionNumber("1.0"),
+                                        scmLink,
+                                        ZonedDateTime.now(),
+                                        List.of(),
+                                        0,
+                                        "42",
+                                        defaultBranch)),
+                        Map.of(),
+                        List.of()));
         when(ctx.getGitHub()).thenReturn(gh);
         when(ctx.getRepositoryName()).thenReturn(Optional.of(pluginRepo));
 
         when(gh.getRepository(pluginRepo)).thenReturn(ghRepository);
         final PagedIterable<GHCheckRun> checkRuns = (PagedIterable<GHCheckRun>) mock(PagedIterable.class);
         when(ghRepository.getCheckRuns(defaultBranch, Map.of("check_name", "SpotBugs")))
-            .thenReturn(checkRuns);
+                .thenReturn(checkRuns);
 
         final SpotBugsProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(SpotBugsProbe.KEY, "SpotBugs not found in build configuration.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        SpotBugsProbe.KEY, "SpotBugs not found in build configuration.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpForAdoptionProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,39 +58,64 @@ class UpForAdoptionProbeTest extends AbstractProbeTest<UpForAdoptionProbe> {
         final UpForAdoptionProbe upForAdoptionProbe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder", "adopt-this-plugin"), 0, "", "main")),
-            Collections.emptyMap(),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                "foo",
+                                new Plugin(
+                                        "foo",
+                                        new VersionNumber("1.0"),
+                                        "not-a-scm",
+                                        ZonedDateTime.now().minusDays(1),
+                                        List.of("builder", "adopt-this-plugin"),
+                                        0,
+                                        "",
+                                        "main")),
+                        Collections.emptyMap(),
+                        Collections.emptyList()));
 
         final ProbeResult result = upForAdoptionProbe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", upForAdoptionProbe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        UpForAdoptionProbe.KEY, "This plugin is up for adoption.", upForAdoptionProbe.getVersion()));
     }
 
     @Test
     void shouldBeAbleToDetectPluginNotForAdoption() {
-        final io.jenkins.pluginhealth.scoring.model.Plugin plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final io.jenkins.pluginhealth.scoring.model.Plugin plugin =
+                mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final UpForAdoptionProbe upForAdoptionProbe = getSpy();
 
         when(plugin.getName()).thenReturn("foo");
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of("foo", new Plugin("foo", new VersionNumber("1.0"), "not-a-scm", ZonedDateTime.now().minusDays(1), List.of("builder"), 0, "", "main")),
-            Collections.emptyMap(),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                "foo",
+                                new Plugin(
+                                        "foo",
+                                        new VersionNumber("1.0"),
+                                        "not-a-scm",
+                                        ZonedDateTime.now().minusDays(1),
+                                        List.of("builder"),
+                                        0,
+                                        "",
+                                        "main")),
+                        Collections.emptyMap(),
+                        Collections.emptyList()));
 
         final ProbeResult result = upForAdoptionProbe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", upForAdoptionProbe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        UpForAdoptionProbe.KEY,
+                        "This plugin is not up for adoption.",
+                        upForAdoptionProbe.getVersion()));
     }
 
     @Test
@@ -100,18 +124,15 @@ class UpForAdoptionProbeTest extends AbstractProbeTest<UpForAdoptionProbe> {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getName()).thenReturn("foo");
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), List.of()));
 
         final UpForAdoptionProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(UpForAdoptionProbe.KEY, "This plugin is not in the update-center.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        UpForAdoptionProbe.KEY, "This plugin is not in the update-center.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/UpdateCenterPluginPublicationProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,19 +56,18 @@ class UpdateCenterPluginPublicationProbeTest extends AbstractProbeTest<UpdateCen
         final String pluginName = "foo";
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            Collections.emptyList()
-        ));
+        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), Collections.emptyList()));
 
         final UpdateCenterPluginPublicationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(UpdateCenterPluginPublicationProbe.KEY, "This plugin's publication has been stopped by the update-center.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        UpdateCenterPluginPublicationProbe.KEY,
+                        "This plugin's publication has been stopped by the update-center.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -79,20 +77,24 @@ class UpdateCenterPluginPublicationProbeTest extends AbstractProbeTest<UpdateCen
         final String pluginName = "foo";
 
         when(plugin.getName()).thenReturn(pluginName);
-        when(ctx.getUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(pluginName, new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
-                pluginName, null, null, null, List.of(), 0, "2.361.1", "main"
-            )),
-            Map.of(),
-            List.of()
-        ));
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Map.of(
+                                pluginName,
+                                new io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin(
+                                        pluginName, null, null, null, List.of(), 0, "2.361.1", "main")),
+                        Map.of(),
+                        List.of()));
 
         final UpdateCenterPluginPublicationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);
 
         assertThat(result)
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "This plugin is still actively published by the update-center.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        UpdateCenterPluginPublicationProbe.KEY,
+                        "This plugin is still actively published by the update-center.",
+                        probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/repository/PluginRepositoryIT.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/repository/PluginRepositoryIT.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,8 +41,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class PluginRepositoryIT extends AbstractDBContainerTest {
-    @Autowired private PluginRepository repository;
-    @Autowired private TestEntityManager entityManager;
+    @Autowired
+    private PluginRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     @Test
     void shouldBeEmpty() {
@@ -52,7 +54,8 @@ class PluginRepositoryIT extends AbstractDBContainerTest {
 
     @Test
     void shouldBeAbleToSaveOnePlugin() {
-        final Plugin myPlugin = repository.save(new Plugin("myPlugin", new VersionNumber("1.0"), "this-is-ok", ZonedDateTime.now()));
+        final Plugin myPlugin =
+                repository.save(new Plugin("myPlugin", new VersionNumber("1.0"), "this-is-ok", ZonedDateTime.now()));
         assertThat(myPlugin).extracting("name").isEqualTo("myPlugin");
         assertThat(myPlugin).extracting("version").isEqualTo(new VersionNumber("1.0"));
         assertThat(myPlugin).extracting("scm").isEqualTo("this-is-ok");
@@ -84,12 +87,17 @@ class PluginRepositoryIT extends AbstractDBContainerTest {
 
     @Test
     void shouldBeAbleToUpdatePlugin() {
-        final Plugin plugin1 = new Plugin("plugin-1", new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusMinutes(10));
+        final Plugin plugin1 = new Plugin(
+                "plugin-1", new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusMinutes(10));
         entityManager.persist(plugin1);
         final Plugin plugin2 = new Plugin("plugin-2", new VersionNumber("1.0"), "scm", ZonedDateTime.now());
         entityManager.persist(plugin2);
 
-        final Plugin plugin1Updated = new Plugin("plugin-1", new VersionNumber("1.1"), "update-scm", ZonedDateTime.now().minusMinutes(2));
+        final Plugin plugin1Updated = new Plugin(
+                "plugin-1",
+                new VersionNumber("1.1"),
+                "update-scm",
+                ZonedDateTime.now().minusMinutes(2));
 
         final Optional<Plugin> pluginFromDBOpt = repository.findByName(plugin1Updated.getName());
         assertThat(pluginFromDBOpt).isPresent();
@@ -103,17 +111,13 @@ class PluginRepositoryIT extends AbstractDBContainerTest {
 
         final Optional<Plugin> pluginToCheck = repository.findByName(plugin1.getName());
         assertThat(pluginToCheck)
-            .isPresent()
-            .get()
-            .extracting(
-                Plugin::getName,
-                Plugin::getScm,
-                Plugin::getVersion,
-                Plugin::getReleaseTimestamp)
-            .containsExactly(
-                plugin1Updated.getName(),
-                plugin1Updated.getScm(),
-                plugin1Updated.getVersion(),
-                plugin1Updated.getReleaseTimestamp());
+                .isPresent()
+                .get()
+                .extracting(Plugin::getName, Plugin::getScm, Plugin::getVersion, Plugin::getReleaseTimestamp)
+                .containsExactly(
+                        plugin1Updated.getName(),
+                        plugin1Updated.getScm(),
+                        plugin1Updated.getVersion(),
+                        plugin1Updated.getReleaseTimestamp());
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/repository/ScoreRepositoryIT.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/repository/ScoreRepositoryIT.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,52 +42,84 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 public class ScoreRepositoryIT extends AbstractDBContainerTest {
-    @Autowired private ScoreRepository repository;
-    @Autowired private TestEntityManager entityManager;
+    @Autowired
+    private ScoreRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     @Test
     void shouldBeAbleToDeleteOldScores() {
-        final Plugin plugin1 = entityManager.persist(new Plugin("plugin-1", new VersionNumber("1.0"), "scm", ZonedDateTime.now()));
-        final Plugin plugin2 = entityManager.persist(new Plugin("plugin-2", new VersionNumber("1.0"), "scm", ZonedDateTime.now()));
-        final Plugin plugin3 = entityManager.persist(new Plugin("plugin-3", new VersionNumber("1.1"), "scm", ZonedDateTime.now()));
+        final Plugin plugin1 =
+                entityManager.persist(new Plugin("plugin-1", new VersionNumber("1.0"), "scm", ZonedDateTime.now()));
+        final Plugin plugin2 =
+                entityManager.persist(new Plugin("plugin-2", new VersionNumber("1.0"), "scm", ZonedDateTime.now()));
+        final Plugin plugin3 =
+                entityManager.persist(new Plugin("plugin-3", new VersionNumber("1.1"), "scm", ZonedDateTime.now()));
 
-        final Score oldScore1 = entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusDays(1)));
-        final Score oldScore2 = entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusMonths(1)));
-        final Score recentScore1 = entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusHours(8)));
+        final Score oldScore1 =
+                entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusDays(1)));
+        final Score oldScore2 =
+                entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusMonths(1)));
+        final Score recentScore1 =
+                entityManager.persist(new Score(plugin1, ZonedDateTime.now().minusHours(8)));
         final Score recentScore2 = entityManager.persist(new Score(plugin1, ZonedDateTime.now()));
         final Score recentScore3 = entityManager.persist(new Score(plugin1, ZonedDateTime.now()));
         final Score recentScore4 = entityManager.persist(new Score(plugin1, ZonedDateTime.now()));
         final Score recentScore5 = entityManager.persist(new Score(plugin1, ZonedDateTime.now()));
 
-        final Score oldScore21 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusMonths(1)));
-        final Score oldScore22 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(5)));
-        final Score recentScore01 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(3)));
-        final Score recentScore02 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(2)));
-        final Score recentScore03 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(1)));
-        final Score recentScore04 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusHours(15)));
-        final Score recentScore05 = entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(4)));
+        final Score oldScore21 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusMonths(1)));
+        final Score oldScore22 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(5)));
+        final Score recentScore01 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(3)));
+        final Score recentScore02 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(2)));
+        final Score recentScore03 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(1)));
+        final Score recentScore04 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusHours(15)));
+        final Score recentScore05 =
+                entityManager.persist(new Score(plugin2, ZonedDateTime.now().minusDays(4)));
 
-        final Score oldScore31 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(7)));
-        final Score oldScore32 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(6)));
-        final Score recentScore001 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(5)));
-        final Score recentScore002 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(4)));
-        final Score recentScore003 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(3)));
-        final Score recentScore004 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(2)));
-        final Score recentScore005 = entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(1)));
+        final Score oldScore31 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(7)));
+        final Score oldScore32 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(6)));
+        final Score recentScore001 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(5)));
+        final Score recentScore002 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(4)));
+        final Score recentScore003 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(3)));
+        final Score recentScore004 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(2)));
+        final Score recentScore005 =
+                entityManager.persist(new Score(plugin3, ZonedDateTime.now().minusDays(1)));
 
         long noOfRowsDeleted = repository.deleteOldScoreFromPlugin();
         List<Score> remainingScores = repository.findAll();
 
         assertThat(noOfRowsDeleted).isEqualTo(6);
         assertThat(remainingScores)
-            .hasSize(15)
-            .doesNotContain(oldScore1, oldScore2, oldScore21, oldScore22, oldScore31, oldScore32)
-            .containsExactlyInAnyOrder(
-                 recentScore1, recentScore2, recentScore3, recentScore4, recentScore5,
-                 recentScore01, recentScore02, recentScore03, recentScore04, recentScore05,
-                 recentScore001, recentScore002, recentScore003, recentScore004, recentScore005
-            );
+                .hasSize(15)
+                .doesNotContain(oldScore1, oldScore2, oldScore21, oldScore22, oldScore31, oldScore32)
+                .containsExactlyInAnyOrder(
+                        recentScore1,
+                        recentScore2,
+                        recentScore3,
+                        recentScore4,
+                        recentScore5,
+                        recentScore01,
+                        recentScore02,
+                        recentScore03,
+                        recentScore04,
+                        recentScore05,
+                        recentScore001,
+                        recentScore002,
+                        recentScore003,
+                        recentScore004,
+                        recentScore005);
     }
 }
-
-

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AbstractScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AbstractScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,16 +51,17 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final AdoptionScoring scoring = getSpy();
         final Plugin plugin = mock(Plugin.class);
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                        ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.key()).isEqualTo("adoption");
         assertThat(result.weight()).isEqualTo(.8f);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Cannot determine the last commit date.");
+                .contains("Cannot determine the last commit date.");
     }
 
     @Test
@@ -70,10 +70,15 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusHours(4));
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1),
-            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.key()).isEqualTo("adoption");
@@ -86,14 +91,15 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final AdoptionScoring scoring = getSpy();
         final Plugin plugin = mock(Plugin.class);
 
-        when(plugin.getDetails()).thenReturn(
-            Map.of(UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1))
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                        ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Cannot determine the last commit date.");
+                .contains("Cannot determine the last commit date.");
     }
 
     @Test
@@ -102,17 +108,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(2));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(100);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 6 months gap between last release and last commit.");
+                .contains("Less than 6 months gap between last release and last commit.");
     }
 
     @Test
@@ -121,17 +130,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(8));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(80);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than a year between last release and last commit.");
+                .contains("Less than a year between last release and last commit.");
     }
 
     @Test
@@ -140,17 +152,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(18));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(60);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 2 years between last release and last commit.");
+                .contains("Less than 2 years between last release and last commit.");
     }
 
     @Test
@@ -159,17 +174,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusYears(3));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(40);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 4 years between last release and last commit.");
+                .contains("Less than 4 years between last release and last commit.");
     }
 
     @Test
@@ -178,16 +196,19 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusYears(5));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("There is more than 4 years between the last release and the last commit.");
+                .contains("There is more than 4 years between the last release and the last commit.");
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DeprecatedPluginScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -49,9 +48,10 @@ class DeprecatedPluginScoringTest extends AbstractScoringTest<DeprecatedPluginSc
         final Plugin plugin = mock(Plugin.class);
         final DeprecatedPluginScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DeprecatedPluginProbe.KEY, ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is NOT deprecated.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DeprecatedPluginProbe.KEY,
+                        ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is NOT deprecated.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
 
@@ -79,9 +79,10 @@ class DeprecatedPluginScoringTest extends AbstractScoringTest<DeprecatedPluginSc
         final Plugin plugin = mock(Plugin.class);
         final DeprecatedPluginScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DeprecatedPluginProbe.KEY, ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is marked as deprecated.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DeprecatedPluginProbe.KEY,
+                        ProbeResult.success(DeprecatedPluginProbe.KEY, "This plugin is marked as deprecated.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,18 +54,30 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
     }
 
     @Test
@@ -74,27 +85,41 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0 && res.score() == 0 && res.resolutions().size() == 1 &&
-                        res.reasons().contains("Plugin is not using Release Drafter to manage its changelog.");
-                },
-                "Release drafter is not configured"
-            ));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 0
+                                    && res.resolutions().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin is not using Release Drafter to manage its changelog.");
+                        },
+                        "Release drafter is not configured"));
     }
 
     @Test
@@ -102,28 +127,44 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
-            ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
+                        ContinuousDeliveryProbe.KEY,
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0 && res.score() == 100 && res.reasons().size() == 1 &&
-                        res.reasons().contains("Plugin using Release Drafter because it has CD configured.");
-                },
-                "CD is configured."
-            ));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 100
+                                    && res.reasons().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin using Release Drafter because it has CD configured.");
+                        },
+                        "CD is configured."));
     }
 
     @Test
@@ -131,17 +172,28 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin is using description from the plugin archetype.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -149,17 +201,28 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is not located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -167,16 +230,27 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is not located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin is using description from the plugin archetype.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,189 +57,263 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
 
     static Stream<Arguments> probeResultsAndValue() {
         return Stream.of(
-            arguments(// Nothing
-                Map.of(),
-                0
-            ),
-            arguments(// All bad
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                0
-            ),
-            arguments(// All bad with open dependabot pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                0
-            ),
-            arguments(// All good
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                100
-            ),
-            arguments(// All good
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                100
-            ),
-            arguments(// Only Jenkinsfile
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                76
-            ),
-            arguments(// Jenkinsfile and dependabot but with open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                85
-            ),
-            arguments(// Jenkinsfile and dependabot with no open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                94
-            ),
-            arguments(// Jenkinsfile and renovate but with open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                85
-            ),
-            arguments(// Jenkinsfile and renovate with no open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                94
-            ),
-            arguments(// Jenkinsfile and CD
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                82
-            ),
-            arguments(// Jenkinsfile and CD and dependabot but with open pull request
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                91
-            ),
-            arguments(// Dependabot only with no open pull requests
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                18
-            ),
-            arguments(// Dependabot only with open pull requests
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                9
-            ),
-            arguments(// Dependabot with no open pull request and CD
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                24
-            ),
-            arguments(// Renovate only with no open pull requests
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                18
-            ),
-            arguments(// Renovate only with open pull requests
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1)
-                ),
-                9
-            ),
-            arguments(// Renovate with no open pull request and CD
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                24
-            ),
-            arguments(// CD only
-                Map.of(
-                    JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                    DependabotProbe.KEY, ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                    RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                    DependabotPullRequestProbe.KEY, ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
-                    ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-                ),
-                6
-            )
-        );
+                arguments( // Nothing
+                        Map.of(), 0),
+                arguments( // All bad
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        0),
+                arguments( // All bad with open dependabot pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        0),
+                arguments( // All good
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        100),
+                arguments( // All good
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        100),
+                arguments( // Only Jenkinsfile
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        76),
+                arguments( // Jenkinsfile and dependabot but with open pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        85),
+                arguments( // Jenkinsfile and dependabot with no open pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        94),
+                arguments( // Jenkinsfile and renovate but with open pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        85),
+                arguments( // Jenkinsfile and renovate with no open pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        94),
+                arguments( // Jenkinsfile and CD
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        82),
+                arguments( // Jenkinsfile and CD and dependabot but with open pull request
+                        Map.of(
+                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        91),
+                arguments( // Dependabot only with no open pull requests
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        18),
+                arguments( // Dependabot only with open pull requests
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        9),
+                arguments( // Dependabot with no open pull request and CD
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        24),
+                arguments( // Renovate only with no open pull requests
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        18),
+                arguments( // Renovate only with open pull requests
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY,
+                                                "Could not find JEP-229 workflow definition.",
+                                                1)),
+                        9),
+                arguments( // Renovate with no open pull request and CD
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        24),
+                arguments( // CD only
+                        Map.of(
+                                JenkinsfileProbe.KEY,
+                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                DependabotProbe.KEY,
+                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ContinuousDeliveryProbe.KEY,
+                                        ProbeResult.success(
+                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)),
+                        6));
     }
 
     @ParameterizedTest
@@ -255,9 +328,9 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
 
         assertThat(result.componentsResults().size()).isEqualTo(3);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value", "weight")
-            .isEqualTo(new ScoreResult(KEY, value, COEFFICIENT, Set.of(), scoring.version()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value", "weight")
+                .isEqualTo(new ScoreResult(KEY, value, COEFFICIENT, Set.of(), scoring.version()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/SecurityWarningScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/SecurityWarningScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,9 +48,11 @@ class SecurityWarningScoringTest extends AbstractScoringTest<SecurityWarningScor
         final Plugin plugin = mock(Plugin.class);
         final SecurityWarningScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            KnownSecurityVulnerabilityProbe.KEY, ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "SECURITY-123, link-to-security-advisory", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        KnownSecurityVulnerabilityProbe.KEY,
+                        ProbeResult.success(
+                                KnownSecurityVulnerabilityProbe.KEY, "SECURITY-123, link-to-security-advisory", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
 
@@ -79,9 +80,11 @@ class SecurityWarningScoringTest extends AbstractScoringTest<SecurityWarningScor
         final Plugin plugin = mock(Plugin.class);
         final SecurityWarningScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            KnownSecurityVulnerabilityProbe.KEY, ProbeResult.success(KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        KnownSecurityVulnerabilityProbe.KEY,
+                        ProbeResult.success(
+                                KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/UpdateCenterPublishedPluginDetectionScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/UpdateCenterPublishedPluginDetectionScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -38,7 +37,8 @@ import io.jenkins.pluginhealth.scoring.probes.UpdateCenterPluginPublicationProbe
 
 import org.junit.jupiter.api.Test;
 
-class UpdateCenterPublishedPluginDetectionScoringTest extends AbstractScoringTest<UpdateCenterPublishedPluginDetectionScoring> {
+class UpdateCenterPublishedPluginDetectionScoringTest
+        extends AbstractScoringTest<UpdateCenterPublishedPluginDetectionScoring> {
     @Override
     UpdateCenterPublishedPluginDetectionScoring getSpy() {
         return spy(UpdateCenterPublishedPluginDetectionScoring.class);
@@ -47,11 +47,16 @@ class UpdateCenterPublishedPluginDetectionScoringTest extends AbstractScoringTes
     @Test
     public void shouldScoreCorrectlyWhenPluginInUpdateCenter() {
         final Plugin plugin = mock(Plugin.class);
-        final UpdateCenterPublishedPluginDetectionScoring scoring = spy(UpdateCenterPublishedPluginDetectionScoring.class);
+        final UpdateCenterPublishedPluginDetectionScoring scoring =
+                spy(UpdateCenterPublishedPluginDetectionScoring.class);
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "This plugin is still actively published by the update-center.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpdateCenterPluginPublicationProbe.KEY,
+                        ProbeResult.success(
+                                UpdateCenterPluginPublicationProbe.KEY,
+                                "This plugin is still actively published by the update-center.",
+                                1)));
 
         final ScoreResult result = scoring.apply(plugin);
 
@@ -79,9 +84,10 @@ class UpdateCenterPublishedPluginDetectionScoringTest extends AbstractScoringTes
         final Plugin plugin = mock(Plugin.class);
         final UpdateCenterPublishedPluginDetectionScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpdateCenterPluginPublicationProbe.KEY, ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpdateCenterPluginPublicationProbe.KEY,
+                        ProbeResult.success(UpdateCenterPluginPublicationProbe.KEY, "", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
 

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginServiceIT.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,8 +42,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class PluginServiceIT extends AbstractDBContainerTest {
-    @Autowired private TestEntityManager entityManager;
-    @Autowired private PluginRepository pluginRepository;
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PluginRepository pluginRepository;
+
     private PluginService pluginService;
 
     @BeforeEach
@@ -55,42 +58,34 @@ class PluginServiceIT extends AbstractDBContainerTest {
     @Test
     void shouldNotDuplicatePluginWhenNameIsTheSame() {
         final Plugin p1 = entityManager.persist(
-            new Plugin("myPlugin", new VersionNumber("1.0"), "https://github.com/jenkinsci/my-plugin", null)
-        );
-        final Plugin p2 = entityManager.persist(
-            new Plugin("bar", new VersionNumber("1.2"), "scm-2", ZonedDateTime.now())
-        );
+                new Plugin("myPlugin", new VersionNumber("1.0"), "https://github.com/jenkinsci/my-plugin", null));
+        final Plugin p2 =
+                entityManager.persist(new Plugin("bar", new VersionNumber("1.2"), "scm-2", ZonedDateTime.now()));
 
-        assertThat(pluginService.streamAll())
-            .hasSize(2)
-            .containsExactlyInAnyOrder(p2, p1);
+        assertThat(pluginService.streamAll()).hasSize(2).containsExactlyInAnyOrder(p2, p1);
 
-        final Plugin copy = new Plugin("myPlugin", new VersionNumber("1.1"), "https://github.com/jenkinsci/my-plugin", null);
+        final Plugin copy =
+                new Plugin("myPlugin", new VersionNumber("1.1"), "https://github.com/jenkinsci/my-plugin", null);
         pluginService.saveOrUpdate(copy);
-        assertThat(pluginService.streamAll())
-            .hasSize(2)
-            .containsExactlyInAnyOrder(p2, copy);
+        assertThat(pluginService.streamAll()).hasSize(2).containsExactlyInAnyOrder(p2, copy);
     }
 
     @Test
     void shouldBeAbleToSavePluginWithThreeDigitVersion() {
-        final Plugin plugin = entityManager.persist(
-            new Plugin("foo-bar", new VersionNumber("1.0.1"), null, ZonedDateTime.now())
-        );
+        final Plugin plugin =
+                entityManager.persist(new Plugin("foo-bar", new VersionNumber("1.0.1"), null, ZonedDateTime.now()));
 
         assertThat(pluginService.getPluginsCount()).isEqualTo(1);
         assertThat(pluginService.findByName("foo-bar"))
-            .isPresent()
-            .get()
-            .extracting("version")
-            .isNotNull()
-            .isEqualTo(new VersionNumber("1.0.1"));
+                .isPresent()
+                .get()
+                .extracting("version")
+                .isNotNull()
+                .isEqualTo(new VersionNumber("1.0.1"));
     }
 
     @Test
     void shouldReturnsNonNullObjectWhenNoPluginWithName() {
-        assertThat(pluginService.findByName("not-existing"))
-            .isNotNull()
-            .isEmpty();
+        assertThat(pluginService.findByName("not-existing")).isNotNull().isEmpty();
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/service/ScoreServiceIT.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/service/ScoreServiceIT.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,9 +50,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class ScoreServiceIT extends AbstractDBContainerTest {
-    @Autowired private TestEntityManager entityManager;
-    @Autowired private ScoreRepository scoreRepository;
-    @MockBean private PluginService pluginService;
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ScoreRepository scoreRepository;
+
+    @MockBean
+    private PluginService pluginService;
 
     private ScoreService scoreService;
 
@@ -64,31 +68,24 @@ class ScoreServiceIT extends AbstractDBContainerTest {
 
     @Test
     void shouldBeAbleToSaveScoreForPlugin() {
-        final Plugin p1 = entityManager.persist(
-            new Plugin("plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5))
-        );
+        final Plugin p1 = entityManager.persist(new Plugin(
+                "plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5)));
 
         final Score score = new Score(p1, ZonedDateTime.now());
         final ScoreResult result = new ScoreResult("foo", 100, 1, Set.of(), 1);
         score.addDetail(result);
 
         final Score saved = scoreService.save(score);
-        assertThat(saved)
-            .extracting(Score::getPlugin, Score::getValue)
-            .contains(p1, 100L);
-        assertThat(saved.getDetails())
-            .hasSize(1)
-            .contains(result);
+        assertThat(saved).extracting(Score::getPlugin, Score::getValue).contains(p1, 100L);
+        assertThat(saved.getDetails()).hasSize(1).contains(result);
     }
 
     @Test
     void shouldBeAbleToExtractScoreSummary() {
-        final Plugin p1 = entityManager.persist(
-            new Plugin("plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5))
-        );
-        final Plugin p2 = entityManager.persist(
-            new Plugin("plugin-2", new VersionNumber("2.0"), "scm", ZonedDateTime.now().minusMinutes(10))
-        );
+        final Plugin p1 = entityManager.persist(new Plugin(
+                "plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5)));
+        final Plugin p2 = entityManager.persist(new Plugin(
+                "plugin-2", new VersionNumber("2.0"), "scm", ZonedDateTime.now().minusMinutes(10)));
 
         final Score p1s = new Score(p1, ZonedDateTime.now());
         p1s.addDetail(new ScoreResult("foo", 100, 1, Set.of(), 1));
@@ -103,24 +100,16 @@ class ScoreServiceIT extends AbstractDBContainerTest {
         final Map<String, Score> summary = scoreService.getLatestScoresSummaryMap();
 
         assertThat(summary)
-            .extractingFromEntries(
-                Map.Entry::getKey,
-                Map.Entry::getValue
-            )
-            .containsExactlyInAnyOrder(
-                tuple(p1.getName(), p1s),
-                tuple(p2.getName(), p2s)
-            );
+                .extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)
+                .containsExactlyInAnyOrder(tuple(p1.getName(), p1s), tuple(p2.getName(), p2s));
     }
 
     @Test
     void shouldOnlyRetrieveLatestScoreForPlugins() {
-        final Plugin p1 = entityManager.persist(
-            new Plugin("plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5))
-        );
-        final Plugin p2 = entityManager.persist(
-            new Plugin("plugin-2", new VersionNumber("2.0"), "scm", ZonedDateTime.now().minusMinutes(10))
-        );
+        final Plugin p1 = entityManager.persist(new Plugin(
+                "plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5)));
+        final Plugin p2 = entityManager.persist(new Plugin(
+                "plugin-2", new VersionNumber("2.0"), "scm", ZonedDateTime.now().minusMinutes(10)));
 
         final Score p1s = new Score(p1, ZonedDateTime.now());
         p1s.addDetail(new ScoreResult("foo", 1, 1, Set.of(), 1));
@@ -146,14 +135,8 @@ class ScoreServiceIT extends AbstractDBContainerTest {
         final Map<String, Score> summary = scoreService.getLatestScoresSummaryMap();
 
         assertThat(summary)
-            .extractingFromEntries(
-                Map.Entry::getKey,
-                Map.Entry::getValue
-            )
-            .containsExactlyInAnyOrder(
-                tuple(p1.getName(), p1s),
-                tuple(p2.getName(), p2s)
-            );
+                .extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)
+                .containsExactlyInAnyOrder(tuple(p1.getName(), p1s), tuple(p2.getName(), p2s));
     }
 
     @Test
@@ -161,26 +144,19 @@ class ScoreServiceIT extends AbstractDBContainerTest {
         final String s1Key = "foo";
 
         final Plugin p1 = entityManager.persist(new Plugin(
-            "plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5)
-        ));
+                "plugin-1", new VersionNumber("1.0"), null, ZonedDateTime.now().minusMinutes(5)));
         final Plugin p2 = entityManager.persist(new Plugin(
-            "plugin-2", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(3)
-        ));
+                "plugin-2", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(3)));
         final Plugin p3 = entityManager.persist(new Plugin(
-            "plugin-3", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(2)
-        ));
+                "plugin-3", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(2)));
         final Plugin p4 = entityManager.persist(new Plugin(
-            "plugin-4", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(8)
-        ));
+                "plugin-4", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(8)));
         final Plugin p5 = entityManager.persist(new Plugin(
-            "plugin-5", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(13)
-        ));
+                "plugin-5", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(13)));
         final Plugin p6 = entityManager.persist(new Plugin(
-            "plugin-6", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(34)
-        ));
+                "plugin-6", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(34)));
         final Plugin p7 = entityManager.persist(new Plugin(
-            "plugin-7", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(21)
-        ));
+                "plugin-7", new VersionNumber("1.3"), null, ZonedDateTime.now().minusMinutes(21)));
 
         final Score p1s = new Score(p1, ZonedDateTime.now());
         p1s.addDetail(new ScoreResult(s1Key, 50, .5f, Set.of(), 1));
@@ -214,18 +190,14 @@ class ScoreServiceIT extends AbstractDBContainerTest {
 
         final ScoreService.ScoreStatistics scoresStatistics = scoreService.getScoresStatistics();
 
-        assertThat(scoresStatistics)
-            .isEqualTo(new ScoreService.ScoreStatistics(
-                50, 0, 100, 0, 50, 80
-            ));
+        assertThat(scoresStatistics).isEqualTo(new ScoreService.ScoreStatistics(50, 0, 100, 0, 50, 80));
     }
 
     @Test
     void shouldBeAbleToFindLatestScoreForPluginByName() {
         final String name = "foo";
-        final Plugin plugin = entityManager.persist(
-            new Plugin(name, new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusMinutes(5))
-        );
+        final Plugin plugin = entityManager.persist(new Plugin(
+                name, new VersionNumber("1.0"), "scm", ZonedDateTime.now().minusMinutes(5)));
         final Score score = entityManager.persist(new Score(plugin, ZonedDateTime.now()));
 
         when(pluginService.findByName(name)).thenReturn(Optional.of(plugin));

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/service/ScoreServiceTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/service/ScoreServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,8 +36,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ScoreServiceTest {
-    @Mock private ScoreRepository scoreRepository;
-    @Mock private PluginService pluginService;
+    @Mock
+    private ScoreRepository scoreRepository;
+
+    @Mock
+    private PluginService pluginService;
 
     private ScoreService scoreService;
 
@@ -49,13 +51,9 @@ public class ScoreServiceTest {
 
     @Test
     void shouldBeAbleToComputeScoreStatisticCorrectly() {
-        when(scoreRepository.getLatestScoreValueOfEveryPlugin()).thenReturn(
-            new int[] { 50, 0, 100, 75, 80, 42, 0 }
-        );
+        when(scoreRepository.getLatestScoreValueOfEveryPlugin()).thenReturn(new int[] {50, 0, 100, 75, 80, 42, 0});
 
         final ScoreService.ScoreStatistics scoresStatistics = scoreService.getScoresStatistics();
-        assertThat(scoresStatistics).isEqualTo(new ScoreService.ScoreStatistics(
-            50, 0, 100, 0, 50, 80
-        ));
+        assertThat(scoresStatistics).isEqualTo(new ScoreService.ScoreStatistics(50, 0, 100, 0, 50, 80));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,6 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.43.0</version>
           <configuration>
-            <ratchetFrom>origin/main</ratchetFrom>
             <java>
               <palantirJavaFormat />
               <licenseHeader>

--- a/test/src/main/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
+++ b/test/src/main/java/io/jenkins/pluginhealth/scoring/AbstractDBContainerTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import org.jetbrains.annotations.NotNull;
@@ -39,9 +38,11 @@ public abstract class AbstractDBContainerTest {
     @Container
     private static final PostgreSQLContainer<?> DB_CONTAINER = PluginHealthScoringDatabaseContainer.getInstance();
 
-    static class DockerPostgresDatasourceInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    static class DockerPostgresDatasourceInitializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         @Override
         public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+            // @formatter:off
             TestPropertyValues.of(
                 "spring.datasource.url=" + DB_CONTAINER.getJdbcUrl(),
                 "spring.datasource.username=" + DB_CONTAINER.getUsername(),
@@ -49,6 +50,7 @@ public abstract class AbstractDBContainerTest {
                 "app.cron.update-center=0 0 */2 * * *",
                 "app.cron.probe-engine=0 0 */2 * * *"
             ).applyTo(applicationContext);
+            // @formatter:on
         }
     }
 }

--- a/test/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringDatabaseContainer.java
+++ b/test/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringDatabaseContainer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import org.testcontainers.containers.PostgreSQLContainer;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import io.jenkins.pluginhealth.scoring.config.ApplicationConfiguration;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ApplicationConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ApplicationConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import java.nio.file.Path;
@@ -34,9 +33,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "app")
 @Validated
 public record ApplicationConfiguration(@Valid Jenkins jenkins, @Valid GitHub gitHub) {
-    public record Jenkins(@NotBlank String updateCenter, @NotBlank String documentationUrls) {
-    }
+    public record Jenkins(@NotBlank String updateCenter, @NotBlank String documentationUrls) {}
 
-    public record GitHub(@NotBlank String appId, Path privateKeyPath, @NotBlank String appInstallationName) {
-    }
+    public record GitHub(@NotBlank String appId, Path privateKeyPath, @NotBlank String appInstallationName) {}
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/DatabaseConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/DatabaseConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -33,5 +32,4 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackages = "io.jenkins.pluginhealth.scoring.repository")
 @EntityScan(basePackages = "io.jenkins.pluginhealth.scoring.model")
-public class DatabaseConfiguration {
-}
+public class DatabaseConfiguration {}

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicator.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicator.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import java.io.IOException;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GithubConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GithubConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import java.io.IOException;
@@ -57,9 +56,9 @@ public class GithubConfiguration {
         final GitHubBuilder gitHubBuilder = new GitHubBuilder();
 
         try {
-            final OkHttpClient httpClient = new OkHttpClient.Builder().cache(
-                new Cache(Files.createTempDirectory("http_cache").toFile(), 50 * 1024 * 1024)
-            ).build();
+            final OkHttpClient httpClient = new OkHttpClient.Builder()
+                    .cache(new Cache(Files.createTempDirectory("http_cache").toFile(), 50 * 1024 * 1024))
+                    .build();
             gitHubBuilder.withConnector(new OkHttpGitHubConnector(httpClient));
         } catch (IOException ex) {
             LOGGER.warn("Could not create cache folder for GitHub connection. Will work without.", ex);
@@ -77,21 +76,21 @@ public class GithubConfiguration {
         return gitHubBuilder.build();
     }
 
-    private AppInstallationAuthorizationProvider createAuthorizationProvider() throws GeneralSecurityException, IOException {
+    private AppInstallationAuthorizationProvider createAuthorizationProvider()
+            throws GeneralSecurityException, IOException {
         final String appId = configuration.gitHub().appId();
         final Path privateKeyPath = configuration.gitHub().privateKeyPath();
         final String appInstallationName = configuration.gitHub().appInstallationName();
 
         final JWTTokenProvider jwtTokenProvider = new JWTTokenProvider(appId, privateKeyPath);
         return new AppInstallationAuthorizationProvider(
-            app -> {
-                try {
-                    return app.getInstallationByOrganization(appInstallationName);
-                } catch (GHFileNotFoundException ex) {
-                    return app.getInstallationByUser(appInstallationName);
-                }
-            },
-            jwtTokenProvider
-        );
+                app -> {
+                    try {
+                        return app.getInstallationByOrganization(appInstallationName);
+                    } catch (GHFileNotFoundException ex) {
+                        return app.getInstallationByUser(appInstallationName);
+                    }
+                },
+                jwtTokenProvider);
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ScheduleConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ScheduleConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import org.springframework.context.annotation.Configuration;
@@ -29,5 +28,4 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
-public class ScheduleConfiguration {
-}
+public class ScheduleConfiguration {}

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/SecurityConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/SecurityConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import org.springframework.context.annotation.Bean;
@@ -36,19 +35,20 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .authorizeHttpRequests(request ->
-                request
-                    .requestMatchers(HttpMethod.GET, "/js/*", "/style.css", "/svg/*").permitAll()
-                    .requestMatchers(HttpMethod.GET,
+        http.authorizeHttpRequests(request -> request.requestMatchers(HttpMethod.GET, "/js/*", "/style.css", "/svg/*")
+                .permitAll()
+                .requestMatchers(
+                        HttpMethod.GET,
                         "/api/scores",
                         "/",
-                        "/probes", "/probes/*",
-                        "/scores", "/scores/*",
-                        "/actuator/**"
-                    ).permitAll()
-                    .anyRequest().authenticated()
-            );
+                        "/probes",
+                        "/probes/*",
+                        "/scores",
+                        "/scores/*",
+                        "/actuator/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated());
         return http.build();
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/IndexController.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/IndexController.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import org.springframework.stereotype.Controller;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ProbesController.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ProbesController.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import java.util.Comparator;
@@ -57,12 +56,11 @@ public class ProbesController {
         final ModelAndView modelAndView = new ModelAndView("probes/listing");
 
         modelAndView.addObject(
-            "probes",
-            probeService.getProbes().stream()
-                .map(ProbeDetails::map)
-                .sorted(Comparator.comparing(ProbeDetails::id))
-                .toList()
-        );
+                "probes",
+                probeService.getProbes().stream()
+                        .map(ProbeDetails::map)
+                        .sorted(Comparator.comparing(ProbeDetails::id))
+                        .toList());
         return modelAndView;
     }
 
@@ -71,18 +69,15 @@ public class ProbesController {
         final ModelAndView modelAndView = new ModelAndView("probes/results");
 
         modelAndView
-            .addObject("probeResults", probeService.getProbesFinalResults())
-            .addObject("pluginsCount", pluginService.getPluginsCount());
+                .addObject("probeResults", probeService.getProbesFinalResults())
+                .addObject("pluginsCount", pluginService.getPluginsCount());
 
         return modelAndView;
     }
 
     record ProbeDetails(String id, String description) {
         static ProbeDetails map(Probe probe) {
-            return new ProbeDetails(
-                probe.key(),
-                probe.getDescription()
-            );
+            return new ProbeDetails(probe.key(), probe.getDescription());
         }
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreAPI.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import java.time.ZonedDateTime;
@@ -54,63 +53,55 @@ public class ScoreAPI {
         this.scoreService = scoreService;
     }
 
-    @GetMapping(value = {"", "/"}, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(
+            value = {"", "/"},
+            produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ScoreReport> getReport() {
         final Map<String, Score> latestScoresSummaryMap = scoreService.getLatestScoresSummaryMap();
         final Optional<String> optETag = latestScoresSummaryMap.values().stream()
-            .max(Comparator.comparing(Score::getComputedAt))
-            .map(Score::getComputedAt)
-            .map(ZonedDateTime::toEpochSecond)
-            .map(String::valueOf);
+                .max(Comparator.comparing(Score::getComputedAt))
+                .map(Score::getComputedAt)
+                .map(ZonedDateTime::toEpochSecond)
+                .map(String::valueOf);
 
-        record Tuple(String name, PluginScoreSummary summary) {
-        }
+        record Tuple(String name, PluginScoreSummary summary) {}
 
-        final Map<String, PluginScoreSummary> plugins = latestScoresSummaryMap
-            .entrySet().stream()
-            .map(entry -> {
-                final var score = entry.getValue();
-                return new Tuple(
-                    entry.getKey(),
-                    new PluginScoreSummary(
-                        score.getValue(),
-                        score.getDetails().stream()
-                            .collect(Collectors.toMap(
-                                    ScoreResult::key,
-                                    PluginScoreDetail::new
-                                )
-                            )
-                    )
-                );
-            })
-            .collect(Collectors.toMap(Tuple::name, Tuple::summary));
+        final Map<String, PluginScoreSummary> plugins = latestScoresSummaryMap.entrySet().stream()
+                .map(entry -> {
+                    final var score = entry.getValue();
+                    return new Tuple(
+                            entry.getKey(),
+                            new PluginScoreSummary(
+                                    score.getValue(),
+                                    score.getDetails().stream()
+                                            .collect(Collectors.toMap(ScoreResult::key, PluginScoreDetail::new))));
+                })
+                .collect(Collectors.toMap(Tuple::name, Tuple::summary));
 
-        final ResponseEntity.BodyBuilder bodyBuilder = ResponseEntity.ok()
-            .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS));
+        final ResponseEntity.BodyBuilder bodyBuilder =
+                ResponseEntity.ok().cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS));
         optETag.ifPresent(bodyBuilder::eTag);
 
         return bodyBuilder.body(new ScoreReport(plugins, scoreService.getScoresStatistics()));
     }
 
-    public record ScoreReport(Map<String, PluginScoreSummary> plugins, ScoreService.ScoreStatistics statistics) {
-    }
+    public record ScoreReport(Map<String, PluginScoreSummary> plugins, ScoreService.ScoreStatistics statistics) {}
 
-    private record PluginScoreSummary(long value, Map<String, PluginScoreDetail> details) {
-    }
+    private record PluginScoreSummary(long value, Map<String, PluginScoreDetail> details) {}
 
     private record PluginScoreDetail(float value, float weight, List<PluginScoreDetailComponent> components) {
         private PluginScoreDetail(ScoreResult result) {
             this(
-                result.value(),
-                result.weight(),
-                result.componentsResults().stream()
-                    .map(PluginScoreDetailComponent::new)
-                    .collect(Collectors.toList())
-            );
+                    result.value(),
+                    result.weight(),
+                    result.componentsResults().stream()
+                            .map(PluginScoreDetailComponent::new)
+                            .collect(Collectors.toList()));
         }
     }
 
-    private record PluginScoreDetailComponent(int value, float weight, List<String> reasons, List<Resolution> resolutions) {
+    private record PluginScoreDetailComponent(
+            int value, float weight, List<String> reasons, List<Resolution> resolutions) {
         private PluginScoreDetailComponent(ScoringComponentResult result) {
             this(result.score(), result.weight(), result.reasons(), result.resolutions());
         }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreController.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/http/ScoreController.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import java.util.Map;
@@ -60,12 +59,12 @@ public class ScoreController {
 
     @GetMapping(path = "/{pluginName}")
     public ModelAndView getScoreOf(@PathVariable String pluginName) {
-        return scoreService.latestScoreFor(pluginName)
-            .map(score -> {
-                return new ModelAndView("scores/details", Map.of(
-                    "score", score
-                ));
-            })
-            .orElseGet(() -> new ModelAndView("scores/unknown", Map.of("pluginName", pluginName), HttpStatus.NOT_FOUND));
+        return scoreService
+                .latestScoreFor(pluginName)
+                .map(score -> {
+                    return new ModelAndView("scores/details", Map.of("score", score));
+                })
+                .orElseGet(() ->
+                        new ModelAndView("scores/unknown", Map.of("pluginName", pluginName), HttpStatus.NOT_FOUND));
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngine.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -57,7 +56,12 @@ public final class ProbeEngine {
     private final GitHub gitHub;
     private final PluginDocumentationService pluginDocumentationService;
 
-    public ProbeEngine(ProbeService probeService, PluginService pluginService, UpdateCenterService updateCenterService, GitHub gitHub, PluginDocumentationService pluginDocumentationService) {
+    public ProbeEngine(
+            ProbeService probeService,
+            PluginService pluginService,
+            UpdateCenterService updateCenterService,
+            GitHub gitHub,
+            PluginDocumentationService pluginDocumentationService) {
         this.probeService = probeService;
         this.pluginService = pluginService;
         this.updateCenterService = updateCenterService;
@@ -72,8 +76,10 @@ public final class ProbeEngine {
         LOGGER.info("Start running probes on all plugins");
         final UpdateCenter updateCenter = updateCenterService.fetchUpdateCenter();
         final Map<String, String> pluginDocumentationUrl = pluginDocumentationService.fetchPluginDocumentationUrl();
-        pluginService.streamAll().parallel()
-            .forEach(plugin -> this.runOn(plugin, updateCenter, pluginDocumentationUrl));
+        pluginService
+                .streamAll()
+                .parallel()
+                .forEach(plugin -> this.runOn(plugin, updateCenter, pluginDocumentationUrl));
         LOGGER.info("Probe engine has finished");
     }
 

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DeleteOldScoreScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DeleteOldScoreScheduler.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import io.jenkins.pluginhealth.scoring.service.ScoreService;
@@ -44,7 +43,7 @@ public class DeleteOldScoreScheduler {
     public void deleteOldScores() {
         LOGGER.info("Deleting old scores");
 
-        int numberOfRowsDeleted  = scoreService.deleteOldScores();
+        int numberOfRowsDeleted = scoreService.deleteOldScores();
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Deleted {} rows when deleting old scores", numberOfRowsDeleted);

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import java.io.IOException;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import java.io.IOException;
@@ -49,10 +48,9 @@ public class UpdateCenterScheduler {
     @Scheduled(cron = "${app.cron.update-center}", zone = "UTC")
     public void updateDatabase() throws IOException {
         LOGGER.info("Updating plugins from update-center");
-        updateCenterService.fetchUpdateCenter()
-            .plugins().values().stream()
-            .map(Plugin::toPlugin)
-            .forEach(pluginService::saveOrUpdate);
+        updateCenterService.fetchUpdateCenter().plugins().values().stream()
+                .map(Plugin::toPlugin)
+                .forEach(pluginService::saveOrUpdate);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Plugins updated from update-center");
         }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/scores/ScoringEngine.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/scores/ScoringEngine.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.time.ZonedDateTime;
@@ -63,8 +62,7 @@ public final class ScoringEngine {
 
     public void run() {
         LOGGER.info("Start scoring all plugins");
-        pluginService.streamAll()
-            .forEach(this::runOn);
+        pluginService.streamAll().forEach(this::runOn);
         LOGGER.info("Score engine has finished");
     }
 
@@ -73,18 +71,19 @@ public final class ScoringEngine {
             LOGGER.debug("Scoring {}", plugin.getName());
         }
         final Optional<ZonedDateTime> latestProbeResult = plugin.getDetails().values().stream()
-            .map(ProbeResult::timestamp).max(Comparator.naturalOrder());
+                .map(ProbeResult::timestamp)
+                .max(Comparator.naturalOrder());
         final Optional<Score> latestScore = scoreService.latestScoreFor(plugin.getName());
-        if (latestScore.isPresent() && (latestProbeResult.isEmpty() || latestProbeResult.get().isBefore(latestScore.get().getComputedAt()))) {
+        if (latestScore.isPresent()
+                && (latestProbeResult.isEmpty()
+                        || latestProbeResult.get().isBefore(latestScore.get().getComputedAt()))) {
             final Score score = latestScore.get();
             boolean scoringIsSame = scoringService.getScoringList().stream()
-                .allMatch(scoring ->
-                    score.getDetails().stream()
-                        .filter(sr -> sr.key().equals(scoring.key()))
-                        .findFirst()
-                        .map(result -> scoring.version() == result.version())
-                        .orElseGet(() -> false)
-                );
+                    .allMatch(scoring -> score.getDetails().stream()
+                            .filter(sr -> sr.key().equals(scoring.key()))
+                            .findFirst()
+                            .map(result -> scoring.version() == result.version())
+                            .orElseGet(() -> false));
             if (scoringIsSame) {
                 LOGGER.debug("Previous score, computed at {} is still valid.", score.getComputedAt());
                 return score;
@@ -92,38 +91,38 @@ public final class ScoringEngine {
         }
 
         Score score = this.scoringService.getScoringList().stream()
-            .map(scoring -> scoring.apply(plugin))
-            .collect(new Collector<ScoreResult, Score, Score>() {
-                @Override
-                public Supplier<Score> supplier() {
-                    return () -> new Score(plugin, ZonedDateTime.now());
-                }
+                .map(scoring -> scoring.apply(plugin))
+                .collect(new Collector<ScoreResult, Score, Score>() {
+                    @Override
+                    public Supplier<Score> supplier() {
+                        return () -> new Score(plugin, ZonedDateTime.now());
+                    }
 
-                @Override
-                public BiConsumer<Score, ScoreResult> accumulator() {
-                    return Score::addDetail;
-                }
+                    @Override
+                    public BiConsumer<Score, ScoreResult> accumulator() {
+                        return Score::addDetail;
+                    }
 
-                @Override
-                public BinaryOperator<Score> combiner() {
-                    return (score1, score2) -> {
-                        for (ScoreResult res : score2.getDetails()) {
-                            score1.addDetail(res);
-                        }
-                        return score1;
-                    };
-                }
+                    @Override
+                    public BinaryOperator<Score> combiner() {
+                        return (score1, score2) -> {
+                            for (ScoreResult res : score2.getDetails()) {
+                                score1.addDetail(res);
+                            }
+                            return score1;
+                        };
+                    }
 
-                @Override
-                public Function<Score, Score> finisher() {
-                    return Function.identity();
-                }
+                    @Override
+                    public Function<Score, Score> finisher() {
+                        return Function.identity();
+                    }
 
-                @Override
-                public Set<Characteristics> characteristics() {
-                    return EnumSet.of(Characteristics.IDENTITY_FINISH, Characteristics.UNORDERED);
-                }
-            });
+                    @Override
+                    public Set<Characteristics> characteristics() {
+                        return EnumSet.of(Characteristics.IDENTITY_FINISH, Characteristics.UNORDERED);
+                    }
+                });
 
         try {
             return scoreService.save(score);

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.io.IOException;
@@ -53,15 +52,13 @@ public class PluginDocumentationService {
     public Map<String, String> fetchPluginDocumentationUrl() {
         try {
             final Map<String, Link> documentationUrlsMap = objectMapper.readValue(
-                new URL(configuration.jenkins().documentationUrls()),
-                  new TypeReference<>() {
-                  }
-            );
+                    new URL(configuration.jenkins().documentationUrls()), new TypeReference<>() {});
             return documentationUrlsMap.entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> e.getValue() == null || e.getValue().url() == null ? "" : e.getValue().url()
-                ));
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue() == null || e.getValue().url() == null
+                                    ? ""
+                                    : e.getValue().url()));
         } catch (MalformedURLException e) {
             LOGGER.error("URL to documentation link is incorrect.", e);
             return Map.of();

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ProbeService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.io.IOException;
@@ -61,31 +60,31 @@ public class ProbeService {
     }
 
     private static final List<String> IGNORE_RAW_RESULT_PROBES = List.of(
-        DependabotPullRequestProbe.KEY,
-        InstallationStatProbe.KEY,
-        JenkinsCoreProbe.KEY,
-        LastCommitDateProbe.KEY,
-        PullRequestProbe.KEY
-    );
+            DependabotPullRequestProbe.KEY,
+            InstallationStatProbe.KEY,
+            JenkinsCoreProbe.KEY,
+            LastCommitDateProbe.KEY,
+            PullRequestProbe.KEY);
 
     @Transactional(readOnly = true)
     public Map<String, ProbeResult> getProbesFinalResults() {
         return probes.stream()
-            .filter(probe -> !IGNORE_RAW_RESULT_PROBES.contains(probe.key()))
-            .collect(Collectors.toMap(Probe::key, probe -> new ProbeResult(
-                    getProbesRawResultsFromDatabase(probe.key(), true),
-                    getProbesRawResultsFromDatabase(probe.key(), false)
-                )
-            ));
+                .filter(probe -> !IGNORE_RAW_RESULT_PROBES.contains(probe.key()))
+                .collect(Collectors.toMap(
+                        Probe::key,
+                        probe -> new ProbeResult(
+                                getProbesRawResultsFromDatabase(probe.key(), true),
+                                getProbesRawResultsFromDatabase(probe.key(), false))));
     }
 
-    private record ProbeResult(long validated, long unvalidated) {
-    }
+    private record ProbeResult(long validated, long unvalidated) {}
 
     private long getProbesRawResultsFromDatabase(String probeID, boolean valid) {
         return switch (probeID) {
-            case UpForAdoptionProbe.KEY, KnownSecurityVulnerabilityProbe.KEY, DeprecatedPluginProbe.KEY ->
-                pluginRepository.getProbeRawResult(probeID, valid ? "FAILURE" : "SUCCESS");
+            case UpForAdoptionProbe.KEY,
+                    KnownSecurityVulnerabilityProbe.KEY,
+                    DeprecatedPluginProbe.KEY -> pluginRepository.getProbeRawResult(
+                    probeID, valid ? "FAILURE" : "SUCCESS");
             default -> pluginRepository.getProbeRawResult(probeID, valid ? "SUCCESS" : "FAILURE");
         };
     }
@@ -96,10 +95,9 @@ public class ProbeService {
 
     public Map<String, ProbeView> getProbesView() {
         return getProbes().stream()
-            .map(probe -> new ProbeView(probe.key(), probe.getDescription()))
-            .collect(Collectors.toMap(ProbeView::key, p -> p));
+                .map(probe -> new ProbeView(probe.key(), probe.getDescription()))
+                .collect(Collectors.toMap(ProbeView::key, p -> p));
     }
 
-    public record ProbeView(String key, String description) {
-    }
+    public record ProbeView(String key, String description) {}
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoringService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/ScoringService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.util.List;
@@ -51,10 +50,8 @@ public class ScoringService {
 
     public Map<String, ScoreView> getScoringsView() {
         return getScoringList().stream()
-            .map(scoring -> new ScoringService.ScoreView(
-                scoring.key(), scoring.weight(), scoring.description()
-            ))
-            .collect(Collectors.toMap(ScoreView::key, s -> s));
+                .map(scoring -> new ScoringService.ScoreView(scoring.key(), scoring.weight(), scoring.description()))
+                .collect(Collectors.toMap(ScoreView::key, s -> s));
     }
 
     public record ScoreView(String key, float coefficient, String description) {}

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import java.io.IOException;

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringIT.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/PluginHealthScoringIT.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import org.junit.jupiter.api.Test;
@@ -35,6 +34,5 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 final class PluginHealthScoringIT extends AbstractDBContainerTest {
     @Test
-    void contextLoads() {
-    }
+    void contextLoads() {}
 }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ProbeControllerTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ProbeControllerTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -53,13 +52,16 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @ExtendWith({SpringExtension.class, MockitoExtension.class})
 @ImportAutoConfiguration({ProjectInfoAutoConfiguration.class, SecurityConfiguration.class})
-@WebMvcTest(
-    controllers = ProbesController.class
-)
+@WebMvcTest(controllers = ProbesController.class)
 class ProbeControllerTest {
-    @MockBean private PluginService pluginService;
-    @MockBean private ProbeService probeService;
-    @Autowired private MockMvc mockMvc;
+    @MockBean
+    private PluginService pluginService;
+
+    @MockBean
+    private ProbeService probeService;
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Test
     void shouldDisplayListOfProbes() throws Exception {
@@ -67,12 +69,9 @@ class ProbeControllerTest {
         when(probeService.getProbes()).thenReturn(List.of(probe));
 
         mockMvc.perform(get("/probes"))
-            .andExpect(status().isOk())
-            .andExpect(view().name("probes/listing"))
-            .andExpectAll(
-                model().attributeExists("probes"),
-                model().attribute("probes", hasSize(1))
-            );
+                .andExpect(status().isOk())
+                .andExpect(view().name("probes/listing"))
+                .andExpectAll(model().attributeExists("probes"), model().attribute("probes", hasSize(1)));
 
         verify(probeService).getProbes();
     }
@@ -82,12 +81,10 @@ class ProbeControllerTest {
         when(pluginService.getPluginsCount()).thenReturn(1L);
 
         mockMvc.perform(get("/probes/results"))
-            .andExpect(status().isOk())
-            .andExpect(view().name("probes/results"))
-            .andExpectAll(
-                model().attributeExists("probeResults", "pluginsCount"),
-                model().attribute("pluginsCount", 1L)
-            );
+                .andExpect(status().isOk())
+                .andExpect(view().name("probes/results"))
+                .andExpectAll(
+                        model().attributeExists("probeResults", "pluginsCount"), model().attribute("pluginsCount", 1L));
 
         verify(pluginService).getPluginsCount();
         verify(probeService).getProbesFinalResults();

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,15 +59,18 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
-@ImportAutoConfiguration({ ProjectInfoAutoConfiguration.class, SecurityConfiguration.class })
-@WebMvcTest(
-    controllers = ScoreAPI.class
-)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@ImportAutoConfiguration({ProjectInfoAutoConfiguration.class, SecurityConfiguration.class})
+@WebMvcTest(controllers = ScoreAPI.class)
 class ScoreAPITest {
-    @MockBean private ScoreService scoreService;
-    @Autowired private MockMvc mockMvc;
-    @Autowired ObjectMapper mapper;
+    @MockBean
+    private ScoreService scoreService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper mapper;
 
     @Test
     void shouldBeAbleToProvideScoresSummary() throws Exception {
@@ -77,34 +79,54 @@ class ScoreAPITest {
 
         final ZonedDateTime computedAt = ZonedDateTime.now().minusMinutes(1);
         final Score scoreP1 = new Score(p1, computedAt);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
         final Score scoreP2 = new Score(p2, ZonedDateTime.now().minusDays(1));
-        scoreP2.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
-        scoreP2.addDetail(new ScoreResult("scoring-2", 50, 1, Set.of(
-            new ScoringComponentResult(0, 1, List.of("There is no Jenkinsfile detected on the plugin repository.")),
-            new ScoringComponentResult(100, .5f, List.of("The plugin documentation was migrated to its repository.")),
-            new ScoringComponentResult(100, .5f, List.of("The plugin is using dependabot.", "0 open pull requests from dependency update tool."))
-        ), 1));
+        scoreP2.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
+        scoreP2.addDetail(new ScoreResult(
+                "scoring-2",
+                50,
+                1,
+                Set.of(
+                        new ScoringComponentResult(
+                                0, 1, List.of("There is no Jenkinsfile detected on the plugin repository.")),
+                        new ScoringComponentResult(
+                                100, .5f, List.of("The plugin documentation was migrated to its repository.")),
+                        new ScoringComponentResult(
+                                100,
+                                .5f,
+                                List.of(
+                                        "The plugin is using dependabot.",
+                                        "0 open pull requests from dependency update tool."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", scoreP1,
-            "plugin-2", scoreP2
-        ));
-        when(scoreService.getScoresStatistics()).thenReturn(new ScoreService.ScoreStatistics(
-            87.5, 50, 100, 100, 100, 100
-        ));
+        when(scoreService.getLatestScoresSummaryMap())
+                .thenReturn(Map.of(
+                        "plugin-1", scoreP1,
+                        "plugin-2", scoreP2));
+        when(scoreService.getScoresStatistics())
+                .thenReturn(new ScoreService.ScoreStatistics(87.5, 50, 100, 100, 100, 100));
 
         mockMvc.perform(get("/api/scores"))
-            .andExpectAll(
-                status().isOk(),
-                header().string("ETag", equalTo("\"" + computedAt.toEpochSecond() + "\"")),
-                content().contentType(MediaType.APPLICATION_JSON),
-                content().json("""
+                .andExpectAll(
+                        status().isOk(),
+                        header().string("ETag", equalTo("\"" + computedAt.toEpochSecond() + "\"")),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        content()
+                                .json(
+                                        """
                     {
                         'plugins': {
                             'plugin-1': {
@@ -165,8 +187,8 @@ class ScoreAPITest {
                             'thirdQuartile': 100
                         }
                     }
-                    """, false)
-            );
+                    """,
+                                        false));
     }
 
     @Test
@@ -175,21 +197,22 @@ class ScoreAPITest {
 
         final ZonedDateTime computedAt = ZonedDateTime.now().minusHours(2);
         final Score scoreP1 = new Score(plugin, computedAt);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", scoreP1
-        ));
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of("plugin-1", scoreP1));
 
         MvcResult mvcResult = mockMvc.perform(get("/api/scores"))
-            .andExpectAll(
-                status().isOk(),
-                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))),
-                content().contentType(MediaType.APPLICATION_JSON)
-            )
-            .andReturn();
+                .andExpectAll(
+                        status().isOk(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))),
+                        content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
 
         final HttpHeaders httpHeaders = new HttpHeaders();
         String responseETag = mvcResult.getResponse().getHeader("ETag");
@@ -197,11 +220,10 @@ class ScoreAPITest {
         httpHeaders.setIfNoneMatch(responseETag);
 
         mvcResult = mockMvc.perform(get("/api/scores").headers(httpHeaders))
-            .andExpectAll(
-                status().isNotModified(),
-                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond())))
-            )
-            .andReturn();
+                .andExpectAll(
+                        status().isNotModified(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))))
+                .andReturn();
 
         responseETag = mvcResult.getResponse().getHeader("ETag");
         assertThat(responseETag).isNotNull();
@@ -209,19 +231,20 @@ class ScoreAPITest {
 
         final ZonedDateTime newScoreComputedAt = ZonedDateTime.now().minusMinutes(5);
         final Score newScoreP1 = new Score(plugin, newScoreComputedAt);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", newScoreP1
-        ));
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of("plugin-1", newScoreP1));
 
         mockMvc.perform(get("/api/scores").headers(httpHeaders))
-            .andExpectAll(
-                status().isOk(),
-                header().string("ETag", equalTo("\"%s\"".formatted(newScoreComputedAt.toEpochSecond()))),
-                content().contentType(MediaType.APPLICATION_JSON)
-            );
+                .andExpectAll(
+                        status().isOk(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(newScoreComputedAt.toEpochSecond()))),
+                        content().contentType(MediaType.APPLICATION_JSON));
     }
 }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreControllerTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreControllerTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -63,51 +62,51 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @ExtendWith({SpringExtension.class, MockitoExtension.class})
 @ImportAutoConfiguration({ProjectInfoAutoConfiguration.class, SecurityConfiguration.class})
-@WebMvcTest(
-    controllers = ScoreController.class
-)
+@WebMvcTest(controllers = ScoreController.class)
 class ScoreControllerTest {
-    @MockBean private ScoreService scoreService;
-    @MockBean private ScoringService scoringService;
-    @Autowired private MockMvc mockMvc;
+    @MockBean
+    private ScoreService scoreService;
+
+    @MockBean
+    private ScoringService scoringService;
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @Test
     void shouldDisplayListOfScoring() throws Exception {
-        when(scoringService.getScoringList())
-            .thenReturn(List.of(
-                new Scoring() {
-                    @Override
-                    public String key() {
-                        return "foo";
-                    }
+        when(scoringService.getScoringList()).thenReturn(List.of(new Scoring() {
+            @Override
+            public String key() {
+                return "foo";
+            }
 
-                    @Override
-                    public float weight() {
-                        return 1;
-                    }
+            @Override
+            public float weight() {
+                return 1;
+            }
 
-                    @Override
-                    public String description() {
-                        return "description";
-                    }
+            @Override
+            public String description() {
+                return "description";
+            }
 
-                    @Override
-                    public List<ScoringComponent> getComponents() {
-                        return List.of();
-                    }
+            @Override
+            public List<ScoringComponent> getComponents() {
+                return List.of();
+            }
 
-                    @Override
-                    public int version() {
-                        return 0;
-                    }
-                }
-            ));
+            @Override
+            public int version() {
+                return 0;
+            }
+        }));
 
         mockMvc.perform(get("/scores"))
-            .andExpect(status().isOk())
-            .andExpect(view().name("scores/listing"))
-            .andExpect(model().attribute("module", "scores"))
-            .andExpect(model().attributeExists("scorings"));
+                .andExpect(status().isOk())
+                .andExpect(view().name("scores/listing"))
+                .andExpect(model().attribute("module", "scores"))
+                .andExpect(model().attributeExists("scorings"));
     }
 
     @Test
@@ -118,9 +117,7 @@ class ScoreControllerTest {
 
         final Plugin plugin = mock(Plugin.class);
         when(plugin.getName()).thenReturn(pluginName);
-        when(plugin.getDetails()).thenReturn(Map.of(
-            probeKey, ProbeResult.success(probeKey, "message", 1)
-        ));
+        when(plugin.getDetails()).thenReturn(Map.of(probeKey, ProbeResult.success(probeKey, "message", 1)));
         when(plugin.getScm()).thenReturn("this-is-the-url-of-the-plugin-location");
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusHours(1));
         when(plugin.getVersion()).thenReturn(new VersionNumber("1.0"));
@@ -128,37 +125,34 @@ class ScoreControllerTest {
         final Score score = mock(Score.class);
         when(score.getPlugin()).thenReturn(plugin);
         when(score.getValue()).thenReturn(42L);
-        when(score.getDetails()).thenReturn(Set.of(
-            new ScoreResult(scoreKey, 42, 1f, Set.of(), 1)
-        ));
+        when(score.getDetails()).thenReturn(Set.of(new ScoreResult(scoreKey, 42, 1f, Set.of(), 1)));
 
         when(scoreService.latestScoreFor(pluginName)).thenReturn(Optional.of(score));
 
         mockMvc.perform(get("/scores/{pluginName}", pluginName))
-            .andExpect(status().isOk())
-            .andExpect(view().name("scores/details"))
-            .andExpect(model().attribute("module", "scores"))
-            .andExpect(model().attributeExists("score"))
-            /*.andExpect(model().attribute(
-                "score",
-                allOf(
-                    hasProperty("value", equalTo(42L)),
-                    hasProperty("pluginName", equalTo(pluginName)),
-                    hasProperty("probeResults", instanceOf(Map.class)),
-                    hasProperty("details", instanceOf(Collection.class))
-                )
-            ))*/; // TODO see https://github.com/hamcrest/JavaHamcrest/issues/392
+                .andExpect(status().isOk())
+                .andExpect(view().name("scores/details"))
+                .andExpect(model().attribute("module", "scores"))
+                .andExpect(model().attributeExists("score"))
+        /*.andExpect(model().attribute(
+            "score",
+            allOf(
+                hasProperty("value", equalTo(42L)),
+                hasProperty("pluginName", equalTo(pluginName)),
+                hasProperty("probeResults", instanceOf(Map.class)),
+                hasProperty("details", instanceOf(Collection.class))
+            )
+        ))*/ ; // TODO see https://github.com/hamcrest/JavaHamcrest/issues/392
     }
 
     @Test
     void shouldDisplayErrorWhenPluginUnknown() throws Exception {
-        when(scoreService.latestScoreFor(anyString()))
-            .thenReturn(Optional.empty());
+        when(scoreService.latestScoreFor(anyString())).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/scores/foo-bar"))
-            .andExpect(status().isNotFound())
-            .andExpect(view().name("scores/unknown"))
-            .andExpect(model().attribute("module", "scores"))
-            .andExpect(model().attribute("pluginName", equalTo("foo-bar")));
+                .andExpect(status().isNotFound())
+                .andExpect(view().name("scores/unknown"))
+                .andExpect(model().attribute("module", "scores"))
+                .andExpect(model().attribute("pluginName", equalTo("foo-bar")));
     }
 }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,19 +58,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProbeEngineTest {
-    @Mock private PluginService pluginService;
-    @Mock private ProbeService probeService;
-    @Mock private UpdateCenterService updateCenterService;
-    @Mock private GitHub gitHub;
-    @Mock private PluginDocumentationService pluginDocumentationService;
+    @Mock
+    private PluginService pluginService;
+
+    @Mock
+    private ProbeService probeService;
+
+    @Mock
+    private UpdateCenterService updateCenterService;
+
+    @Mock
+    private GitHub gitHub;
+
+    @Mock
+    private PluginDocumentationService pluginDocumentationService;
 
     @BeforeEach
     void setup() throws IOException {
-        when(updateCenterService.fetchUpdateCenter()).thenReturn(new UpdateCenter(
-            Map.of(),
-            Map.of(),
-            List.of()
-        ));
+        when(updateCenterService.fetchUpdateCenter()).thenReturn(new UpdateCenter(Map.of(), Map.of(), List.of()));
     }
 
     @Test
@@ -87,11 +91,13 @@ class ProbeEngineTest {
         when(probe.key()).thenReturn("probe");
         when(probe.doApply(plugin, ctx)).thenReturn(expectedResult);
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe).doApply(plugin, ctx);
@@ -115,11 +121,13 @@ class ProbeEngineTest {
         when(probe.key()).thenReturn(probeKey);
         when(probe.getVersion()).thenReturn(1L);
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe, never()).doApply(plugin, ctx);
@@ -133,9 +141,15 @@ class ProbeEngineTest {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
-        when(plugin.getDetails()).thenReturn(Map.of(
-            "probe", new ProbeResult("probe", "message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        "probe",
+                        new ProbeResult(
+                                "probe",
+                                "message",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusDays(1),
+                                1)));
         when(plugin.getName()).thenReturn("foo");
 
         when(probe.getVersion()).thenReturn(1L);
@@ -143,11 +157,13 @@ class ProbeEngineTest {
         when(probe.requiresRelease()).thenReturn(false);
         when(probe.isSourceCodeRelated()).thenReturn(true);
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe, never()).doApply(plugin, ctx);
@@ -163,23 +179,33 @@ class ProbeEngineTest {
         final ProbeResult result = new ProbeResult(probeKey, "message", ProbeResult.Status.SUCCESS, 1);
 
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
-        when(plugin.getDetails()).thenReturn(Map.of(
-            probeKey, new ProbeResult(probeKey, "message", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        probeKey,
+                        new ProbeResult(
+                                probeKey,
+                                "message",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusDays(1),
+                                1)));
 
         when(probe.getVersion()).thenReturn(1L);
-        when(ctx.getScmRepository()).thenReturn(Optional.of(Files.createTempDirectory("ProbeEngineTest-shouldApplyProbeRelatedToCodeWithNewCommit")));
+        when(ctx.getScmRepository())
+                .thenReturn(Optional.of(
+                        Files.createTempDirectory("ProbeEngineTest-shouldApplyProbeRelatedToCodeWithNewCommit")));
         when(ctx.getLastCommitDate()).thenReturn(Optional.of(ZonedDateTime.now()));
 
         when(probe.key()).thenReturn(probeKey);
         when(probe.isSourceCodeRelated()).thenReturn(true);
         when(probe.doApply(plugin, ctx)).thenReturn(result);
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe).doApply(plugin, ctx);
@@ -195,18 +221,28 @@ class ProbeEngineTest {
 
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now());
-        when(plugin.getDetails()).thenReturn(Map.of(probeKey, new ProbeResult(probeKey, "this is ok", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1)));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        probeKey,
+                        new ProbeResult(
+                                probeKey,
+                                "this is ok",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusDays(1),
+                                1)));
 
         when(probe.getVersion()).thenReturn(1L);
         when(probe.key()).thenReturn(probeKey);
         when(probe.requiresRelease()).thenReturn(true);
         when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.success(probeKey, "This is also ok", 1));
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe).doApply(eq(plugin), any(ProbeContext.class));
@@ -221,21 +257,28 @@ class ProbeEngineTest {
         final ProbeContext ctx = mock(ProbeContext.class);
 
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
-        when(plugin.getDetails()).thenReturn(Map.of(
-            probeKey,
-            new ProbeResult(probeKey, "this is ok", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        probeKey,
+                        new ProbeResult(
+                                probeKey,
+                                "this is ok",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusDays(1),
+                                1)));
 
         when(probe.getVersion()).thenReturn(1L);
         when(probe.requiresRelease()).thenReturn(false);
         when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.success(probeKey, "This is also ok", 1));
         when(probe.key()).thenReturn(probeKey);
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe).doApply(plugin, ctx);
@@ -251,11 +294,13 @@ class ProbeEngineTest {
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
         when(probe.doApply(plugin, ctx)).thenReturn(ProbeResult.error("foo", "bar", 1));
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(plugin).addDetails(any(ProbeResult.class));
@@ -269,9 +314,9 @@ class ProbeEngineTest {
         final Probe probeTwo = new Probe() {
             @Override
             protected ProbeResult doApply(Plugin plugin, ProbeContext ctx) {
-                return plugin.getDetails().get("foo") != null ?
-                    ProbeResult.success(key(), "This is also ok", this.getVersion()) :
-                    ProbeResult.error(key(), "This cannot be validated", this.getVersion());
+                return plugin.getDetails().get("foo") != null
+                        ? ProbeResult.success(key(), "This is also ok", this.getVersion())
+                        : ProbeResult.error(key(), "This cannot be validated", this.getVersion());
             }
 
             @Override
@@ -293,13 +338,15 @@ class ProbeEngineTest {
         when(probeOne.key()).thenReturn("foo");
         when(probeOne.doApply(plugin, ctx)).thenReturn(ProbeResult.success("foo", "This is ok", 1));
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probeOne, probeTwo));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(plugin, times(2)).addDetails(any(ProbeResult.class));
@@ -310,9 +357,8 @@ class ProbeEngineTest {
     void shouldForceProbeExecutionWhenNewVersionOfTheProbe() throws IOException {
         final String probeKey = "foo";
         final long version = 1L;
-        final ProbeResult newProbeResult = new ProbeResult(
-            probeKey, "this is a message", ProbeResult.Status.SUCCESS, version + 1
-        );
+        final ProbeResult newProbeResult =
+                new ProbeResult(probeKey, "this is a message", ProbeResult.Status.SUCCESS, version + 1);
 
         final Plugin plugin = mock(Plugin.class);
         final Probe probe = spy(new Probe() {
@@ -343,17 +389,18 @@ class ProbeEngineTest {
         });
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        final ProbeResult previousResult = new ProbeResult(probeKey, "this is a message", ProbeResult.Status.SUCCESS, version);
+        final ProbeResult previousResult =
+                new ProbeResult(probeKey, "this is a message", ProbeResult.Status.SUCCESS, version);
         when(plugin.getScm()).thenReturn("this-is-ok-for-testing");
-        when(plugin.getDetails()).thenReturn(Map.of(
-            probeKey, previousResult
-        ));
+        when(plugin.getDetails()).thenReturn(Map.of(probeKey, previousResult));
 
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(probeService.getProbes()).thenReturn(List.of(probe));
         when(pluginService.streamAll()).thenReturn(Stream.of(plugin));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(probe).doApply(plugin, ctx);
@@ -374,10 +421,12 @@ class ProbeEngineTest {
         when(probe.apply(p2, ctx)).thenReturn(ProbeResult.success("foo", "this is ok too", 1));
 
         when(probeService.getProbes()).thenReturn(List.of(probe));
-        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class))).thenReturn(ctx);
+        when(probeService.getProbeContext(any(Plugin.class), any(UpdateCenter.class)))
+                .thenReturn(ctx);
         when(pluginService.streamAll()).thenReturn(Stream.of(p1, p2));
 
-        final ProbeEngine probeEngine = new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
+        final ProbeEngine probeEngine =
+                new ProbeEngine(probeService, pluginService, updateCenterService, gitHub, pluginDocumentationService);
         probeEngine.run();
 
         verify(pluginDocumentationService).fetchPluginDocumentationUrl();

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterSchedulerIT.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterSchedulerIT.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,14 +45,21 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
 class UpdateCenterSchedulerIT extends AbstractDBContainerTest {
-    @Autowired private PluginRepository pluginRepository;
-    @Mock private UpdateCenterService ucService;
+    @Autowired
+    private PluginRepository pluginRepository;
+
+    @Mock
+    private UpdateCenterService ucService;
+
     private UpdateCenterScheduler upScheduler;
 
     @BeforeEach
     void setupUpdateCenterContent() throws IOException {
-        final UpdateCenter updateCenter = Jackson2ObjectMapperBuilder.json().build()
-            .readValue(UpdateCenterSchedulerIT.class.getResourceAsStream("/update-center/update-center.actual.json"), UpdateCenter.class);
+        final UpdateCenter updateCenter = Jackson2ObjectMapperBuilder.json()
+                .build()
+                .readValue(
+                        UpdateCenterSchedulerIT.class.getResourceAsStream("/update-center/update-center.actual.json"),
+                        UpdateCenter.class);
 
         when(ucService.fetchUpdateCenter()).thenReturn(updateCenter);
         upScheduler = new UpdateCenterScheduler(ucService, new PluginService(pluginRepository));

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/scores/ScoringEngineTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/scores/ScoringEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,9 +56,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ScoringEngineTest {
-    @Mock private PluginService pluginService;
-    @Mock private ScoringService scoringService;
-    @Mock private ScoreService scoreService;
+    @Mock
+    private PluginService pluginService;
+
+    @Mock
+    private ScoringService scoringService;
+
+    @Mock
+    private ScoreService scoreService;
 
     @Test
     void shouldBeAbleToScoreOnePlugin() {
@@ -119,8 +123,9 @@ class ScoringEngineTest {
         final ArgumentCaptor<Score> scoreArgument = ArgumentCaptor.forClass(Score.class);
         verify(scoreService, times(3)).save(scoreArgument.capture());
         assertThat(scoreArgument.getAllValues())
-            .filteredOn(score -> Objects.nonNull(score) && score.getDetails().size() == 2 && score.getValue() == 85)
-            .hasSize(3);
+                .filteredOn(
+                        score -> Objects.nonNull(score) && score.getDetails().size() == 2 && score.getValue() == 85)
+                .hasSize(3);
     }
 
     @Test
@@ -128,9 +133,15 @@ class ScoringEngineTest {
         final Plugin pluginA = mock(Plugin.class);
         final String pluginName = "plugin-a";
         when(pluginA.getName()).thenReturn(pluginName);
-        when(pluginA.getDetails()).thenReturn(Map.of(
-            "foo-bar", new ProbeResult("foo-bar", "", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusMinutes(15), 1)
-        ));
+        when(pluginA.getDetails())
+                .thenReturn(Map.of(
+                        "foo-bar",
+                        new ProbeResult(
+                                "foo-bar",
+                                "",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusMinutes(15),
+                                1)));
 
         final String scoringAKey = "scoring-A";
         final Scoring scoringA = mock(Scoring.class);
@@ -139,9 +150,7 @@ class ScoringEngineTest {
 
         final Score oldPluginAScore = mock(Score.class);
         when(oldPluginAScore.getComputedAt()).thenReturn(ZonedDateTime.now().minusMinutes(5));
-        when(oldPluginAScore.getDetails()).thenReturn(Set.of(
-            new ScoreResult(scoringAKey, 100, 1, Set.of(), 1)
-        ));
+        when(oldPluginAScore.getDetails()).thenReturn(Set.of(new ScoreResult(scoringAKey, 100, 1, Set.of(), 1)));
 
         when(scoringService.getScoringList()).thenReturn(List.of(scoringA));
         when(scoreService.latestScoreFor(pluginName)).thenReturn(Optional.of(oldPluginAScore));
@@ -162,26 +171,26 @@ class ScoringEngineTest {
         final Score previousScore = mock(Score.class);
 
         when(plugin.getName()).thenReturn("foo-bar");
-        when(plugin.getDetails()).thenReturn(Map.of(
-            "foo-bar", new ProbeResult("foo-bar", "", ProbeResult.Status.SUCCESS, ZonedDateTime.now().minusDays(1), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        "foo-bar",
+                        new ProbeResult(
+                                "foo-bar",
+                                "",
+                                ProbeResult.Status.SUCCESS,
+                                ZonedDateTime.now().minusDays(1),
+                                1)));
 
         when(scoringA.key()).thenReturn("scoring-a");
         when(scoringA.version()).thenReturn(2);
         final ScoreResult expectedNewScoreResult = new ScoreResult("scoring-a", 100, .5f, Set.of(), 2);
-        when(scoringA.apply(plugin)).thenReturn(
-            expectedNewScoreResult
-        );
+        when(scoringA.apply(plugin)).thenReturn(expectedNewScoreResult);
 
-        when(previousScore.getDetails()).thenReturn(Set.of(
-            new ScoreResult("scoring-a", 1, 1, Set.of(), 1)
-        ));
+        when(previousScore.getDetails()).thenReturn(Set.of(new ScoreResult("scoring-a", 1, 1, Set.of(), 1)));
         when(previousScore.getComputedAt()).thenReturn(ZonedDateTime.now().minusHours(1));
 
         when(scoringService.getScoringList()).thenReturn(List.of(scoringA));
-        when(scoreService.latestScoreFor("foo-bar")).thenReturn(Optional.of(
-            previousScore
-        ));
+        when(scoreService.latestScoreFor("foo-bar")).thenReturn(Optional.of(previousScore));
         when(scoreService.save(any(Score.class))).then(AdditionalAnswers.returnsFirstArg());
 
         final ScoringEngine scoringEngine = new ScoringEngine(scoringService, pluginService, scoreService);
@@ -205,18 +214,17 @@ class ScoringEngineTest {
 
         String pluginName = "plugin";
         when(plugin.getName()).thenReturn(pluginName);
-        when(plugin.getDetails()).thenReturn(Map.of(
-            "probe-a", new ProbeResult("probe-a", "", ProbeResult.Status.SUCCESS, now.minusMinutes(10), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        "probe-a",
+                        new ProbeResult("probe-a", "", ProbeResult.Status.SUCCESS, now.minusMinutes(10), 1)));
 
         when(scoringA.version()).thenReturn(1);
         when(scoringA.key()).thenReturn("scoring-a");
         when(scoringB.key()).thenReturn("scoring-b");
 
         Score previousScore = mock(Score.class);
-        when(previousScore.getDetails()).thenReturn(Set.of(
-            new ScoreResult("scoring-a", 1, 1, Set.of(), 1)
-        ));
+        when(previousScore.getDetails()).thenReturn(Set.of(new ScoreResult("scoring-a", 1, 1, Set.of(), 1)));
         when(previousScore.getComputedAt()).thenReturn(now.minusMinutes(5));
         when(scoreService.latestScoreFor(pluginName)).thenReturn(Optional.of(previousScore));
 
@@ -239,9 +247,10 @@ class ScoringEngineTest {
 
         String pluginName = "plugin";
         when(plugin.getName()).thenReturn(pluginName);
-        when(plugin.getDetails()).thenReturn(Map.of(
-            "probe-a", new ProbeResult("probe-a", "", ProbeResult.Status.SUCCESS, now.minusMinutes(10), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        "probe-a",
+                        new ProbeResult("probe-a", "", ProbeResult.Status.SUCCESS, now.minusMinutes(10), 1)));
 
         when(scoringA.version()).thenReturn(1);
         when(scoringA.key()).thenReturn("scoring-a");
@@ -249,10 +258,10 @@ class ScoringEngineTest {
         when(scoringB.key()).thenReturn("scoring-b");
 
         Score previousScore = mock(Score.class);
-        when(previousScore.getDetails()).thenReturn(Set.of(
-            new ScoreResult("scoring-a", 1, 1, Set.of(), 1),
-            new ScoreResult("scoring-b", 1, 1, Set.of(), 1)
-        ));
+        when(previousScore.getDetails())
+                .thenReturn(Set.of(
+                        new ScoreResult("scoring-a", 1, 1, Set.of(), 1),
+                        new ScoreResult("scoring-b", 1, 1, Set.of(), 1)));
         when(previousScore.getComputedAt()).thenReturn(now.minusMinutes(5));
         when(scoreService.latestScoreFor(pluginName)).thenReturn(Optional.of(previousScore));
 

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,50 +38,50 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 
 @JsonTest
 class PluginDocumentationServiceTest {
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     void shouldBeAbleToParseAvailableFile() {
-        final URL url = PluginDocumentationService.class.getResource("/documentation-urls/plugin-documentation-urls.json");
+        final URL url =
+                PluginDocumentationService.class.getResource("/documentation-urls/plugin-documentation-urls.json");
         assertThat(url).isNotNull();
 
         final ApplicationConfiguration config = new ApplicationConfiguration(
-            new ApplicationConfiguration.Jenkins("foo", url.toString()),
-            new ApplicationConfiguration.GitHub("foo", null, "bar")
-        );
+                new ApplicationConfiguration.Jenkins("foo", url.toString()),
+                new ApplicationConfiguration.GitHub("foo", null, "bar"));
 
         final PluginDocumentationService service = new PluginDocumentationService(objectMapper, config);
         final Map<String, String> map = service.fetchPluginDocumentationUrl();
 
         assertThat(map)
-            .contains(entry("foo", "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"))
-            .contains(entry("bar", "https://github.com/jenkinsci/bar-plugin"));
+                .contains(entry("foo", "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"))
+                .contains(entry("bar", "https://github.com/jenkinsci/bar-plugin"));
     }
 
     @Test
     void shouldBeAbleToParseFileWithNullValue() {
-        final URL url = PluginDocumentationService.class.getResource("/documentation-urls/plugin-documentation-urls-with-nulls.json");
+        final URL url = PluginDocumentationService.class.getResource(
+                "/documentation-urls/plugin-documentation-urls-with-nulls.json");
         assertThat(url).isNotNull();
 
         final ApplicationConfiguration config = new ApplicationConfiguration(
-            new ApplicationConfiguration.Jenkins("foo", url.toString()),
-            new ApplicationConfiguration.GitHub("foo", null, "bar")
-        );
+                new ApplicationConfiguration.Jenkins("foo", url.toString()),
+                new ApplicationConfiguration.GitHub("foo", null, "bar"));
 
         final PluginDocumentationService service = new PluginDocumentationService(objectMapper, config);
         final Map<String, String> map = service.fetchPluginDocumentationUrl();
 
         assertThat(map)
-            .contains(entry("foo", "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"))
-            .contains(entry("bar", "https://github.com/jenkinsci/bar-plugin"));
+                .contains(entry("foo", "https://wiki.jenkins-ci.org/display/JENKINS/foo+plugin"))
+                .contains(entry("bar", "https://github.com/jenkinsci/bar-plugin"));
     }
 
     @Test
     void shouldSurviveIncorrectlyConfiguredDocumentationURL() {
         final ApplicationConfiguration config = new ApplicationConfiguration(
-            new ApplicationConfiguration.Jenkins("foo", "this-is-not-a-correct-url"),
-            new ApplicationConfiguration.GitHub("foo", null, "bar")
-        );
+                new ApplicationConfiguration.Jenkins("foo", "this-is-not-a-correct-url"),
+                new ApplicationConfiguration.GitHub("foo", null, "bar"));
         final PluginDocumentationService service = new PluginDocumentationService(objectMapper, config);
         final Map<String, String> map = service.fetchPluginDocumentationUrl();
 

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2023 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +37,8 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 
 @JsonTest
 class UpdateCenterServiceTest {
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     void shouldBeAbleToParseUpdateCenterWithNoDeprecations() throws Exception {
@@ -46,9 +46,8 @@ class UpdateCenterServiceTest {
         assertThat(updateCenterURL).isNotNull();
 
         final ApplicationConfiguration configuration = new ApplicationConfiguration(
-            new ApplicationConfiguration.Jenkins(updateCenterURL.toString(), "foo"),
-            new ApplicationConfiguration.GitHub("foo", null, "bar")
-        );
+                new ApplicationConfiguration.Jenkins(updateCenterURL.toString(), "foo"),
+                new ApplicationConfiguration.GitHub("foo", null, "bar"));
 
         UpdateCenterService updateCenterService = new UpdateCenterService(objectMapper, configuration);
 


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Because of #477, the release cannot be built on infra.ci.jenkins.io because the code is cloned using shallow clone.
This means spotless cannot see if the files it has were modified in comparison of the main branch of the project.

So we need to apply spotless on all the files for the build to complete.
A shame release to generate so much noise. 

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

N/A. This is only code formatting. 
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
