### PR TITLE
add profile aware schedulers

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -142,22 +142,21 @@ docker container exec -it plugin-health-scoring-db-1 psql -U <postgres-user-name
 
 ==== Not using `cron` when doing development
 
-There are a few components that use `@Scheduled` in the app. This can be a pain to work with while doing development:
+There are a few components that use `cron` inside `@Scheduled` in the app. This is a pain to work with when doing development.
 
-There are 2 classes that use `@Scheduled` in the app:
+Therefore, we actually have 2 versions of these schedules:
 
-* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterScheduler.java`
-* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/ProbeEngineScheduler.java`
+* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultProbeEngineScheduler.java`
+* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultUpdateCenterScheduler.java`
 
-NOTE: There is actually a third file (`war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DeleteOldScoreScheduler.java`), but that doesn't really matter for development.
+and 
 
-You have a choice. You can choose to always update the cron value in your `.env` file or while in development, you can change the `@Scheduled` value to something like:
+* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DevProbeEngineScheduler.java`
+* `war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DevUpdateCenterScheduler.java`
 
-`@Scheduled(initialDelay = 10 * 1000 /* 10 secs after startup */, fixedDelay = 1000 * 60 * 90 * 1)`
+The `default` versions use `cron`. However, the `dev` versions use a combination of `initialDelay` and `fixedDelay`. 
 
-What this means is the initial delay will be 10 seconds, and then after that initial run, it will run every 90 minutes. Tweak the values to whatever you want, but leave the `initialDelay` in so you don't have a race condition on startup.
-
-WARNING: DO NOT COMMIT the `@Scheduled` changes.
+Depending on how you start the application will determine which schedules start. If you start with `-Dspring-boot.run.profiles=dev`, then the `Dev*` versions will start. Otherwise the `Default*` versions will start.
 
 == Run the application on Gitpod
 

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultProbeEngineScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultProbeEngineScheduler.java
@@ -28,16 +28,18 @@ import java.io.IOException;
 import io.jenkins.pluginhealth.scoring.probes.ProbeEngine;
 import io.jenkins.pluginhealth.scoring.scores.ScoringEngine;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ProbeEngineScheduler {
+@Profile("default")
+public class DefaultProbeEngineScheduler {
     private final ProbeEngine probeEngine;
     private final ScoringEngine scoringEngine;
 
-    public ProbeEngineScheduler(ProbeEngine probeEngine, ScoringEngine scoringEngine) {
+    public DefaultProbeEngineScheduler(ProbeEngine probeEngine, ScoringEngine scoringEngine) {
         this.probeEngine = probeEngine;
         this.scoringEngine = scoringEngine;
     }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultUpdateCenterScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultUpdateCenterScheduler.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2025 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.schedule;
+
+import java.io.IOException;
+
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
+import io.jenkins.pluginhealth.scoring.service.PluginService;
+import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("default")
+public class DefaultUpdateCenterScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUpdateCenterScheduler.class);
+    private final UpdateCenterService updateCenterService;
+    private final PluginService pluginService;
+
+    public DefaultUpdateCenterScheduler(UpdateCenterService updateCenterService, PluginService pluginService) {
+        this.updateCenterService = updateCenterService;
+        this.pluginService = pluginService;
+    }
+
+    @Async
+    @Scheduled(cron = "${app.cron.update-center}", zone = "UTC")
+    public void updateDatabase() throws IOException {
+        LOGGER.info("Updating plugins from update-center");
+        updateCenterService.fetchUpdateCenter().plugins().values().stream()
+                .map(Plugin::toPlugin)
+                .forEach(pluginService::saveOrUpdate);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Plugins updated from update-center");
+        }
+    }
+}

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DevUpdateCenterScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DevUpdateCenterScheduler.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2025 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.schedule;
+
+import java.io.IOException;
+
+import io.jenkins.pluginhealth.scoring.model.updatecenter.Plugin;
+import io.jenkins.pluginhealth.scoring.service.PluginService;
+import io.jenkins.pluginhealth.scoring.service.UpdateCenterService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev")
+public class DevUpdateCenterScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DevUpdateCenterScheduler.class);
+    private final UpdateCenterService updateCenterService;
+    private final PluginService pluginService;
+
+    public DevUpdateCenterScheduler(UpdateCenterService updateCenterService, PluginService pluginService) {
+        this.updateCenterService = updateCenterService;
+        this.pluginService = pluginService;
+    }
+
+    @Async
+    @Scheduled(initialDelay = 10 * 1000 /* 10 secs after startup */, fixedDelay = 1000 * 60 * 90 * 1)
+    public void updateDatabase() throws IOException {
+        LOGGER.info("Updating plugins from update-center");
+        updateCenterService.fetchUpdateCenter().plugins().values().stream()
+                .map(Plugin::toPlugin)
+                .forEach(pluginService::saveOrUpdate);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Plugins updated from update-center");
+        }
+    }
+}

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterSchedulerIT.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/schedule/UpdateCenterSchedulerIT.java
@@ -51,7 +51,7 @@ class UpdateCenterSchedulerIT extends AbstractDBContainerTest {
     @Mock
     private UpdateCenterService ucService;
 
-    private UpdateCenterScheduler upScheduler;
+    private DefaultUpdateCenterScheduler upScheduler;
 
     @BeforeEach
     void setupUpdateCenterContent() throws IOException {
@@ -62,7 +62,7 @@ class UpdateCenterSchedulerIT extends AbstractDBContainerTest {
                         UpdateCenter.class);
 
         when(ucService.fetchUpdateCenter()).thenReturn(updateCenter);
-        upScheduler = new UpdateCenterScheduler(ucService, new PluginService(pluginRepository));
+        upScheduler = new DefaultUpdateCenterScheduler(ucService, new PluginService(pluginRepository));
     }
 
     @Test


### PR DESCRIPTION
### Description

There are a couple of scheduled items using `cron`. However, when doing development, it's a bit of pain to always be recalculating the cron line. In order to not do that, we were manually updating the `@Scheduled` to use `initialDelay` and `fixedDelay`.

With this change, we now have 2 version of scheduled components; one for when the application is started with a `dev` profile that uses `initialDelay` and `fixedDelay` and one where there is no profile specified, i.e. `default`, that uses the `cron` that we've using.

Also updated the CONTRIBUTING guide to reflect these new changes.

### Testing done

* `mvn clean verify`
* ran locally with `mvn spring-boot:run -Dskip.yarn -Drun.jvmArguments="-Xms2048m -Xmx2048m"` and `mvn spring-boot:run -Dskip.yarn -Dspring-boot.run.profiles=dev -Drun.jvmArguments="-Xms2048m -Xmx2048m"` to see if the schedules loaded as expected.

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
