### PR TITLE
Inheriting contributing guide should not lower score

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -47,15 +47,19 @@ public class ContributingGuidelinesProbe extends Probe {
         }
 
         final Path repository = context.getScmRepository().get();
-        try (Stream<Path> paths = Files.find(repository, 2,
-            (file, basicFileAttributes) -> Files.isReadable(file)
-                && ("CONTRIBUTING.md".equalsIgnoreCase(file.getFileName().toString())
-                || "CONTRIBUTING.adoc".equalsIgnoreCase(file.getFileName().toString())))) {
+        try (Stream<Path> paths = Files.find(
+                repository,
+                2,
+                (file, basicFileAttributes) -> Files.isReadable(file)
+                        && ("CONTRIBUTING.md"
+                                        .equalsIgnoreCase(file.getFileName().toString())
+                                || "CONTRIBUTING.adoc"
+                                        .equalsIgnoreCase(file.getFileName().toString())))) {
             return paths.findAny()
-                .map(file -> file.toFile().length() != 0
-                    ? this.success("Contributing guidelines found.")
-                    : this.success("Contributing guide seems to be empty."))
-                .orElseGet(() -> this.success("Inherit from organization contributing guide."));
+                    .map(file -> file.toFile().length() != 0
+                            ? this.success("Contributing guidelines found.")
+                            : this.success("Contributing guide seems to be empty."))
+                    .orElseGet(() -> this.success("Inherit from organization contributing guide."));
         } catch (IOException e) {
             return this.error(e.getMessage());
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.IOException;
@@ -53,8 +52,10 @@ public class ContributingGuidelinesProbe extends Probe {
                 && ("CONTRIBUTING.md".equalsIgnoreCase(file.getFileName().toString())
                 || "CONTRIBUTING.adoc".equalsIgnoreCase(file.getFileName().toString())))) {
             return paths.findAny()
-                .map(file -> this.success("Contributing guidelines found."))
-                .orElseGet(() -> this.success("No contributing guidelines found."));
+                .map(file -> file.toFile().length() != 0
+                    ? this.success("Contributing guidelines found.")
+                    : this.success("Contributing guide seems to be empty."))
+                .orElseGet(() -> this.success("Inherit from organization contributing guide."));
         } catch (IOException e) {
             return this.error(e.getMessage());
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import java.util.List;
@@ -61,141 +60,141 @@ public class DocumentationScoring extends Scoring {
     @Override
     public List<ScoringComponent> getComponents() {
         return List.of(
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "The plugin has a specific contributing guide.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
-                    if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
-                        return new ScoringComponentResult(100, getWeight(), List.of("Plugin has a contributing guide."));
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "The plugin has a specific contributing guide.";
                     }
-                    return new ScoringComponentResult(
-                        0,
-                        getWeight(),
-                        List.of("The plugin relies on the global contributing guide."),
-                        List.of(new Resolution(
-                            "See why and how to add a contributing guide",
-                            "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-contributing-guide/"
-                        ))
-                    );
-                }
 
-                @Override
-                public int getWeight() {
-                    return 2;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Plugin documentation should be migrated from the wiki.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult probeResult = probeResults.get(DocumentationMigrationProbe.KEY);
-                    if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                        return new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration."));
-                    }
-                    return switch (probeResult.message()) {
-                        case "Documentation is located in the plugin repository." ->
-                            new ScoringComponentResult(100, getWeight(), List.of("Documentation is in plugin repository."));
-                        case "Documentation is not located in the plugin repository." -> new ScoringComponentResult(
-                            0,
-                            getWeight(),
-                            List.of("Documentation should be migrated in plugin repository."),
-                            List.of(
-                                new Resolution("https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")
-                            )
-                        );
-                        default ->
-                            new ScoringComponentResult(0, getWeight(), List.of("Cannot confirm or not the documentation migration.", probeResult.message()));
-                    };
-                }
-
-                @Override
-                public int getWeight() {
-                    return 4;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Recommend to setup Release Drafter on the plugin repository.";
-                }
-
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    ProbeResult cdProbe = probeResults.get(ContinuousDeliveryProbe.KEY);
-                    if (cdProbe != null && "JEP-229 workflow definition found.".equals(cdProbe.message())) {
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
+                        if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
+                            return new ScoringComponentResult(
+                                    100, getWeight(), List.of("Plugin has a contributing guide."));
+                        }
                         return new ScoringComponentResult(
-                            100,
-                            getWeight(),
-                            List.of("Plugin using Release Drafter because it has CD configured.")
-                        );
+                                0,
+                                getWeight(),
+                                List.of("The plugin relies on the global contributing guide."),
+                                List.of(
+                                        new Resolution(
+                                                "See why and how to add a contributing guide",
+                                                "https://www.jenkins.io/doc/developer/tutorial-improve/add-a-contributing-guide/")));
                     }
