### PR TITLE
Provide scoring timestamp on JSON API

### DIFF
--- a/war/src/main/resources/application.yaml
+++ b/war/src/main/resources/application.yaml
@@ -4,6 +4,8 @@ spring:
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     driverClassName: org.postgresql.Driver
+  jackson:
+    date-format: com.fasterxml.jackson.databind.util.StdDateFormat
   jpa:
     hibernate:
       ddl-auto: update

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/http/ScoreAPITest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,8 +46,6 @@ import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
 import io.jenkins.pluginhealth.scoring.service.ScoreService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -63,15 +60,18 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@ExtendWith({ SpringExtension.class, MockitoExtension.class })
-@ImportAutoConfiguration({ ProjectInfoAutoConfiguration.class, SecurityConfiguration.class })
-@WebMvcTest(
-    controllers = ScoreAPI.class
-)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@ImportAutoConfiguration({ProjectInfoAutoConfiguration.class, SecurityConfiguration.class})
+@WebMvcTest(controllers = ScoreAPI.class)
 class ScoreAPITest {
-    @MockBean private ScoreService scoreService;
-    @Autowired private MockMvc mockMvc;
-    @Autowired ObjectMapper mapper;
+    @MockBean
+    private ScoreService scoreService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper mapper;
 
     @Test
     void shouldBeAbleToProvideScoresSummary() throws Exception {
@@ -80,28 +80,46 @@ class ScoreAPITest {
 
         final ZonedDateTime scoreP1Date = ZonedDateTime.now().minusMinutes(1);
         final Score scoreP1 = new Score(p1, scoreP1Date);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
         final ZonedDateTime scoreP2Date = ZonedDateTime.now().minusDays(1);
         final Score scoreP2 = new Score(p2, scoreP2Date);
-        scoreP2.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
-        scoreP2.addDetail(new ScoreResult("scoring-2", 50, 1, Set.of(
-            new ScoringComponentResult(0, 1, List.of("There is no Jenkinsfile detected on the plugin repository.")),
-            new ScoringComponentResult(100, .5f, List.of("The plugin documentation was migrated to its repository.")),
-            new ScoringComponentResult(100, .5f, List.of("The plugin is using dependabot.", "0 open pull requests from dependency update tool."))
-        ), 1));
+        scoreP2.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
+        scoreP2.addDetail(new ScoreResult(
+                "scoring-2",
+                50,
+                1,
+                Set.of(
+                        new ScoringComponentResult(
+                                0, 1, List.of("There is no Jenkinsfile detected on the plugin repository.")),
+                        new ScoringComponentResult(
+                                100, .5f, List.of("The plugin documentation was migrated to its repository.")),
+                        new ScoringComponentResult(
+                                100,
+                                .5f,
+                                List.of(
+                                        "The plugin is using dependabot.",
+                                        "0 open pull requests from dependency update tool."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", scoreP1,
-            "plugin-2", scoreP2
-        ));
-        when(scoreService.getScoresStatistics()).thenReturn(new ScoreService.ScoreStatistics(
-            87.5, 50, 100, 100, 100, 100
-        ));
+        when(scoreService.getLatestScoresSummaryMap())
+                .thenReturn(Map.of(
+                        "plugin-1", scoreP1,
+                        "plugin-2", scoreP2));
+        when(scoreService.getScoresStatistics())
+                .thenReturn(new ScoreService.ScoreStatistics(87.5, 50, 100, 100, 100, 100));
 
         // @formatter:off
         mockMvc.perform(get("/api/scores"))
@@ -187,21 +205,22 @@ class ScoreAPITest {
 
         final ZonedDateTime computedAt = ZonedDateTime.now().minusHours(2);
         final Score scoreP1 = new Score(plugin, computedAt);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", scoreP1
-        ));
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of("plugin-1", scoreP1));
 
         MvcResult mvcResult = mockMvc.perform(get("/api/scores"))
-            .andExpectAll(
-                status().isOk(),
-                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))),
-                content().contentType(MediaType.APPLICATION_JSON)
-            )
-            .andReturn();
+                .andExpectAll(
+                        status().isOk(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))),
+                        content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
 
         final HttpHeaders httpHeaders = new HttpHeaders();
         String responseETag = mvcResult.getResponse().getHeader("ETag");
@@ -209,11 +228,10 @@ class ScoreAPITest {
         httpHeaders.setIfNoneMatch(responseETag);
 
         mvcResult = mockMvc.perform(get("/api/scores").headers(httpHeaders))
-            .andExpectAll(
-                status().isNotModified(),
-                header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond())))
-            )
-            .andReturn();
+                .andExpectAll(
+                        status().isNotModified(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(computedAt.toEpochSecond()))))
+                .andReturn();
 
         responseETag = mvcResult.getResponse().getHeader("ETag");
         assertThat(responseETag).isNotNull();
@@ -221,19 +239,20 @@ class ScoreAPITest {
 
         final ZonedDateTime newScoreComputedAt = ZonedDateTime.now().minusMinutes(5);
         final Score newScoreP1 = new Score(plugin, newScoreComputedAt);
-        scoreP1.addDetail(new ScoreResult("scoring-1", 100, 1, Set.of(
-            new ScoringComponentResult(100, 1, List.of("There is no active security advisory for the plugin."))
-        ), 1));
+        scoreP1.addDetail(new ScoreResult(
+                "scoring-1",
+                100,
+                1,
+                Set.of(new ScoringComponentResult(
+                        100, 1, List.of("There is no active security advisory for the plugin."))),
+                1));
 
-        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of(
-            "plugin-1", newScoreP1
-        ));
+        when(scoreService.getLatestScoresSummaryMap()).thenReturn(Map.of("plugin-1", newScoreP1));
 
         mockMvc.perform(get("/api/scores").headers(httpHeaders))
-            .andExpectAll(
-                status().isOk(),
-                header().string("ETag", equalTo("\"%s\"".formatted(newScoreComputedAt.toEpochSecond()))),
-                content().contentType(MediaType.APPLICATION_JSON)
-            );
+                .andExpectAll(
+                        status().isOk(),
+                        header().string("ETag", equalTo("\"%s\"".formatted(newScoreComputedAt.toEpochSecond()))),
+                        content().contentType(MediaType.APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #489.

This introduce the date of the score computation on the API endpoint. 
This can be used to display that information on plugins.jenkins.io

@zbynek you can see the produced API content on the test.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Modified existing API test to validate the existence and format of the date.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
