### PR TITLE
Add `--repo` flag

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -31,7 +31,7 @@ gh repo sync\
 git switch main
 
 draft_releases=$(\
-    gh release list --json tagName,isDraft\
+    gh release list --repo jenkins-infra/plugin-health-scoring --json tagName,isDraft\
     | jq '[.[] | select(.isDraft == true)]'\
 )
 
@@ -86,6 +86,7 @@ gh release edit "${gh_draft_tag}"\
     --tag "${release_tag}"\
     --title="${release_title}"\
     --draft=false\
-    --latest
+    --latest\
+    --repo jenkins-infra/plugin-health-scoring 
 
 mvn -q release:clean


### PR DESCRIPTION
### Description

Add the `--repo` flag to a couple of the commands to always make sure we are correctly/fully referencing `jenkins-infra/plugin-health-scoring`. This is a safety in case the script is run from either the original (`jenkins-infra`) repo or a fork.

### Testing done

Ran the commands manually (outside the script)

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
