### PR TITLE
chore(Jenkinsfile) avoid rebuilding tags and PRs daily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 // Do not rebuild daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
-String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily : ''
+String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 
 pipeline {
   agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 #!/usr/bin/env groovy
 
+# Do not rebuild daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
+String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily : ''
+
 pipeline {
   agent {
     // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
@@ -11,7 +14,7 @@ pipeline {
     timestamps()
   }
   triggers {
-    cron('@daily')
+    cron(cronPattern)
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-# Do not rebuild daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
+// Do not rebuild daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
 String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily : ''
 
 pipeline {


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/plugin-health-scoring/pull/536 which introduces a daily cron trigger.

We forgot that this trigger should be "branch-conditionnal" otherwise it tries to rebuild everything including tags once a day (which is... not a good thing)

----


Notes:
- No need to trigger a release: this change will be picked by the jobs once merged
- Regarding the tags, I'll run a build replay to set them up to "never rebuild" with a successful status (dummy `echo OK` step) so it will stop them. Only the following tags are subject to the rebuild:
  - 4.0.0
  - 4.0.1
  - 4.0.2
  - 4.1.0 