### PR TITLE
Detects if a plugin repository is archived or not

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RepositoryArchivedStatusProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/RepositoryArchivedStatusProbe.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(value = RepositoryArchivedStatusProbe.ORDER)
+public class RepositoryArchivedStatusProbe extends Probe {
+    public static final int ORDER = SCMLinkValidationProbe.ORDER + 100;
+    public static final String KEY = "repository-archived";
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        if (plugin.getScm() == null) {
+            return this.error("Plugin SCM is unknown, cannot fetch the number of open pull requests.");
+        }
+        final GitHub gh = context.getGitHub();
+        final Optional<String> repositoryName = context.getRepositoryName();
+        if (repositoryName.isEmpty()) {
+            return this.error("Cannot find repository for " + plugin.getName());
+        }
+
+        try {
+            final GHRepository repository = gh.getRepository(repositoryName.get());
+            return this.success("%b".formatted(repository.isArchived()));
+        } catch (IOException e) {
+            return this.error("Cannot access repository " + repositoryName.get());
+        }
+    }
+
+    @Override
+    public String key() {
+        return KEY;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Learn if the plugin repository is archived or not.";
+    }
+
+    @Override
+    public long getVersion() {
+        return 1;
+    }
+}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/Scoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/Scoring.java
@@ -103,7 +103,7 @@ public abstract class Scoring {
                                     .sum();
                             return new ScoreResult(
                                     key(),
-                                    (int) Math.max(0, Math.round(sum / weight)),
+                                    weight == 0 ? 100 : (int) Math.max(0, Math.round(sum / weight)),
                                     weight(),
                                     changelogResults,
                                     version());

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RepositoryArchivedStatusProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/RepositoryArchivedStatusProbeTest.java
@@ -1,0 +1,140 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+class RepositoryArchivedStatusProbeTest extends AbstractProbeTest<RepositoryArchivedStatusProbe> {
+
+    @Override
+    RepositoryArchivedStatusProbe getSpy() {
+        return spy(RepositoryArchivedStatusProbe.class);
+    }
+
+    @Test
+    void shouldNotRequireRelease() {
+        assertFalse(getSpy().requiresRelease());
+    }
+
+    @Test
+    void shouldNotBeRelatedToSourceCode() {
+        assertFalse(getSpy().requiresRelease());
+    }
+
+    @Test
+    void shouldFailWithNoSCM() {
+        final Plugin pl = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        final RepositoryArchivedStatusProbe probe = getSpy();
+
+        assertThat(probe.apply(pl, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.error(
+                        RepositoryArchivedStatusProbe.KEY,
+                        "Plugin SCM is unknown, cannot fetch the number of open pull requests.",
+                        1));
+    }
+
+    @Test
+    void shouldFailWithNoRepositoryName() {
+        final Plugin pl = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+
+        when(pl.getName()).thenReturn("_test_");
+        when(pl.getScm()).thenReturn("valid-url");
+        when(ctx.getRepositoryName()).thenReturn(Optional.empty());
+
+        final RepositoryArchivedStatusProbe probe = getSpy();
+
+        assertThat(probe.apply(pl, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(
+                        ProbeResult.error(RepositoryArchivedStatusProbe.KEY, "Cannot find repository for _test_", 1));
+    }
+
+    @Test
+    void shouldSucceedToFindArchivedRepository() throws Exception {
+        final Plugin pl = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final GitHub gh = mock(GitHub.class);
+        final GHRepository ghRepository = mock(GHRepository.class);
+
+        when(pl.getName()).thenReturn("_test_");
+        when(pl.getScm()).thenReturn("valid-url");
+        when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/_test_"));
+
+        when(ctx.getGitHub()).thenReturn(gh);
+        when(gh.getRepository(anyString())).thenReturn(ghRepository);
+
+        when(ghRepository.isArchived()).thenReturn(true);
+
+        final RepositoryArchivedStatusProbe probe = getSpy();
+
+        assertThat(probe.apply(pl, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(RepositoryArchivedStatusProbe.KEY, "true", 1));
+    }
+
+    @Test
+    void shouldSucceedToFindNotArchivedRepository() throws Exception {
+        final Plugin pl = mock(Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final GitHub gh = mock(GitHub.class);
+        final GHRepository ghRepository = mock(GHRepository.class);
+
+        when(pl.getName()).thenReturn("_test_");
+        when(pl.getScm()).thenReturn("valid-url");
+        when(ctx.getRepositoryName()).thenReturn(Optional.of("jenkinsci/_test_"));
+
+        when(ctx.getGitHub()).thenReturn(gh);
+        when(gh.getRepository(anyString())).thenReturn(ghRepository);
+
+        when(ghRepository.isArchived()).thenReturn(false);
+
+        final RepositoryArchivedStatusProbe probe = getSpy();
+
+        assertThat(probe.apply(pl, ctx))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(RepositoryArchivedStatusProbe.KEY, "false", 1));
+    }
+}


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description
Closes #567.

When a maintainer want to mark a plugins as End-Of-Life, the repository of the plugin can be marked as archived.
This means that no further development, fix of any kind can be provided to the source code.
In this situation, we need to drastically reduce the plugin score.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Run new unit tests locally.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
