### PR TITLE
Disable spotless on tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ pipeline {
         script {
           infra.withArtifactCachingProxy() {
             def OPTS = env.MAVEN_SETTINGS ? "-s ${MAVEN_SETTINGS}" : ''
-            sh """
+            OPTS += env.TAG_NAME ? ' -Dspotless.check.skip=true' : ''
+            sh '''
               ./mvnw -V \
                 --no-transfer-progress \
                 ${OPTS} \
@@ -30,7 +31,7 @@ pipeline {
                 -Dmaven.test.failure.ignore \
                 -Dcheckstyle.failOnViolation=false \
                 -Dspotbugs.failOnError=false
-            """
+            '''
           }
         }
       }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

This PR disable spotless check when building a tag to avoid the following error:

> [ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.43.0:check (default) on project plugin-health-scoring-parent: Execution default of goal com.diffplug.spotless:spotless-maven-plugin:2.43.0:check failed: No such reference 'origin/main' -> [Help 1]

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Tested with a replay of the v3.7.1 tag build on infra.ci.jenkins.io: https://infra.ci.jenkins.io/job/docker-jobs/job/plugin-health-scoring/view/tags/job/v3.7.1/8/console

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [ ] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
