### PR TITLE
Empty reasons for code ownership scoring

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -86,6 +86,11 @@ public class CodeOwnershipProbe extends Probe {
 
     @Override
     public long getVersion() {
-        return 1;
+        return 2;
+    }
+
+    @Override
+    protected boolean isSourceCodeRelated() {
+        return true;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -197,7 +197,7 @@ public class PluginMaintenanceScoring extends Scoring {
                         return 10;
                     }
                 },
-                new ScoringComponent() {
+                new ScoringComponent() { // CodeOwnership
                     @Override
                     public String getDescription() {
                         return "Plugin should have a valid CODEOWNERS file.";
@@ -207,14 +207,41 @@ public class PluginMaintenanceScoring extends Scoring {
                     public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
                         final ProbeResult result = probeResults.get(CodeOwnershipProbe.KEY);
                         if (result == null || ProbeResult.Status.ERROR.equals(result.status())) {
-                            return new ScoringComponentResult(0, getWeight(), List.of());
+                            return new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Could not determine the plugins code ownership."),
+                                    List.of(
+                                            new Resolution(
+                                                    "Please open a bug on plugin-health-scoring project.",
+                                                    "https://github.com/jenkins-infra/plugin-health-scoring/issues/new/choose")));
                         }
 
                         return switch (result.message()) {
-                            case "CODEOWNERS file is valid." -> new ScoringComponentResult(100, getWeight(), List.of());
+                            case "CODEOWNERS file is valid." -> new ScoringComponentResult(
+                                    100, getWeight(), List.of("Code Ownership definition found and is valid."));
                             case "CODEOWNERS file is not set correctly." -> new ScoringComponentResult(
-                                    50, getWeight(), List.of());
-                            default -> new ScoringComponentResult(0, getWeight(), List.of());
+                                    50,
+                                    getWeight(),
+                                    List.of("Code Ownership is not set properly."),
+                                    List.of(
+                                            new Resolution(
+                                                    "Learn about code owners",
+                                                    "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners"),
+                                            new Resolution(
+                                                    "See OpenRewrite recipe to fix this.",
+                                                    "https://docs.openrewrite.org/recipes/jenkins/github/addteamtocodeowners")));
+                            default -> new ScoringComponentResult(
+                                    0,
+                                    getWeight(),
+                                    List.of("Repository would benefit from defining the code ownership."),
+                                    List.of(
+                                            new Resolution(
+                                                    "Learn about code owners",
+                                                    "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners"),
+                                            new Resolution(
+                                                    "See OpenRewrite recipe to fix this.",
+                                                    "https://docs.openrewrite.org/recipes/jenkins/github/addteamtocodeowners")));
                         };
                     }
 
@@ -244,6 +271,6 @@ public class PluginMaintenanceScoring extends Scoring {
 
     @Override
     public int version() {
-        return 4;
+        return 5;
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
@@ -45,6 +45,11 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
     }
 
     @Test
+    void shouldRequiresCodeModifications() {
+        assertThat(getSpy().isSourceCodeRelated()).isTrue();
+    }
+
+    @Test
     void shouldDetectMissingCodeOwnershipFile() throws IOException {
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -63,439 +63,399 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                 arguments( // All bad
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         0),
                 arguments( // All bad with open dependabot pull request
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         0),
                 arguments( // All good
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         100),
                 arguments( // All good
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         100),
                 arguments( // Only Jenkinsfile
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         50),
                 arguments( // Jenkinsfile and dependabot but with open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         60),
                 arguments( // Jenkinsfile and dependabot with no open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         70),
                 arguments( // Jenkinsfile and renovate but with open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         60),
                 arguments( // Jenkinsfile and renovate with no open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         70),
                 arguments( // Jenkinsfile and CD
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         60),
                 arguments( // Jenkinsfile and CD and dependabot but with open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         70),
                 arguments( // Jenkinsfile and CD and dependabot but with no open pull request
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         80),
                 arguments( // Dependabot only with no open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         20),
                 arguments( // Dependabot only with open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         10),
                 arguments( // Dependabot with no open pull request and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         30),
                 arguments( // Renovate only with no open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         20),
                 arguments( // Renovate only with open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         10),
                 arguments( // Renovate with no open pull request and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY, ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         30),
                 arguments( // CD only
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(
-                                                CodeOwnershipProbe.KEY,
-                                                "No CODEOWNERS file found in plugin repository.",
-                                                1)),
+                                ProbeResult.success(
+                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
                         10),
                 arguments( // Codeownership only
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                        ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         20),
                 arguments( // Codeownership + Jenkinsfile
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY,
-                                                "Could not find JEP-229 workflow definition.",
-                                                1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         70),
                 arguments( // Codeownership + Jenkinsfile + CD
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         80),
                 arguments( // Codeownership + Jenkinsfile + CD + Dependabot
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "1", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         90),
                 arguments( // Codeownership + Jenkinsfile + CD
                         Map.of(
-                                JenkinsfileProbe.KEY, ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
+                                JenkinsfileProbe.KEY,
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
                                 DependabotProbe.KEY,
-                                        ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
                                 RenovateProbe.KEY,
-                                        ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 DependabotPullRequestProbe.KEY,
-                                        ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, "0", 1),
                                 ContinuousDeliveryProbe.KEY,
-                                        ProbeResult.success(
-                                                ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
+                                ProbeResult.success(
+                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
-                                        ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
+                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
                         100));
     }
 
@@ -510,6 +470,9 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
         final ScoreResult result = scoring.apply(plugin);
 
         assertThat(result.componentsResults().size()).isEqualTo(4);
+        assertThat(result.componentsResults().stream()
+                        .noneMatch(cr -> cr.reasons().isEmpty()))
+                .isTrue();
         assertThat(result)
                 .isNotNull()
                 .usingRecursiveComparison()


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #503.
Follow up of #499.

The code owners scoring component did not provide a valid list of reasons nor resolutions.
This is clearly because the initial pull request was merge too soon.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Added an assertion to make sure the reasons list is not empty.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