-                    ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
-                    if (result != null && "Release Drafter is configured.".equals(result.message())) {
+
+                    @Override
+                    public int getWeight() {
+                        return 2;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Plugin documentation should be migrated from the wiki.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin $, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult probeResult = probeResults.get(DocumentationMigrationProbe.KEY);
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(
+                                    0, getWeight(), List.of("Cannot confirm or not the documentation migration."));
+                        }
+                        return switch (probeResult.message()) {
+                            case "Documentation is located in the plugin repository." -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("Documentation is in plugin repository."));
+                            case "Documentation is not located in the plugin repository." -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Documentation should be migrated in plugin repository."),
+                                    List.of(
+                                            new Resolution(
+                                                    "https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/")));
+                            default -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of(
+                                            "Cannot confirm or not the documentation migration.",
+                                            probeResult.message()));
+                        };
+                    }
+
+                    @Override
+                    public int getWeight() {
+                        return 4;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Recommend to setup Release Drafter on the plugin repository.";
+                    }
+
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        ProbeResult cdProbe = probeResults.get(ContinuousDeliveryProbe.KEY);
+                        if (cdProbe != null && "JEP-229 workflow definition found.".equals(cdProbe.message())) {
+                            return new ScoringComponentResult(
+                                    100,
+                                    getWeight(),
+                                    List.of("Plugin using Release Drafter because it has CD configured."));
+                        }
+                        ProbeResult result = probeResults.get(ReleaseDrafterProbe.KEY);
+                        if (result != null && "Release Drafter is configured.".equals(result.message())) {
+                            return new ScoringComponentResult(
+                                    100, getWeight(), List.of("Plugin is using Release Drafter."));
+                        }
                         return new ScoringComponentResult(
-                            100,
-                            getWeight(),
-                            List.of("Plugin is using Release Drafter.")
-                        );
+                                0,
+                                0,
+                                List.of("Plugin is not using Release Drafter to manage its changelog."),
+                                List.of(
+                                        new Resolution(
+                                                "Plugin could benefit from using Release Drafter.",
+                                                "https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc")));
                     }
-                    return new ScoringComponentResult(
-                        0,
-                        0,
-                        List.of("Plugin is not using Release Drafter to manage its changelog."),
-                        List.of(new Resolution(
-                            "Plugin could benefit from using Release Drafter.",
-                            "https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc"
-                        ))
-                    );
-                }
 
-                @Override
-                public int getWeight() {
-                    return 0;
-                }
-            },
-            new ScoringComponent() {
-                @Override
-                public String getDescription() {
-                    return "Plugin description should be located in the index.jelly file.";
-                }
+                    @Override
+                    public int getWeight() {
+                        return 0;
+                    }
+                },
+                new ScoringComponent() {
+                    @Override
+                    public String getDescription() {
+                        return "Plugin description should be located in the index.jelly file.";
+                    }
 
-                @Override
-                public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
-                    final ProbeResult result = probeResults.get(PluginDescriptionMigrationProbe.KEY);
-                    if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
+                    @Override
+                    public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                        final ProbeResult result = probeResults.get(PluginDescriptionMigrationProbe.KEY);
+                        if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
+                            return new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Cannot determine if the plugin description was correctly migrated."));
+                        }
+
+                        final String message = result.message();
+                        if ("Plugin seems to have a correct description.".equals(message)) {
+                            return new ScoringComponentResult(100, getWeight(), List.of(message));
+                        }
                         return new ScoringComponentResult(
-                            0,
-                            getWeight(),
-                            List.of("Cannot determine if the plugin description was correctly migrated.")
-                        );
+                                0,
+                                getWeight(),
+                                List.of(message),
+                                List.of(
+                                        new Resolution(
+                                                "Please see how to migrate the plugin description for the plugin.",
+                                                "https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/")));
                     }
 
