### PR TITLE
Don't consider dependency management bot with no dependencies

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbe.java
@@ -63,6 +63,6 @@ public class MavenDependenciesProbe extends AbstractMavenProbe {
 
     @Override
     public long getVersion() {
-        return 1;
+        return 2;
     }
 }

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbe.java
@@ -45,6 +45,7 @@ public class MavenDependenciesProbe extends AbstractMavenProbe {
             return success(List.of());
         }
         return success(dependencies.stream()
+                .filter(dep -> !"provided".equals(dep.getScope()) && !"runtime".equals(dep.getScope()))
                 .map(dep -> String.format(
                         "%s:%s:%s:%b", dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.isOptional()))
                 .toList());

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DependencyManagementScoring.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/scores/DependencyManagementScoring.java
@@ -1,0 +1,140 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.scores;
+
+import java.util.List;
+import java.util.Map;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.Resolution;
+import io.jenkins.pluginhealth.scoring.model.ScoringComponentResult;
+import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
+import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
+import io.jenkins.pluginhealth.scoring.probes.MavenDependenciesProbe;
+import io.jenkins.pluginhealth.scoring.probes.RenovateProbe;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DependencyManagementScoring extends Scoring {
+    public static final String KEY = "dependency-management";
+
+    @Override
+    public String key() {
+        return KEY;
+    }
+
+    @Override
+    public float weight() {
+        return 0.2f;
+    }
+
+    @Override
+    public String description() {
+        return "We encourage the usage of Dependency Management tools";
+    }
+
+    @Override
+    public List<ScoringComponent> getComponents() {
+        return List.of(new ScoringComponent() {
+            @Override
+            public String getDescription() {
+                return "";
+            }
+
+            @Override
+            public ScoringComponentResult getScore(Plugin plugin, Map<String, ProbeResult> probeResults) {
+                final ProbeResult mavenDependencies = probeResults.get(MavenDependenciesProbe.KEY);
+                if (mavenDependencies != null && mavenDependencies.status().equals(ProbeResult.Status.SUCCESS)) {
+                    final List<String> dependencies = (List<String>) mavenDependencies.message();
+                    if (dependencies.isEmpty()) {
+                        return new ScoringComponentResult(100, 0, List.of("The plugin is not using any dependencies"));
+                    }
+                }
+
+                final ProbeResult dependabot = probeResults.get(DependabotProbe.KEY);
+                final ProbeResult renovate = probeResults.get(RenovateProbe.KEY);
+                final ProbeResult pullRequestCount = probeResults.get(DependabotPullRequestProbe.KEY);
+
+                if (dependabot != null
+                        && ProbeResult.Status.SUCCESS.equals(dependabot.status())
+                        && "Dependabot is configured.".equals(dependabot.message())) {
+                    return manageOpenDependencyPullRequestValue(plugin, dependabot, pullRequestCount);
+                }
+                if (renovate != null
+                        && ProbeResult.Status.SUCCESS.equals(renovate.status())
+                        && "Renovate is configured.".equals(renovate.message())) {
+                    return manageOpenDependencyPullRequestValue(plugin, renovate, pullRequestCount);
+                }
+
+                return new ScoringComponentResult(
+                        0,
+                        getWeight(),
+                        List.of("Could not retrieve details required to score the plugin."),
+                        List.of(new Resolution(
+                                "Please open an issue on the project.",
+                                "https://github.com/jenkins-infra/plugin-health-scoring/issues/new/choose")));
+            }
+
+            private ScoringComponentResult manageOpenDependencyPullRequestValue(
+                    Plugin plugin, @NotNull ProbeResult botProbeResult, ProbeResult pullRequestCount) {
+                if (pullRequestCount != null) {
+                    return 0 == (int) pullRequestCount.message()
+                            ? new ScoringComponentResult(
+                                    100,
+                                    getWeight(),
+                                    List.of((String) botProbeResult.message(), "0 open dependency pull request"))
+                            : new ScoringComponentResult(
+                                    50,
+                                    getWeight(),
+                                    List.of(
+                                            (String) botProbeResult.message(),
+                                            "%s open dependency pull request".formatted(pullRequestCount.message())),
+                                    List.of(new Resolution(
+                                            "See the open pull requests of the plugin",
+                                            "%s/pulls?q=is%%3Aopen+is%%3Apr+label%%3Adependencies"
+                                                    .formatted(plugin.getScm()))));
+                }
+                return new ScoringComponentResult(
+                        0,
+                        getWeight(),
+                        List.of(
+                                (String) botProbeResult.message(),
+                                "Cannot determine if there is any dependency pull request opened on the repository."));
+            }
+
+            @Override
+            public int getWeight() {
+                return 1;
+            }
+        });
+    }
+
+    @Override
+    public int version() {
+        return 1;
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/MavenDependenciesProbeTest.java
@@ -95,4 +95,31 @@ class MavenDependenciesProbeTest extends AbstractProbeTest<MavenDependenciesProb
                                 "other-groupId:other-artifactId:other-version:true"),
                         probe.getVersion()));
     }
