### PR TITLE
Accepts all Renovate config file locations

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/AbstractDependencyBotConfigurationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -48,17 +47,15 @@ public abstract class AbstractDependencyBotConfigurationProbe extends Probe {
             return this.error("There is no local repository for plugin " + plugin.getName() + ".");
         }
         final Path scmRepository = context.getScmRepository().get();
-        final Path githubConfig = scmRepository.resolve(".github");
-        if (Files.notExists(githubConfig)) {
-            LOGGER.trace("No GitHub configuration folder at {} ", key());
-            return this.success("No GitHub configuration folder found.");
-        }
 
-        try (Stream<Path> paths = Files.find(githubConfig, 1, (path, $) ->
-            Files.isRegularFile(path) && isPathBotConfigFile(path.getFileName().toString()))) {
+        try (Stream<Path> paths = Files.find(
+                scmRepository,
+                2,
+                (path, $) -> Files.isRegularFile(path)
+                        && isPathBotConfigFile(path.getFileName().toString()))) {
             return paths.findFirst()
-                .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
-                .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
+                    .map(file -> this.success(String.format("%s is configured.", capitalize(getBotName()))))
+                    .orElseGet(() -> this.success(String.format("%s is not configured.", capitalize(getBotName()))));
         } catch (IOException ex) {
             LOGGER.error("Could not browse the plugin folder during probe {}", key(), ex);
             return this.error("Could not browse the plugin folder");

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import org.springframework.core.annotation.Order;

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbe.java
@@ -57,6 +57,6 @@ public class DependabotProbe extends AbstractDependencyBotConfigurationProbe {
 
     @Override
     public long getVersion() {
-        return 2;
+        return 3;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
@@ -59,6 +59,6 @@ public class RenovateProbe extends AbstractDependencyBotConfigurationProbe {
 
     @Override
     public long getVersion() {
-        return 2;
+        return 3;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbe.java
@@ -21,8 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
+
+import java.util.List;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -42,7 +43,8 @@ public class RenovateProbe extends AbstractDependencyBotConfigurationProbe {
 
     @Override
     protected boolean isPathBotConfigFile(String filename) {
-        return "renovate.json".equals(filename);
+        return List.of("renovate.json", "renovate.json5", ".renovaterc", ".renovaterc.json", ".renovaterc.json5")
+                .contains(filename);
     }
 
     @Override

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/DependabotProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,9 +67,12 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         final DependabotProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.error(DependabotProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.error(
+                        DependabotProbe.KEY,
+                        "There is no local repository for plugin " + plugin.getName() + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -83,9 +85,10 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(
+                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -100,9 +103,10 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(
+                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -119,9 +123,9 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 
@@ -138,9 +142,9 @@ class DependabotProbeTest extends AbstractProbeTest<DependabotProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", probe.getVersion()));
         verify(probe).doApply(any(Plugin.class), any(ProbeContext.class));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RenovateProbeTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,25 +63,13 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
 
         final RenovateProbe probe = getSpy();
         assertThat(probe.apply(plugin, ctx))
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.error(RenovateProbe.KEY, "There is no local repository for plugin " + plugin.getName() + ".", probe.getVersion()));
-    }
-
-    @Test
-    void shouldDetectMissingGitHubActionFolder() throws Exception {
-        final Plugin plugin = mock(Plugin.class);
-        final ProbeContext ctx = mock(ProbeContext.class);
-        final RenovateProbe probe = getSpy();
-
-        final Path repo = Files.createTempDirectory("foo");
-        when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
-
-        assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "No GitHub configuration folder found.", probe.getVersion()));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        RenovateProbe.KEY,
+                        "There is no local repository for plugin " + plugin.getName() + ".",
+                        probe.getVersion()));
     }
 
     @Test
@@ -96,26 +83,108 @@ public class RenovateProbeTest extends AbstractProbeTest<RenovateProbe> {
         when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "message", "status")
+                .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", probe.getVersion()));
     }
 
     @Test
-    void shouldDetectRenovateFile() throws Exception {
+    void shouldAcceptAnyOfRenovateConfigFileLocation() throws Exception {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final RenovateProbe probe = getSpy();
 
-        final Path repo = Files.createTempDirectory("foo");
-        final Path github = Files.createDirectories(repo.resolve(".github"));
+        // /renovate.json
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Files.createFile(repo.resolve("renovate.json"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
 
-        Files.createFile(github.resolve("renovate.json"));
-        when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find 'renovate.json'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
 
-        assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "message", "status")
-            .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        // /renovate.json5
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Files.createFile(repo.resolve("renovate.json5"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find 'renovate.json5'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
+
+        // /.github/renovate.json
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Path github = Files.createDirectories(repo.resolve(".github"));
+            Files.createFile(github.resolve("renovate.json"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find '.github/renovate.json'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
+
+        // /.github/renovate.json5
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            final Path github = Files.createDirectories(repo.resolve(".github"));
+            Files.createFile(github.resolve("renovate.json5"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find '.github/renovate.json5'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
+
+        // /.renovaterc
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Files.createFile(repo.resolve(".renovaterc"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find '.renovaterc'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
+
+        // /.renovaterc.json
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Files.createFile(repo.resolve(".renovaterc.json"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find '.renovaterc.json'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
+
+        // /.renovaterc.json5
+        {
+            final Path repo = Files.createTempDirectory("foo");
+            Files.createFile(repo.resolve(".renovaterc.json5"));
+            when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
+
+            assertThat(probe.apply(plugin, ctx))
+                    .withFailMessage(() -> "Cannot find '.renovaterc.json5'")
+                    .usingRecursiveComparison()
+                    .comparingOnlyFields("id", "message", "status")
+                    .isEqualTo(ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", probe.getVersion()));
+        }
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #483.

Renovate configuration files can be located in different places and have different names.
I choose not to include `package.json` as this might be confusing for plugins using NPM / Yarn.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Improved existing unit test to validate all accepted configuration files for renovate.
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