-                    final String message = result.message();
-                    if ("Plugin seems to have a correct description.".equals(message)) {
-                        return new ScoringComponentResult(100, getWeight(), List.of(message));
+                    @Override
+                    public int getWeight() {
+                        return 4;
                     }
-                    return new ScoringComponentResult(0, getWeight(), List.of(message),
-                        List.of(new Resolution(
-                            "Please see how to migrate the plugin description for the plugin.",
-                            "https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/"
-                        )));
-                }
-
-                @Override
-                public int getWeight() {
-                    return 4;
-                }
-            }
-        );
+                });
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 package io.jenkins.pluginhealth.scoring.scores;
-
 import java.util.List;
 import java.util.Map;
 
@@ -63,15 +62,20 @@ public class DocumentationScoring extends Scoring {
                 new ScoringComponent() {
                     @Override
                     public String getDescription() {
-                        return "The plugin has a specific contributing guide.";
+                        return "The plugin should have a specific contributing guide.";
                     }
 
                     @Override
                     public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
                         ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
-                        if (probeResult != null && "Contributing guidelines found.".equals(probeResult.message())) {
-                            return new ScoringComponentResult(
-                                    100, getWeight(), List.of("Plugin has a contributing guide."));
+                        if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
+                            return new ScoringComponentResult(0, getWeight(), List.of("Cannot determine if the plugin has contributing guide."));
+                        }
+                        if ("Inherit from organization contributing guide.".equals(probeResult.message())) {
+                            return new ScoringComponentResult(100, 0, List.of("Plugin is inheriting the organization contributing guide."));
+                        }
+                        if ("Contributing guidelines found.".equals(probeResult.message())) {
+                            return new ScoringComponentResult(100, getWeight(), List.of("Plugin seems to have a dedicated contributing guide."));
                         }
                         return new ScoringComponentResult(
                                 0,
@@ -199,6 +203,6 @@ public class DocumentationScoring extends Scoring {
 
     @Override
     public int version() {
-        return 2;
+        return 3;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoring.java
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 package io.jenkins.pluginhealth.scoring.scores;
+
 import java.util.List;
 import java.util.Map;
 
@@ -69,13 +70,16 @@ public class DocumentationScoring extends Scoring {
                     public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
                         ProbeResult probeResult = probeResults.get(ContributingGuidelinesProbe.KEY);
                         if (probeResult == null || ProbeResult.Status.ERROR.equals(probeResult.status())) {
-                            return new ScoringComponentResult(0, getWeight(), List.of("Cannot determine if the plugin has contributing guide."));
+                            return new ScoringComponentResult(
+                                    0, getWeight(), List.of("Cannot determine if the plugin has contributing guide."));
                         }
                         if ("Inherit from organization contributing guide.".equals(probeResult.message())) {
-                            return new ScoringComponentResult(100, 0, List.of("Plugin is inheriting the organization contributing guide."));
+                            return new ScoringComponentResult(
+                                    100, 0, List.of("Plugin is inheriting the organization contributing guide."));
                         }
                         if ("Contributing guidelines found.".equals(probeResult.message())) {
-                            return new ScoringComponentResult(100, getWeight(), List.of("Plugin seems to have a dedicated contributing guide."));
+                            return new ScoringComponentResult(
+                                    100, getWeight(), List.of("Plugin seems to have a dedicated contributing guide."));
                         }
                         return new ScoringComponentResult(
                                 0,

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,9 +65,12 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY,
+                        "Inherit from organization contributing guide.",
+                        probe.getVersion()));
     }
 
     @Test
@@ -85,9 +88,10 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
     }
 
     @Test
@@ -98,16 +102,18 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
 
         when(plugin.getName()).thenReturn("foo");
         final Path repository = Files.createTempDirectory(plugin.getName());
-        final Path guide = Files.createFile(Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
+        final Path guide = Files.createFile(
+                Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
         Files.writeString(guide, """
             Everything is awesome.
             """);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
     }
 
     @Test
@@ -122,8 +128,9 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guide seems to be empty.", probe.getVersion()));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        ContributingGuidelinesProbe.KEY, "Contributing guide seems to be empty.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ContributingGuidelinesProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +67,7 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", probe.getVersion()));
+            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", probe.getVersion()));
     }
 
     @Test
@@ -79,7 +78,10 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
 
         when(plugin.getName()).thenReturn("foo");
         final Path repository = Files.createTempDirectory(plugin.getName());
-        Files.createFile(repository.resolve("CONTRIBUTING.md"));
+        final Path guide = Files.createFile(repository.resolve("CONTRIBUTING.md"));
+        Files.writeString(guide, """
+            Everything is awesome.
+            """);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
@@ -96,12 +98,32 @@ public class ContributingGuidelinesProbeTest extends AbstractProbeTest<Contribut
 
         when(plugin.getName()).thenReturn("foo");
         final Path repository = Files.createTempDirectory(plugin.getName());
-        Files.createFile(Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
+        final Path guide = Files.createFile(Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
+        Files.writeString(guide, """
+            Everything is awesome.
+            """);
         when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
 
         assertThat(probe.apply(plugin, ctx))
             .usingRecursiveComparison()
             .comparingOnlyFields("id", "status", "message")
             .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", probe.getVersion()));
+    }
+
+    @Test
+    public void shouldDetectEmptyContributingGuidelines() throws IOException {
+        final Plugin plugin = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final ContributingGuidelinesProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn("foo");
+        final Path repository = Files.createTempDirectory(plugin.getName());
+        Files.createFile(Files.createDirectory(repository.resolve("docs")).resolve("CONTRIBUTING.md"));
+        when(ctx.getScmRepository()).thenReturn(Optional.of(repository));
+
+        assertThat(probe.apply(plugin, ctx))
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "status", "message")
+            .isEqualTo(ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guide seems to be empty.", probe.getVersion()));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
@@ -55,27 +55,27 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
-                ReleaseDrafterProbe.KEY,
-                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(
+                                ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
+                        ReleaseDrafterProbe.KEY,
+                        ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
     }
 
     @Test
@@ -84,40 +84,38 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY,
-                    "Plugin seems to have a correct description.",
-                    1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
-                ReleaseDrafterProbe.KEY,
-                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(
+                                ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
+                        ReleaseDrafterProbe.KEY,
+                        ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0
-                        && res.score() == 0
-                        && res.resolutions().size() == 1
-                        && res.reasons()
-                        .contains("Plugin is not using Release Drafter to manage its changelog.");
-                },
-                "Release drafter is not configured"));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 0
+                                    && res.resolutions().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin is not using Release Drafter to manage its changelog.");
+                        },
+                        "Release drafter is not configured"));
     }
 
     @Test