+
+    @Test
+    void shouldNotConsiderProvidedNorRuntimeDependencies() throws Exception {
+
+        final Model pom = mock(Model.class);
+        final MavenDependenciesProbe probe = getSpy();
+
+        final Dependency dep1 = new Dependency();
+        dep1.setGroupId("groupId");
+        dep1.setArtifactId("artifactId");
+        dep1.setVersion("version");
+        dep1.setScope("runtime");
+        dep1.setOptional(false);
+        final Dependency dep2 = new Dependency();
+        dep2.setGroupId("other-groupId");
+        dep2.setArtifactId("other-artifactId");
+        dep2.setVersion("other-version");
+        dep2.setOptional(true);
+        dep2.setScope("provided");
+
+        when(pom.getDependencies()).thenReturn(List.of(dep1, dep2));
+
+        assertThat(probe.getMavenDetails(pom))
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(MavenDependenciesProbe.KEY, List.of(), probe.getVersion()));
+    }
 }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DependencyManagementScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/DependencyManagementScoringTest.java
@@ -1,0 +1,140 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.scores;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+import io.jenkins.pluginhealth.scoring.model.ScoreResult;
+import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
+import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
+import io.jenkins.pluginhealth.scoring.probes.MavenDependenciesProbe;
+import io.jenkins.pluginhealth.scoring.probes.RenovateProbe;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DependencyManagementScoringTest extends AbstractScoringTest<DependencyManagementScoring> {
+
+    @Override
+    DependencyManagementScoring getSpy() {
+        return spy(DependencyManagementScoring.class);
+    }
+
+    static Stream<Arguments> probeResultsAndValue() {
+        return Stream.of(
+                Arguments.arguments(Map.of(), 0),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of(), 1)),
+                        100),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1)),
+                        0),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1)),
+                        0),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                DependabotProbe.KEY,
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1)),
+                        0),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1)),
+                        50),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                DependabotProbe.KEY,
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1)),
+                        50),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                RenovateProbe.KEY,
+                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1)),
+                        100),
+                Arguments.arguments(
+                        Map.of(
+                                MavenDependenciesProbe.KEY,
+                                ProbeResult.success(MavenDependenciesProbe.KEY, List.of("this-is-a-dependency"), 1),
+                                DependabotProbe.KEY,
+                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
+                                DependabotPullRequestProbe.KEY,
+                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1)),
+                        100));
+    }
+
+    @ParameterizedTest
+    @MethodSource("probeResultsAndValue")
+    public void shouldScorePluginBasedOnProbeResultMatrix(Map<String, ProbeResult> details, int value) {
+        final Plugin plugin = mock(Plugin.class);
+        final DependencyManagementScoring scoring = getSpy();
+
+        when(plugin.getDetails()).thenReturn(details);
+
+        final ScoreResult result = scoring.apply(plugin);
+
+        assertThat(result.componentsResults().size()).isEqualTo(1);
+        assertThat(result.componentsResults().stream()
+                        .noneMatch(cr -> cr.reasons().isEmpty()))
+                .isTrue();
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("key", "value", "weight")
+                .isEqualTo(new ScoreResult(DependencyManagementScoring.KEY, value, .2f, Set.of(), scoring.version()));
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/scores/PluginMaintenanceScoringTest.java
@@ -38,10 +38,7 @@ import io.jenkins.pluginhealth.scoring.model.ProbeResult;
 import io.jenkins.pluginhealth.scoring.model.ScoreResult;
 import io.jenkins.pluginhealth.scoring.probes.CodeOwnershipProbe;
 import io.jenkins.pluginhealth.scoring.probes.ContinuousDeliveryProbe;
-import io.jenkins.pluginhealth.scoring.probes.DependabotProbe;
-import io.jenkins.pluginhealth.scoring.probes.DependabotPullRequestProbe;
 import io.jenkins.pluginhealth.scoring.probes.JenkinsfileProbe;
-import io.jenkins.pluginhealth.scoring.probes.RenovateProbe;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -64,29 +61,6 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        0),
-                arguments( // All bad with open dependabot pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
@@ -98,28 +72,6 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        100),
-                arguments( // All good
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
@@ -130,333 +82,65 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        56),
-                arguments( // Jenkinsfile and dependabot but with open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        67),
-                arguments( // Jenkinsfile and dependabot with no open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        78),
-                arguments( // Jenkinsfile and renovate but with open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        67),
-                arguments( // Jenkinsfile and renovate with no open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot not is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        78),
+                        71),
                 arguments( // Jenkinsfile and CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        60),
-                arguments( // Jenkinsfile and CD and dependabot but with open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        70),
-                arguments( // Jenkinsfile and CD and dependabot but with no open pull request
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        80),
-                arguments( // Dependabot only with no open pull requests
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        22),
-                arguments( // Dependabot only with open pull requests
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        11),
-                arguments( // Dependabot with no open pull request and CD
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        30),
-                arguments( // Renovate only with no open pull requests
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        22),
-                arguments( // Renovate only with open pull requests
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        11),
-                arguments( // Renovate with no open pull request and CD
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(
-                                        CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        30),
+                        71),
                 arguments( // CD only
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(
                                         CodeOwnershipProbe.KEY, "No CODEOWNERS file found in plugin repository.", 1)),
-                        10),
+                        0),
                 arguments( // Codeownership only
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "No Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        22),
+                        29),
                 arguments( // Codeownership + Jenkinsfile
                         Map.of(
                                 JenkinsfileProbe.KEY,
                                 ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "Could not find JEP-229 workflow definition.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        78),
-                arguments( // Codeownership + Jenkinsfile + CD
+                        100),
+                arguments( // Codeownership + CD
                         Map.of(
                                 JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is not configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
+                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile not found", 1),
                                 ContinuousDeliveryProbe.KEY,
                                 ProbeResult.success(
                                         ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
                                 CodeOwnershipProbe.KEY,
                                 ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        80),
-                arguments( // Codeownership + Jenkinsfile + CD + Dependabot
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 1, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        90),
-                arguments( // Codeownership + Jenkinsfile + CD
-                        Map.of(
-                                JenkinsfileProbe.KEY,
-                                ProbeResult.success(JenkinsfileProbe.KEY, "Jenkinsfile found", 1),
-                                DependabotProbe.KEY,
-                                ProbeResult.success(DependabotProbe.KEY, "Dependabot is configured.", 1),
-                                RenovateProbe.KEY,
-                                ProbeResult.success(RenovateProbe.KEY, "Renovate is not configured.", 1),
-                                DependabotPullRequestProbe.KEY,
-                                ProbeResult.success(DependabotPullRequestProbe.KEY, 0, 1),
-                                ContinuousDeliveryProbe.KEY,
-                                ProbeResult.success(
-                                        ContinuousDeliveryProbe.KEY, "JEP-229 workflow definition found.", 1),
-                                CodeOwnershipProbe.KEY,
-                                ProbeResult.success(CodeOwnershipProbe.KEY, "CODEOWNERS file is valid.", 1)),
-                        100));
+                        29));
     }
 
     @ParameterizedTest
@@ -469,7 +153,7 @@ class PluginMaintenanceScoringTest extends AbstractScoringTest<PluginMaintenance
 
         final ScoreResult result = scoring.apply(plugin);
 
-        assertThat(result.componentsResults().size()).isEqualTo(4);
+        assertThat(result.componentsResults().size()).isEqualTo(3);
         assertThat(result.componentsResults().stream()
                         .noneMatch(cr -> cr.reasons().isEmpty()))
                 .isTrue();


### PR DESCRIPTION
<!--
 DO NOT DELETE
 
 This template was created to help contributors validate their contribution
 and help maintainers understand the contribution.
 Do not delete the template, but complete it. Check the tasklist items that
 the contribution validates, add your contribution description and what kind
 of testing you have done on it.
 The template was not created to be ignored.
 -->

### Description

Since we can have the list of dependencies used by the plugin, we can decide if it makes sense or not to enforce the usage of dependency management bot (Dependabot, Renovate, etc).

Closes #661.

<!-- Comment:
 Please start by adding a link to an issue if the pull request is trying to solve one.
 You can used keyword to do the linking automatically: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
 Provide a clear description of the content of the pull request.
 This includes documentation, link to issues, scenario of executions.
 For UI change, a screenshot of before and after the change is also welcome.
 Make sure you read the contributing guide.
 Please explain how this pull request content will benefit the project.
-->

### Testing done

Added unit tests on the new class and the modified code.

<!-- Comment:
  if there is no automatic test, please explain what you did to validate
  the bugfix or the improvement.
-->

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
