### PR TITLE
Opens probe execution filtering implementation

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/Probe.java
@@ -48,7 +48,7 @@ public abstract class Probe {
      * @return the result of the analyze in a {@link ProbeResult}
      */
     public final ProbeResult apply(Plugin plugin, ProbeContext context) {
-        if (shouldBeExecuted(plugin, context)) {
+        if (isApplicable(plugin, context)) {
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Running {} on {}", this.key(), plugin.getName());
             }
@@ -58,7 +58,14 @@ public abstract class Probe {
         return lastResult != null ? lastResult : this.error(key() + " was not executed on " + plugin.getName());
     }
 
-    private boolean shouldBeExecuted(Plugin plugin, ProbeContext context) {
+    /**
+     * Determine if the current probe should or should not be applied to the plugin with its context.
+     *
+     * @param plugin  the plugin to apply the probe to
+     * @param context the built context to run the probe with
+     * @return true if the probe have to be applied to the plugin
+     */
+    protected boolean isApplicable(Plugin plugin, ProbeContext context) {
         final ProbeResult previousResult = plugin.getDetails().get(this.key());
         if (previousResult == null) {
             return true;

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -40,6 +40,8 @@ There are conditions for each probe to be executed:
 - if the last execution of the probe on a specific plugin was done before the last code change of the plugin and the probe is based on the code of the plugin
 - if the last execution of the probe on a specific plugin was done before the last release of the plugin and the probe requires a release to have its result changed
 
+Each probe can override the method `Probe#isApplicable(Plugin, ProbeContext)` to use other data and decide if it should be executed or no by the `ProbeEngine`.
+
 The `ProbeEngine` is scheduled by the link:../war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java[`ProbeEngineScheduler`] class.
 This is using a CRON expression for its scheduling.
 The environment variable `PROBE_ENGINE_CRON` is used to configure this CRON.


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Let's each probe the possibility to decide if it should be applied on a plugin with its context.
So far, the control of execution was only determined based on release requirement, code change. 
This allow each probe to have a decision based on more specific data present on the plugin data or its context.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Ran verify phase with no problem.
<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

```[tasklist]
### Submitter checklist
- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
```