@@ -126,43 +124,39 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY,
-                    "Plugin seems to have a correct description.",
-                    1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-                ReleaseDrafterProbe.KEY,
-                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
-                ContinuousDeliveryProbe.KEY,
-                ProbeResult.success(
-                    ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                        ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
+                        ContinuousDeliveryProbe.KEY,
+                        ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0
-                        && res.score() == 100
-                        && res.reasons().size() == 1
-                        && res.reasons()
-                        .contains("Plugin using Release Drafter because it has CD configured.");
-                },
-                "CD is configured."));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 100
+                                    && res.reasons().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin using Release Drafter because it has CD configured.");
+                        },
+                        "CD is configured."));
     }
 
     @Test
@@ -171,27 +165,26 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY,
-                    "Plugin is using description from the plugin archetype.",
-                    1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY,
+                                "Plugin is using description from the plugin archetype.",
+                                1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -200,27 +193,24 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is not located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY,
-                    "Plugin seems to have a correct description.",
-                    1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is not located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -229,26 +219,25 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-            .thenReturn(Map.of(
-                DocumentationMigrationProbe.KEY,
-                ProbeResult.success(
-                    DocumentationMigrationProbe.KEY,
-                    "Documentation is not located in the plugin repository.",
-                    1),
-                PluginDescriptionMigrationProbe.KEY,
-                ProbeResult.success(
-                    PluginDescriptionMigrationProbe.KEY,
-                    "Plugin is using description from the plugin archetype.",
-                    1),
-                ContributingGuidelinesProbe.KEY,
-                ProbeResult.success(
-                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                        ProbeResult.success(
+                                DocumentationMigrationProbe.KEY,
+                                "Documentation is not located in the plugin repository.",
+                                1),
+                        PluginDescriptionMigrationProbe.KEY,
+                        ProbeResult.success(
+                                PluginDescriptionMigrationProbe.KEY,
+                                "Plugin is using description from the plugin archetype.",
+                                1),
+                        ContributingGuidelinesProbe.KEY,
+                        ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison()
-            .comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jenkins Infra
+ * Copyright (c) 2022-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.scores;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,18 +54,30 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
     }
 
     @Test
@@ -74,27 +85,41 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0 && res.score() == 0 && res.resolutions().size() == 1 &&
-                        res.reasons().contains("Plugin is not using Release Drafter to manage its changelog.");
-                },
-                "Release drafter is not configured"
-            ));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 0
+                                    && res.resolutions().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin is not using Release Drafter to manage its changelog.");
+                        },
+                        "Release drafter is not configured"));
     }
 
     @Test
