### PR TITLE
fixes Swarm plugin has no active security advisory #627

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2023-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,7 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
                     }
                     final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());
                     final Matcher matcher = pattern.matcher(plugin.getVersion().toString());
-                    return matcher.find();
+                    return matcher.matches();
                 }))
                 .map(warning -> String.join("|", warning.id(), warning.url()))
                 .collect(Collectors.joining(", "));

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Jenkins Infra
+ * Copyright (c) 2023-2025 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,24 +23,23 @@
  */
 package io.jenkins.pluginhealth.scoring.probes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import hudson.util.VersionNumber;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarning;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarningVersion;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
-
-import hudson.util.VersionNumber;
-import org.junit.jupiter.api.Test;
 
 class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurityVulnerabilityProbe> {
     @Override
@@ -265,6 +264,99 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                 .comparingOnlyFields("id", "status", "message")
                 .isEqualTo(ProbeResult.success(
                         KnownSecurityVulnerabilityProbe.KEY, warningId1 + "|" + url1, probe.getVersion()));
+    }
+
+    @Test
+    void swarm349ShouldNotHaveSecurityAdvisory() {
+        final String pluginName = "swarm";
+        final VersionNumber pluginVersion = new VersionNumber("3.49");
+        final String warningId = "SECURITY-597";
+        final String url = "https://jenkins.io/security/advisory/2017-10-11/";
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId,
+                                pluginName,
+                                url,
+                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+    }
+
+    @Test
+    void swarm35ShouldNotHaveSecurityAdvisory() {
+        final String pluginName = "swarm";
+        final VersionNumber pluginVersion = new VersionNumber("3.5");
+        final String warningId = "SECURITY-597";
+        final String url = "https://jenkins.io/security/advisory/2017-10-11/";
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId,
+                                pluginName,
+                                url,
+                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+    }
+
+    @Test
+    void swarm34ShouldHaveSecurityAdvisory() {
+        final String pluginName = "swarm";
+        final VersionNumber pluginVersion = new VersionNumber("3.4");
+        final String warningId = "SECURITY-597";
+        final String url = "https://jenkins.io/security/advisory/2017-10-11/";
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId,
+                                pluginName,
+                                url,
+                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, warningId + "|" + url, probe.getVersion()));
     }
 
     @Test

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -23,23 +23,24 @@
  */
 package io.jenkins.pluginhealth.scoring.probes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-import hudson.util.VersionNumber;
 import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarning;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.SecurityWarningVersion;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
+
+import hudson.util.VersionNumber;
+import org.junit.jupiter.api.Test;
 
 class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurityVulnerabilityProbe> {
     @Override


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

This fixes the issue where the Swarm plugin is showing an active security advisory for 3.49. However, 3.5 (from 2017) has the fix.

Closes #627

### Testing done

`mvn clean verify -Dtest=KnownSecurityVulnerabilityProbeTest -Dsurefire.failIfNoSpecifiedTests=false`

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
