### PR TITLE
Makes CD workflow optional

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Jenkins Infra
+ * Copyright (c) 2022-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -185,8 +185,10 @@ public class PluginMaintenanceScoring extends Scoring {
                                     100, getWeight(), List.of("JEP-229 is configured on the plugin."));
                             case "Could not find JEP-229 workflow definition." -> new ScoringComponentResult(
                                     0,
-                                    getWeight(),
-                                    List.of("JEP-229 is not configured on the plugin."),
+                                    0,
+                                    List.of(
+                                            "JEP-229 is not configured on the plugin.",
+                                            "This is not mandatory, but can help reduce time between pull requests merge and feature / bugfix availability."),
                                     List.of(new Resolution(
                                             "See how to setup JEP-229 on the plugin.",
                                             "https://www.jenkins.io/doc/developer/publishing/releasing-cd/")));

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Jenkins Infra
+ * Copyright (c) 2022-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,7 +140,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        50),
+                        56),
                 arguments( // Jenkinsfile and dependabot but with open pull request
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -157,7 +157,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        60),
+                        67),
                 arguments( // Jenkinsfile and dependabot with no open pull request
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -174,7 +174,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        70),
+                        78),
                 arguments( // Jenkinsfile and renovate but with open pull request
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -191,7 +191,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        60),
+                        67),
                 arguments( // Jenkinsfile and renovate with no open pull request
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -208,7 +208,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        70),
+                        78),
                 arguments( // Jenkinsfile and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -274,7 +274,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        20),
+                        22),
                 arguments( // Dependabot only with open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -291,7 +291,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        10),
+                        11),
                 arguments( // Dependabot with no open pull request and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -325,7 +325,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        20),
+                        22),
                 arguments( // Renovate only with open pull requests
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -342,7 +342,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        10),
+                        11),
                 arguments( // Renovate with no open pull request and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -392,7 +392,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        20),
+                        22),
                 arguments( // Codeownership + Jenkinsfile
                         Map.of(
                                 JenkinsfileProbe.KEY,
@@ -408,7 +408,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        70),
+                        78),
                 arguments( // Codeownership + Jenkinsfile + CD
                         Map.of(
                                 JenkinsfileProbe.KEY,


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

CD workflow is not always wanted, and it not required per se.
Deducing points to plugins because maintainers decide not to use the CD workflow is not realistic.

This is making the CD workflow optional.
You can now have a score of 100 without it.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Ran `mvn verify` locally.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist

- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