@@ -102,28 +127,44 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-            ReleaseDrafterProbe.KEY, ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
-            ContinuousDeliveryProbe.KEY, ProbeResult.success(ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                        ReleaseDrafterProbe.KEY,
+                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
+                        ContinuousDeliveryProbe.KEY,
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-            .hasSize(4)
-            .haveAtLeastOne(new Condition<>(
-                res -> {
-                    return res.weight() == 0 && res.score() == 100 && res.reasons().size() == 1 &&
-                        res.reasons().contains("Plugin using Release Drafter because it has CD configured.");
-                },
-                "CD is configured."
-            ));
+                .hasSize(4)
+                .haveAtLeastOne(new Condition<>(
+                        res -> {
+                            return res.weight() == 0
+                                    && res.score() == 100
+                                    && res.reasons().size() == 1
+                                    && res.reasons()
+                                            .contains("Plugin using Release Drafter because it has CD configured.");
+                        },
+                        "CD is configured."));
     }
 
     @Test
@@ -131,17 +172,28 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin is using description from the plugin archetype.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -149,17 +201,28 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is not located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin seems to have a correct description.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -167,16 +230,27 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
-        when(plugin.getDetails()).thenReturn(Map.of(
-            DocumentationMigrationProbe.KEY, ProbeResult.success(DocumentationMigrationProbe.KEY, "Documentation is not located in the plugin repository.", 1),
-            PluginDescriptionMigrationProbe.KEY, ProbeResult.success(PluginDescriptionMigrationProbe.KEY, "Plugin is using description from the plugin archetype.", 1),
-            ContributingGuidelinesProbe.KEY, ProbeResult.success(ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)
-        ));
+        when(plugin.getDetails())
+                .thenReturn(Map.of(
+                        DocumentationMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        DocumentationMigrationProbe.KEY,
+                                        "Documentation is not located in the plugin repository.",
+                                        1),
+                        PluginDescriptionMigrationProbe.KEY,
+                                ProbeResult.success(
+                                        PluginDescriptionMigrationProbe.KEY,
+                                        "Plugin is using description from the plugin archetype.",
+                                        1),
+                        ContributingGuidelinesProbe.KEY,
+                                ProbeResult.success(
+                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-            .isNotNull()
-            .usingRecursiveComparison().comparingOnlyFields("key", "value")
-            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value")
+                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DocumentationScoringTest.java
@@ -50,34 +50,32 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
     }
 
     @Test
-    void shouldScoreOneHundredWithMigratedDocumentationAndContributingGuide() {
+    void shouldScoreOneHundredWithInheritedContributingGuide() {
         final Plugin plugin = mock(Plugin.class);
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin seems to have a correct description.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-                        ReleaseDrafterProbe.KEY,
-                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY, "Plugin seems to have a correct description.", 1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
+                ReleaseDrafterProbe.KEY,
+                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
     }
 
     @Test
@@ -86,40 +84,40 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin seems to have a correct description.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-                        ReleaseDrafterProbe.KEY,
-                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY,
+                    "Plugin seems to have a correct description.",
+                    1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "Inherit from organization contributing guide.", 1),
+                ReleaseDrafterProbe.KEY,
+                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-                .hasSize(4)
-                .haveAtLeastOne(new Condition<>(
-                        res -> {
-                            return res.weight() == 0
-                                    && res.score() == 0
-                                    && res.resolutions().size() == 1
-                                    && res.reasons()
-                                            .contains("Plugin is not using Release Drafter to manage its changelog.");
-                        },
-                        "Release drafter is not configured"));
+            .hasSize(4)
+            .haveAtLeastOne(new Condition<>(
+                res -> {
+                    return res.weight() == 0
+                        && res.score() == 0
+                        && res.resolutions().size() == 1
+                        && res.reasons()
+                        .contains("Plugin is not using Release Drafter to manage its changelog.");
+                },
+                "Release drafter is not configured"));
     }
 
     @Test
