### PR TITLE
feat!(Dockerfile) Changes UID and GID used to run the application

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
     skipStagesAfterUnstable()
     timestamps()
   }
+  triggers {
+    cron('@daily')
+  }
 
   stages {
     stage('Build') {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.jenkins.pluginhealth.scoring</groupId>
     <artifactId>plugin-health-scoring-parent</artifactId>
-    <version>3.10.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>io.jenkins.pluginhealth.scoring</groupId>
   <artifactId>plugin-health-scoring-parent</artifactId>
-  <version>3.10.1-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Plugin Health Scoring :: Parent</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.jenkins.pluginhealth.scoring</groupId>
     <artifactId>plugin-health-scoring-parent</artifactId>
-    <version>3.10.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.jenkins.pluginhealth.scoring</groupId>
     <artifactId>plugin-health-scoring-parent</artifactId>
-    <version>3.10.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/war/src/main/docker/Dockerfile
+++ b/war/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk as builder
+FROM eclipse-temurin:21-jdk AS builder
 
 WORKDIR /src
 
@@ -7,7 +7,7 @@ RUN jar -xf plugin-health-scoring.jar
 
 FROM eclipse-temurin:21-jre
 
-ENV HOME /app
+ENV HOME=/app
 
 ARG user=phs
 ARG uid=4242
@@ -23,8 +23,8 @@ USER ${user}:${group}
 
 WORKDIR ${HOME}
 
-ENV SPRING_PROFILES_ACTIVE ${spring_profile}
-ENV SERVER_PORT ${server_port}
+ENV SPRING_PROFILES_ACTIVE=${spring_profile}
+ENV SERVER_PORT=${server_port}
 
 ENTRYPOINT ["/bin/bash", "/app/docker-entrypoint.sh"]
 

--- a/war/src/main/docker/Dockerfile
+++ b/war/src/main/docker/Dockerfile
@@ -10,9 +10,9 @@ FROM eclipse-temurin:21-jre
 ENV HOME /app
 
 ARG user=phs
-ARG uid=1000
+ARG uid=4242
 ARG group=phs
-ARG gid=1000
+ARG gid=4242
 
 ARG server_port=8080
 ARG spring_profile=production


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

As spotted in recent pull request build, the docker image cannot be built. 
The reason is that the tag used for the base image, even tho it didn't change recently, the image did. The default UID and GID in the image now overlap with the number we used. 
Changing it to `4242` just so that it is far enough from the new value, random enough to be very unlucky if that is overlapping again in the future (and because that's twice the universal answer of all things).

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```

BREAKING CHANGE: default user UID is now `4242` 