### PR TITLE
Closes #679 - Fix health score calculation when there are open security issues

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -48,7 +48,9 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
                 .filter(w -> w.name().equals(plugin.getName()))
                 .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
                     if (securityWarningVersion.lastVersion() != null) {
-                        return plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion());
+                        if (plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion())) {
+                            return true;
+                        }
                     }
                     final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());
                     final Matcher matcher = pattern.matcher(plugin.getVersion().toString());

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -268,6 +268,64 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
     }
 
     @Test
+    void repositoryConnectorShouldHaveSecurityIssues() {
+        final String pluginName = "repository-connector";
+        final VersionNumber pluginVersion = new VersionNumber("2.2.1");
+
+        SecurityWarning sw1 = new SecurityWarning(
+                "SECURITY-2665-1",
+                pluginName,
+                "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2665%20(1)",
+                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+        SecurityWarning sw2 = new SecurityWarning(
+                "SECURITY-2665-2",
+                pluginName,
+                "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2665%20(2)",
+                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+        SecurityWarning sw3 = new SecurityWarning(
+                "SECURITY-2784-repository-connector",
+                pluginName,
+                "https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2784",
+                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+        SecurityWarning sw4 = new SecurityWarning(
+                "SECURITY-2183",
+                pluginName,
+                "https://www.jenkins.io/security/advisory/2021-02-24/#SECURITY-2183",
+                List.of(new SecurityWarningVersion(new VersionNumber("2.0.2"), "([01]|2[.]0[.][0-2])(|[.-].+)")));
+        SecurityWarning sw5 = new SecurityWarning(
+                "SECURITY-1520",
+                pluginName,
+                "https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1520",
+                List.of(new SecurityWarningVersion(new VersionNumber("1.3.1"), "([01])(|[.-].+)")));
+        SecurityWarning sw6 = new SecurityWarning(
+                "SECURITY-958",
+                pluginName,
+                "https://jenkins.io/security/advisory/2019-03-06/#SECURITY-958",
+                List.of(new SecurityWarningVersion(new VersionNumber("1.2.4"), "(0|1[.]([01]|2[.][0-4]))(|[-.].*)")));
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(), Collections.emptyMap(), List.of(sw1, sw2, sw3, sw4, sw5, sw6)));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY,
+                        sw1.id() + "|" + sw1.url() + ", " + sw2.id() + "|" + sw2.url() + ", " + sw3.id() + "|"
+                                + sw3.url(),
+                        probe.getVersion()));
+    }
+
+    @Test
     void swarm349ShouldNotHaveSecurityAdvisory() {
         final String pluginName = "swarm";
         final VersionNumber pluginVersion = new VersionNumber("3.49");

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -326,6 +326,45 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
     }
 
     @Test
+    void ontrackShouldHaveSecurityIssues() {
+        final String pluginName = "ontrack";
+        final VersionNumber pluginVersion = new VersionNumber("4.1.2");
+
+        SecurityWarning sw1 = new SecurityWarning(
+                "SECURITY-495",
+                pluginName,
+                "https://jenkins.io/security/advisory/2017-04-10/",
+                List.of(new SecurityWarningVersion(new VersionNumber("2.30.5"), "2\\.([0-2]\\d?|30)\\..*")));
+        SecurityWarning sw2 = new SecurityWarning(
+                "SECURITY-1341",
+                pluginName,
+                "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1341",
+                List.of(new SecurityWarningVersion(new VersionNumber("3.4"), "(2|3[.]([0-3]))(|[.-].*)|3[.]4")));
+        SecurityWarning sw3 = new SecurityWarning(
+                "SECURITY-2784-ontrack",
+                pluginName,
+                "https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2784",
+                List.of(new SecurityWarningVersion(new VersionNumber("4.0.0"), ".*")));
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(Collections.emptyMap(), Collections.emptyMap(), List.of(sw1, sw2, sw3)));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, sw3.id() + "|" + sw3.url(), probe.getVersion()));
+    }
+
+    @Test
     void swarm349ShouldNotHaveSecurityAdvisory() {
         final String pluginName = "swarm";
         final VersionNumber pluginVersion = new VersionNumber("3.49");

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -232,7 +232,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
 
     @Test
     void shouldNotBeOKWithWarningWithoutLastVersionAndOneResolved() {
-        final String pluginName = "foo-bar";
+        final String pluginName = "foo-bar-3";
         final VersionNumber pluginVersion = new VersionNumber("1.2");
         final String warningId1 = "SECURITY-1";
         final String warningId2 = "SECURITY-1";
@@ -264,7 +264,9 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                 .usingRecursiveComparison()
                 .comparingOnlyFields("id", "status", "message")
                 .isEqualTo(ProbeResult.success(
-                        KnownSecurityVulnerabilityProbe.KEY, warningId1 + "|" + url1, probe.getVersion()));
+                        KnownSecurityVulnerabilityProbe.KEY,
+                        warningId1 + "|" + url1 + ", " + warningId2 + "|" + url2,
+                        probe.getVersion()));
     }
 
     @Test


### PR DESCRIPTION
### Description

Closes #679

The basic issue is (it appears) we assumed that a new version always resolved all issues. That is not true.

Now, we correctly apply the pattern when we are supposed to. 

### Testing done

* `mvn clean verify`
* Manual testing

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [x] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