@@ -128,43 +126,43 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin seems to have a correct description.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
-                        ReleaseDrafterProbe.KEY,
-                                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
-                        ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY,
+                    "Plugin seems to have a correct description.",
+                    1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "Contributing guidelines found.", 1),
+                ReleaseDrafterProbe.KEY,
+                ProbeResult.success(ReleaseDrafterProbe.KEY, "Release Drafter not is configured.", 1),
+                ContinuousDeliveryProbe.KEY,
+                ProbeResult.success(
+                    ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 100, .5f, Set.of(), 1));
         assertThat(result.componentsResults())
-                .hasSize(4)
-                .haveAtLeastOne(new Condition<>(
-                        res -> {
-                            return res.weight() == 0
-                                    && res.score() == 100
-                                    && res.reasons().size() == 1
-                                    && res.reasons()
-                                            .contains("Plugin using Release Drafter because it has CD configured.");
-                        },
-                        "CD is configured."));
+            .hasSize(4)
+            .haveAtLeastOne(new Condition<>(
+                res -> {
+                    return res.weight() == 0
+                        && res.score() == 100
+                        && res.reasons().size() == 1
+                        && res.reasons()
+                        .contains("Plugin using Release Drafter because it has CD configured.");
+                },
+                "CD is configured."));
     }
 
     @Test
@@ -173,27 +171,27 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin is using description from the plugin archetype.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY,
+                    "Plugin is using description from the plugin archetype.",
+                    1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -202,27 +200,27 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is not located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin seems to have a correct description.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is not located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY,
+                    "Plugin seems to have a correct description.",
+                    1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 40, .5f, Set.of(), 1));
     }
 
     @Test
@@ -231,26 +229,26 @@ class DocumentationScoringTest extends AbstractScoringTest<DocumentationScoring>
         final DocumentationScoring scoring = getSpy();
 
         when(plugin.getDetails())
-                .thenReturn(Map.of(
-                        DocumentationMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        DocumentationMigrationProbe.KEY,
-                                        "Documentation is not located in the plugin repository.",
-                                        1),
-                        PluginDescriptionMigrationProbe.KEY,
-                                ProbeResult.success(
-                                        PluginDescriptionMigrationProbe.KEY,
-                                        "Plugin is using description from the plugin archetype.",
-                                        1),
-                        ContributingGuidelinesProbe.KEY,
-                                ProbeResult.success(
-                                        ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
+            .thenReturn(Map.of(
+                DocumentationMigrationProbe.KEY,
+                ProbeResult.success(
+                    DocumentationMigrationProbe.KEY,
+                    "Documentation is not located in the plugin repository.",
+                    1),
+                PluginDescriptionMigrationProbe.KEY,
+                ProbeResult.success(
+                    PluginDescriptionMigrationProbe.KEY,
+                    "Plugin is using description from the plugin archetype.",
+                    1),
+                ContributingGuidelinesProbe.KEY,
+                ProbeResult.success(
+                    ContributingGuidelinesProbe.KEY, "No contributing guidelines found.", 1)));
 
         ScoreResult result = scoring.apply(plugin);
         assertThat(result)
-                .isNotNull()
-                .usingRecursiveComparison()
-                .comparingOnlyFields("key", "value")
-                .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
+            .isNotNull()
+            .usingRecursiveComparison()
+            .comparingOnlyFields("key", "value")
+            .isEqualTo(new ScoreResult(DocumentationScoring.KEY, 0, .5f, Set.of(), 1));
     }
 }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #487.

This addresses the feedback that inheriting from the global plugin contributing guide shouldn't be a bad thing for the plugin.
Only a few plugins have specific build / contributing requirements. It will be hard / impossible to have a specific behavior to detect those, but we can accept guideline inheritance, reward specific guideline and warn about empty ones.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Adding unit tests on probe and tweaking tests on scoring
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
