### PR TITLE
Codeowner using bad repository name

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -49,16 +49,7 @@ public class CodeOwnershipProbe extends Probe {
             return this.error("There is no local repository for plugin " + plugin.getName() + ".");
         }
         final Path scmRepository = context.getScmRepository().get();
-        final String repositoryName = context.getRepositoryName()
-                .map(repo -> {
-                    final String[] parts = repo.split("/");
-                    if (parts.length == 2) {
-                        return parts[1];
-                    } else {
-                        return "NOT_VALID";
-                    }
-                })
-                .orElse("NOT_VALID");
+        final String repositoryName = context.getRepositoryName().orElse("NOT_VALID");
 
         try (Stream<Path> paths = Files.find(
                 scmRepository,
@@ -70,7 +61,7 @@ public class CodeOwnershipProbe extends Probe {
                         try {
                             return Files.readAllLines(file).stream()
                                             .anyMatch(line ->
-                                                    line.contains("@jenkinsci/%s-developers".formatted(repositoryName)))
+                                                    line.contains("@%s-developers".formatted(repositoryName)))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -49,6 +49,14 @@ public class CodeOwnershipProbe extends Probe {
             return this.error("There is no local repository for plugin " + plugin.getName() + ".");
         }
         final Path scmRepository = context.getScmRepository().get();
+        final String repositoryName = context.getRepositoryName().map(repo -> {
+            final String[] parts = repo.split("/");
+            if (parts.length == 2) {
+                return parts[1];
+            } else {
+                return "NOT_VALID";
+            }
+        }).orElse("NOT_VALID");
 
         try (Stream<Path> paths = Files.find(
                 scmRepository,
@@ -60,8 +68,7 @@ public class CodeOwnershipProbe extends Probe {
                         try {
                             return Files.readAllLines(file).stream()
                                             .anyMatch(line -> line.contains("@jenkinsci/%s-developers"
-                                                    .formatted(context.getRepositoryName()
-                                                            .orElse("NOT_VALID"))))
+                                                    .formatted(repositoryName)))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {
@@ -87,7 +94,7 @@ public class CodeOwnershipProbe extends Probe {
 
     @Override
     public long getVersion() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -49,14 +49,16 @@ public class CodeOwnershipProbe extends Probe {
             return this.error("There is no local repository for plugin " + plugin.getName() + ".");
         }
         final Path scmRepository = context.getScmRepository().get();
-        final String repositoryName = context.getRepositoryName().map(repo -> {
-            final String[] parts = repo.split("/");
-            if (parts.length == 2) {
-                return parts[1];
-            } else {
-                return "NOT_VALID";
-            }
-        }).orElse("NOT_VALID");
+        final String repositoryName = context.getRepositoryName()
+                .map(repo -> {
+                    final String[] parts = repo.split("/");
+                    if (parts.length == 2) {
+                        return parts[1];
+                    } else {
+                        return "NOT_VALID";
+                    }
+                })
+                .orElse("NOT_VALID");
 
         try (Stream<Path> paths = Files.find(
                 scmRepository,
@@ -67,8 +69,8 @@ public class CodeOwnershipProbe extends Probe {
                     .map(file -> {
                         try {
                             return Files.readAllLines(file).stream()
-                                            .anyMatch(line -> line.contains("@jenkinsci/%s-developers"
-                                                    .formatted(repositoryName)))
+                                            .anyMatch(line ->
+                                                    line.contains("@jenkinsci/%s-developers".formatted(repositoryName)))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbe.java
@@ -60,8 +60,7 @@ public class CodeOwnershipProbe extends Probe {
                     .map(file -> {
                         try {
                             return Files.readAllLines(file).stream()
-                                            .anyMatch(line ->
-                                                    line.contains("@%s-developers".formatted(repositoryName)))
+                                            .anyMatch(line -> line.contains("@%s-developers".formatted(repositoryName)))
                                     ? this.success("CODEOWNERS file is valid.")
                                     : this.success("CODEOWNERS file is not set correctly.");
                         } catch (IOException ex) {

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2024 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.probes;
 
 import java.io.File;
@@ -76,8 +75,12 @@ public class ProbeContext {
         final String pluginName = this.plugin.getName();
         try {
             final Path repo = Files.createTempDirectory(pluginName);
-            try (Git git = Git.cloneRepository().setURI(plugin.getScm()).setDirectory(repo.toFile()).call()) {
-                this.scmRepository = Paths.get(git.getRepository().getDirectory().getParentFile().toURI());
+            try (Git git = Git.cloneRepository()
+                    .setURI(plugin.getScm())
+                    .setDirectory(repo.toFile())
+                    .call()) {
+                this.scmRepository = Paths.get(
+                        git.getRepository().getDirectory().getParentFile().toURI());
             } catch (GitAPIException e) {
                 LOGGER.warn("Could not clone Git repository for plugin {}", pluginName, e);
             }
@@ -140,9 +143,7 @@ public class ProbeContext {
     /* default */ void cleanUp() throws IOException {
         if (scmRepository != null) {
             try (Stream<Path> paths = Files.walk(this.scmRepository)) {
-                paths.sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+                paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
             }
         }
     }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ProbeContext.java
@@ -114,6 +114,13 @@ public class ProbeContext {
         return pluginDocumentationLinks;
     }
 
+    /**
+     * Returns the GitHub repository of the plugin source code.
+     * This needs to be in the format 'organization/repository' for the GitHub.
+     * Returns empty if the scm link of the plugin is not set to point to jenkinsci organization.
+     *
+     * @return the GitHub repository of the plugin source code or empty if not formatted correctly
+     */
     public Optional<String> getRepositoryName() {
         if (plugin.getScm() == null || plugin.getScm().isBlank()) {
             return Optional.empty();

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/CodeOwnershipProbeTest.java
@@ -71,7 +71,7 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(ctx.getRepositoryName()).thenReturn(Optional.of("new-super-plugin"));
+        when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/new-super-plugin"));
 
         {
             final Path repo = Files.createTempDirectory(getClass().getName());
@@ -137,7 +137,7 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(ctx.getRepositoryName()).thenReturn(Optional.of("sample-plugin"));
+        when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/sample-plugin"));
 
         {
             final Path repo = Files.createTempDirectory(getClass().getName());
@@ -190,7 +190,7 @@ public class CodeOwnershipProbeTest extends AbstractProbeTest<CodeOwnershipProbe
         final Plugin plugin = mock(Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
 
-        when(ctx.getRepositoryName()).thenReturn(Optional.of("sample-plugin"));
+        when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/sample-plugin"));
 
         {
             final Path repo = Files.createTempDirectory(getClass().getName());

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeContextTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeContextTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+
+import org.junit.jupiter.api.Test;
+
+public class ProbeContextTest {
+    @Test
+    void shouldBeAbleToReturnCorrectPluginRepositoryName() throws Exception {
+        final Plugin plugin = mock(Plugin.class);
+        final UpdateCenter uc = mock(UpdateCenter.class);
+
+        when(plugin.getScm()).thenReturn("https://github.com/jenkinsci/git-client-plugin");
+
+        final ProbeContext ctx = new ProbeContext(plugin, uc);
+        assertThat(ctx.getRepositoryName()).isEqualTo(Optional.of("jenkinsci/git-client-plugin"));
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeContextTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ProbeContextTest.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package io.jenkins.pluginhealth.scoring.probes;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Closes #557.
The repository name provided by the probe context must include the organisation of the repository for the GitHub API usage.
The invalid format was introduced in #554.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Create a test of the `ProbeContext#getRepositoryName` returned format.
The `CodeOwnershipTest` tests was using an incorrect format from this method, leading to invalid testing.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
