### PR TITLE
Plugin repository ownership based on repository name

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -59,8 +59,9 @@ public class CodeOwnershipProbe extends Probe {
                     .map(file -> {
                         try {
                             return Files.readAllLines(file).stream()
-                                            .anyMatch(line -> line.contains(
-                                                    "@jenkinsci/%s-developers".formatted(context.getRepositoryName().orElse("NOT_VALID"))))
+                                            .anyMatch(line -> line.contains("@jenkinsci/%s-developers"
+                                                    .formatted(context.getRepositoryName()
+                                                            .orElse("NOT_VALID"))))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -60,7 +60,7 @@ public class CodeOwnershipProbe extends Probe {
                         try {
                             return Files.readAllLines(file).stream()
                                             .anyMatch(line -> line.contains(
-                                                    "@jenkinsci/%s-plugin-developers".formatted(plugin.getName())))
+                                                    "@jenkinsci/%s-developers".formatted(context.getRepositoryName().orElse("NOT_VALID"))))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.FileInputStream;
@@ -88,7 +87,8 @@ public class SCMLinkValidationProbe extends Probe {
         }
         try {
             context.getGitHub().getRepository(matcher.group("repo"));
-            Optional<Path> pluginPathInRepository = findPluginPom(context.getScmRepository().get(), pluginName);
+            Optional<Path> pluginPathInRepository =
+                    findPluginPom(context.getScmRepository().get(), pluginName);
             Optional<Path> folderPath = pluginPathInRepository.map(path -> path.getParent());
             if (folderPath.isEmpty()) {
                 return this.success(String.format("No valid POM file found in %s plugin.", pluginName));
@@ -117,11 +117,9 @@ public class SCMLinkValidationProbe extends Probe {
          * The `maxDepth` is 3 because a lot of plugins aren't located deeper than <root>/plugins/<pom.xml>.
          * If the `maxDepth` is more than 3, we will be navigating the `src/main/java/io/jenkins/plugins/artifactId/` folder.
          * */
-        try (Stream<Path> paths = Files.find(directory, 3, (path, $) ->
-            "pom.xml".equals(path.getFileName().toString()))) {
-            return paths
-                .filter(pom -> pomFileMatchesPlugin(pom, pluginName))
-                .findFirst();
+        try (Stream<Path> paths = Files.find(
+                directory, 3, (path, $) -> "pom.xml".equals(path.getFileName().toString()))) {
+            return paths.filter(pom -> pomFileMatchesPlugin(pom, pluginName)).findFirst();
         } catch (IOException e) {
             LOGGER.error("Could not browse the folder during probe {}.", pluginName, e);
         }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbe.java
@@ -56,7 +56,7 @@ public class SCMLinkValidationProbe extends Probe {
     public static final int ORDER = UpdateCenterPluginPublicationProbe.ORDER + 100;
     public static final String KEY = "scm";
     private static final Logger LOGGER = LoggerFactory.getLogger(SCMLinkValidationProbe.class);
-    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*)";
+    private static final String GH_REGEXP = "https://(?<server>[^/]*)/(?<repo>jenkinsci/[^/]*-plugin)";
     public static final Pattern GH_PATTERN = Pattern.compile(GH_REGEXP);
 
     @Override

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
@@ -97,7 +97,7 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
             final Path docs = Files.createDirectory(repo.resolve("docs"));
             final Path codeowners = Files.createFile(docs.resolve("CODEOWNERS"));
             Files.writeString(
-                codeowners, """
+                    codeowners, """
                 * @jenkinsci/sample-plugin-developers
                 """);
             when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
@@ -106,8 +106,7 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
             final Path repo = Files.createTempDirectory(getClass().getName());
             final Path docs = Files.createDirectory(repo.resolve(".github"));
             final Path codeowners = Files.createFile(docs.resolve("CODEOWNERS"));
-            Files.writeString(
-                codeowners, """
+            Files.writeString(codeowners, """
                 * @alecharp
                 """);
             when(ctx.getScmRepository()).thenReturn(Optional.of(repo));
@@ -124,13 +123,13 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
                 .comparingOnlyFields("id", "status", "message")
                 .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is not set correctly.", 0));
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is not set correctly.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is not set correctly.", 0));
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is not set correctly.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is not set correctly.", 0));
     }
 
     @Test
@@ -197,7 +196,8 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
             final Path repo = Files.createTempDirectory(getClass().getName());
             final Path codeowners = Files.createFile(repo.resolve("CODEOWNERS"));
             Files.writeString(
-                codeowners, """
+                    codeowners,
+                    """
                 * @jenkinsci/sample-plugin-developers
                 * @alecharp @jenkinsci
                 """);
@@ -208,7 +208,8 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
             final Path github = Files.createDirectory(repo.resolve(".github"));
             final Path codeowners = Files.createFile(github.resolve("CODEOWNERS"));
             Files.writeString(
-                codeowners, """
+                    codeowners,
+                    """
                 * @jenkinsci/sample-plugin-developers
                 * @alecharp @jenkinsci
                 """);
@@ -219,7 +220,8 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
             final Path docs = Files.createDirectory(repo.resolve("docs"));
             final Path codeowners = Files.createFile(docs.resolve("CODEOWNERS"));
             Files.writeString(
-                codeowners, """
+                    codeowners,
+                    """
                 * @jenkinsci/sample-plugin-developers
                 * @alecharp @jenkinsci
                 """);
@@ -229,16 +231,16 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
         final CodeOwnershipProbe probe = getSpy();
 
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
         assertThat(probe.apply(plugin, ctx))
-            .usingRecursiveComparison()
-            .comparingOnlyFields("id", "status", "message")
-            .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(probe.key(), "CODEOWNERS file is valid.", 0));
     }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/SCMLinkValidationProbeTest.java
@@ -99,7 +99,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub gh = mock(GitHub.class);
-        final String repositoryName = "jenkinsci/test-repo";
+        final String repositoryName = "jenkinsci/test-repo-plugin";
 
         when(plugin.getName()).thenReturn("test-repo");
         when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
@@ -124,7 +124,7 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
         final GitHub gh = mock(GitHub.class);
-        final String repositoryName = "jenkinsci/this-is-not-going-to-work";
+        final String repositoryName = "jenkinsci/this-is-not-going-to-work-plugin";
 
         when(plugin.getScm()).thenReturn("https://github.com/" + repositoryName);
         when(plugin.getName()).thenReturn("foo");
@@ -150,13 +150,13 @@ class SCMLinkValidationProbeTest extends AbstractProbeTest<SCMLinkValidationProb
         final GitHub gh = mock(GitHub.class);
         final GHRepository ghRepo = mock(GHRepository.class);
 
-        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/this-is-fine");
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/this-is-fine-plugin");
         when(plugin.getName()).thenReturn("test-repo");
 
         when(ctx.getScmRepository())
                 .thenReturn(Optional.of(Path.of("src/test/resources/jenkinsci/test-repo/test-nested-dir-1")));
         when(ctx.getGitHub()).thenReturn(gh);
-        when(gh.getRepository("jenkinsci/this-is-fine")).thenReturn(ghRepo);
+        when(gh.getRepository("jenkinsci/this-is-fine-plugin")).thenReturn(ghRepo);
 
         final SCMLinkValidationProbe probe = getSpy();
         final ProbeResult result = probe.apply(plugin, ctx);


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #531.

Because it's more difficult to change the `artifactId` of a plugin, compared to a repository name, the ownership should not be based on the `artifactId`.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Added unit tests to validate the change.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
