### PR TITLE
Change the `Profile` value

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultProbeEngineScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultProbeEngineScheduler.java
@@ -34,7 +34,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("default")
+@Profile("production")
 public class DefaultProbeEngineScheduler {
     private final ProbeEngine probeEngine;
     private final ScoringEngine scoringEngine;

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultUpdateCenterScheduler.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/schedule/DefaultUpdateCenterScheduler.java
@@ -37,7 +37,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("default")
+@Profile("production")
 public class DefaultUpdateCenterScheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUpdateCenterScheduler.class);
     private final UpdateCenterService updateCenterService;


### PR DESCRIPTION
When I made changes back in https://github.com/jenkins-infra/plugin-health-scoring/commit/50ae99a0659c5d604c57e8ab866c7169f5d68ced , I misunderstood how the `default` profile works.

Now, we are setting the @Profile value explicitly to `production` so that the production app actually starts.

### Submitter checklist

- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [ ] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
