### PR TITLE
Runs different schedulers asynchronously

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ScheduleConfiguration.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/ScheduleConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,13 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
-public class ScheduleConfiguration {
-}
+@EnableAsync
+public class ScheduleConfiguration {}

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2022-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import java.io.IOException;
@@ -29,6 +28,7 @@ import java.io.IOException;
 import io.jenkins.pluginhealth.scoring.probes.ProbeEngine;
 import io.jenkins.pluginhealth.scoring.scores.ScoringEngine;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -42,6 +42,7 @@ public class ProbeEngineScheduler {
         this.scoringEngine = scoringEngine;
     }
 
+    @Async
     @Scheduled(cron = "${app.cron.probe-engine}", zone = "UTC")
     public void run() throws IOException {
         probeEngine.run();

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.schedule;
 
 import java.io.IOException;
@@ -32,6 +31,7 @@ import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -46,13 +46,13 @@ public class UpdateCenterScheduler {
         this.pluginService = pluginService;
     }
 
+    @Async
     @Scheduled(cron = "${app.cron.update-center}", zone = "UTC")
     public void updateDatabase() throws IOException {
         LOGGER.info("Updating plugins from update-center");
-        updateCenterService.fetchUpdateCenter()
-            .plugins().values().stream()
-            .map(Plugin::toPlugin)
-            .forEach(pluginService::saveOrUpdate);
+        updateCenterService.fetchUpdateCenter().plugins().values().stream()
+                .map(Plugin::toPlugin)
+                .forEach(pluginService::saveOrUpdate);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Plugins updated from update-center");
         }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

When either schedulers are triggered, it is not possible to consult the web pages nor to get any scores from the API.
Running the scheduler methods asynchronously resolve this problem.

Closes #369.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Ran the application locally and could access API and web front while the ProbeEngine was running.
It was not possible before.

Testing this behavour automatically looks too complex for its benefit.

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
