### PR TITLE
The plugn description migration probe requires to have a clone of the code

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -50,21 +49,20 @@ public class PluginDescriptionMigrationProbe extends Probe {
         }
 
         final Path repository = scmRepositoryOpt.get();
-        final Path pluginFolder = context.getScmFolderPath().map(repository::resolve).orElse(repository);
+        final Path pluginFolder =
+                context.getScmFolderPath().map(repository::resolve).orElse(repository);
 
         try (Stream<Path> files = Files.find(
-            pluginFolder.resolve("src").resolve("main").resolve("resources"),
-            1,
-            (path, attributes) -> "index.jelly".equals(path.getFileName().toString())
-        )) {
+                pluginFolder.resolve("src").resolve("main").resolve("resources"), 1, (path, attributes) -> "index.jelly"
+                        .equals(path.getFileName().toString()))) {
             final Optional<Path> jellyFileOpt = files.findFirst();
             if (jellyFileOpt.isEmpty()) {
                 return success("There is no `index.jelly` file in `src/main/resources`.");
             }
             final Path jellyFile = jellyFileOpt.get();
-            return Files.readAllLines(jellyFile).stream().map(String::trim).anyMatch(s -> s.contains("TODO")) ?
-                    success("Plugin is using description from the plugin archetype.") :
-                    success("Plugin seems to have a correct description.");
+            return Files.readAllLines(jellyFile).stream().map(String::trim).anyMatch(s -> s.contains("TODO"))
+                    ? success("Plugin is using description from the plugin archetype.")
+                    : success("Plugin seems to have a correct description.");
         } catch (IOException e) {
             return error("Cannot browse plugin source code folder.");
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/PluginDescriptionMigrationProbe.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 @Order(PluginDescriptionMigrationProbe.ORDER)
 public class PluginDescriptionMigrationProbe extends Probe {
     public static final String KEY = "description-migration";
-    public static final int ORDER = DocumentationMigrationProbe.ORDER + 100;
+    public static final int ORDER = SCMLinkValidationProbe.ORDER + 100;
 
     @Override
     protected ProbeResult doApply(Plugin plugin, ProbeContext context) {


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

While reviewing the latest deployment of the application (v3.7.1), I noticed that the documentation scoring was returning incorrect values. More specifically due to the plugin description migration probe.
That once was not executed correctly, because it didn't have the plugin source code available.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Running the application locally with the fix proved to resolve the problem.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
