### PR TITLE
Fixes tasklist usage prior to GitHub retiring it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,10 +30,10 @@ Closes #issue-id.
   the bugfix or the improvement.
 -->
 
-```
+### Submitter checklist
+
 - [ ] If an issue exists, it is well described and linked in the description
 - [ ] The description of this pull request is detailed and explain why this pull request is needed
 - [ ] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
 - [ ] If required, the documentation has been updated
 - [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
-```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,8 +30,7 @@ Closes #issue-id.
   the bugfix or the improvement.
 -->
 
-```[tasklist]
-### Submitter checklist
+```
 - [ ] If an issue exists, it is well described and linked in the description
 - [ ] The description of this pull request is detailed and explain why this pull request is needed
 - [ ] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.


### PR DESCRIPTION
### Description

This is simply removing the usage of `tasklist` on the pull request template because GitHub is retiring it.
See https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#migrate-to-sub-issues.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

None.

### Submitter checklist

- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
