### PR TITLE
chore(Jenkinsfile): explicitly disable autoSemVer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
 
     stage('Docker image') {
       steps {
-        buildDockerAndPublishImage('plugin-health-scoring', [dockerfile: 'war/src/main/docker/Dockerfile', unstash: 'binary', targetplatforms: 'linux/amd64,linux/arm64'])
+        buildDockerAndPublishImage('plugin-health-scoring', [dockerfile: 'war/src/main/docker/Dockerfile', unstash: 'binary', targetplatforms: 'linux/amd64,linux/arm64', automaticSemanticVersioning: false])
       }
     }
   }


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Related to - https://github.com/jenkins-infra/helpdesk/issues/4165 

https://github.com/jenkins-infra/pipeline-library/pull/929 sets `automaticSemanticVersioning` true by default.

Since we want to avoid  automatic versioning, this PR explicitly disables automatic semantic versioning while building the docker image.

This will be a non-regression test for the pipeline.
 
 
 
<!-- Comment:
-->

### Testing done

 This PR should test the non-regression for the pipeline.

<!-- Comment:
-->

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
