### PR TITLE
Fixes adoptions scoring when last release is more recent than last commit

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.time.Duration;
@@ -51,7 +50,7 @@ public class AdoptionScoring extends Scoring {
             final ZonedDateTime commitDate = ZonedDateTime
                 .parse(lastCommitDateMessage, DateTimeFormatter.ISO_DATE_TIME)
                 .withZoneSameInstant(getZone());
-            return Duration.between(then, commitDate).abs();
+            return Duration.between(then, commitDate);
         }
 
         protected ZoneId getZone() {
@@ -114,6 +113,9 @@ public class AdoptionScoring extends Scoring {
                         return new ScoringComponentResult(-100, 100, List.of("Cannot determine the last commit date."));
                     }
                     final long days = getTimeBetweenLastCommitAndDate(probeResult.message(), plugin.getReleaseTimestamp().withZoneSameInstant(getZone())).toDays();
+                    if (days < 0) {
+                        return new ScoringComponentResult(100, getWeight(), List.of("The latest release is more recent than the latest commit on the plugin."));
+                    }
                     final String defaultReason = "There are %d days between last release and last commit.".formatted(days);
                     if (days < Duration.of(30 * 6, ChronoUnit.DAYS).toDays()) {
                         return new ScoringComponentResult(100, getWeight(), List.of(defaultReason, "Less than 6 months gap between last release and last commit."));

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -179,6 +179,6 @@ public class AdoptionScoring extends Scoring {
 
     @Override
     public int version() {
-        return 4;
+        return 5;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
@@ -31,12 +31,10 @@ import static org.mockito.Mockito.when;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.Set;
 
 import io.jenkins.pluginhealth.scoring.model.Plugin;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
-import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.probes.LastCommitDateProbe;
 import io.jenkins.pluginhealth.scoring.probes.UpForAdoptionProbe;
 
@@ -53,16 +51,17 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final AdoptionScoring scoring = getSpy();
         final Plugin plugin = mock(Plugin.class);
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                        ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.key()).isEqualTo("adoption");
         assertThat(result.weight()).isEqualTo(.8f);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Cannot determine the last commit date.");
+                .contains("Cannot determine the last commit date.");
     }
 
     @Test
@@ -71,10 +70,15 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusHours(4));
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1),
-            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.key()).isEqualTo("adoption");
@@ -87,14 +91,15 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final AdoptionScoring scoring = getSpy();
         final Plugin plugin = mock(Plugin.class);
 
-        when(plugin.getDetails()).thenReturn(
-            Map.of(UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1))
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                        ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Cannot determine the last commit date.");
+                .contains("Cannot determine the last commit date.");
     }
 
     @Test
@@ -103,17 +108,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(2));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(100);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 6 months gap between last release and last commit.");
+                .contains("Less than 6 months gap between last release and last commit.");
     }
 
     @Test
@@ -122,17 +130,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(8));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(80);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than a year between last release and last commit.");
+                .contains("Less than a year between last release and last commit.");
     }
 
     @Test
@@ -141,17 +152,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusMonths(18));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(60);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 2 years between last release and last commit.");
+                .contains("Less than 2 years between last release and last commit.");
     }
 
     @Test
@@ -160,17 +174,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusYears(3));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(40);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("Less than 4 years between last release and last commit.");
+                .contains("Less than 4 years between last release and last commit.");
     }
 
     @Test
@@ -179,17 +196,20 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(ZonedDateTime.now().minusYears(5));
-        when(plugin.getDetails()).thenReturn(
-            Map.of(
-                UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-                LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME), 1)
-            )
-        );
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        ZonedDateTime.now().minusHours(3).format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(0);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("There is more than 4 years between the last release and the last commit.");
+                .contains("There is more than 4 years between the last release and the last commit.");
     }
 
     @Test
@@ -201,14 +221,19 @@ class AdoptionScoringTest extends AbstractScoringTest<AdoptionScoring> {
         final Plugin plugin = mock(Plugin.class);
 
         when(plugin.getReleaseTimestamp()).thenReturn(releaseDateTime);
-        when(plugin.getDetails()).thenReturn(Map.of(
-            UpForAdoptionProbe.KEY, ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
-            LastCommitDateProbe.KEY, ProbeResult.success(LastCommitDateProbe.KEY, commitDateTime.format(DateTimeFormatter.ISO_DATE_TIME), 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        UpForAdoptionProbe.KEY,
+                                ProbeResult.success(UpForAdoptionProbe.KEY, "This plugin is not up for adoption.", 1),
+                        LastCommitDateProbe.KEY,
+                                ProbeResult.success(
+                                        LastCommitDateProbe.KEY,
+                                        commitDateTime.format(DateTimeFormatter.ISO_DATE_TIME),
+                                        1)));
 
         final ScoreResult result = scoring.apply(plugin);
         assertThat(result.value()).isEqualTo(100);
         assertThat(result.componentsResults().stream().flatMap(scr -> scr.reasons().stream()))
-            .contains("The latest release is more recent than the latest commit on the plugin.");
+                .contains("The latest release is more recent than the latest commit on the plugin.");
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/AdoptionScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #485.

When a plugin is in a multimodule repository, and its version is managed within the parent-pom of this repository, it is possible to see that the latest release of the plugin is more recent than its latest commit.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Adding a unit test proving there is a problem.
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
