### PR TITLE
feat: Add probe to detect parent POM version

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ParentPomVersionProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/ParentPomVersionProbe.java
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2026 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.probes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Probe to detect the parent POM version used by a Jenkins plugin.
+ *
+ * <p>Jenkins plugins inherit build configuration from the parent POM
+ * (https://github.com/jenkinsci/plugin-pom). This probe extracts the
+ * parent POM version from the plugin's pom.xml to help track modernization
+ * and identify plugins using outdated parent versions.</p>
+ */
+@Component
+@Order(value = ParentPomVersionProbe.ORDER)
+public class ParentPomVersionProbe extends Probe {
+    public static final int ORDER = LastCommitDateProbe.ORDER + 100;
+    public static final String KEY = "parent-pom-version";
+
+    // Regex to match: <parent>...<version>X.Y.Z</version>...</parent>
+    private static final Pattern PARENT_VERSION_PATTERN =
+            Pattern.compile("<parent>.*?<version>\\s*([^<]+?)\\s*</version>.*?</parent>", Pattern.DOTALL);
+
+    @Override
+    public String key() {
+        return KEY;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Detects the parent POM version used by the plugin";
+    }
+
+    @Override
+    protected ProbeResult doApply(Plugin plugin, ProbeContext context) {
+        // Check if we have a local repository
+        if (context.getScmRepository().isEmpty()) {
+            return this.error("There is no local repository for plugin " + plugin.getName() + ".");
+        }
+
+        final Path repository = context.getScmRepository().get();
+        final Path pomFile = repository.resolve("pom.xml");
+
+        // Check if pom.xml exists
+        if (!Files.exists(pomFile)) {
+            return this.error("pom.xml not found in repository");
+        }
+
+        try {
+            // Read pom.xml content
+            String pomContent = Files.readString(pomFile);
+
+            // Extract parent version
+            String parentVersion = extractParentVersion(pomContent);
+
+            if (parentVersion == null) {
+                return this.error("No parent POM found in pom.xml");
+            }
+
+            // Return success with the version
+            return this.success(parentVersion);
+
+        } catch (IOException e) {
+            return this.error("Error reading pom.xml: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Extracts the parent POM version from pom.xml content.
+     *
+     * @param pomContent the content of pom.xml
+     * @return the parent version string, or null if not found
+     */
+    private String extractParentVersion(String pomContent) {
+        Matcher matcher = PARENT_VERSION_PATTERN.matcher(pomContent);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean isSourceCodeRelated() {
+        // Parent POM version is in the source code (pom.xml)
+        // So this should return true to re-run when code changes
+        return true;
+    }
+
+    @Override
+    public long getVersion() {
+        return 1;
+    }
+}

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ParentPomVersionProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/ParentPomVersionProbeTest.java
@@ -1,0 +1,204 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2026 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.probes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.jenkins.pluginhealth.scoring.model.Plugin;
+import io.jenkins.pluginhealth.scoring.model.ProbeResult;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ParentPomVersionProbeTest {
+
+    @Test
+    void shouldExtractParentPomVersion(@TempDir Path temp) throws IOException {
+        // Given: A pom.xml with parent version 4.80
+        String pomContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.80</version>
+                    <relativePath />
+                </parent>
+                <artifactId>test-plugin</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </project>
+            """;
+
+        Path pomFile = temp.resolve("pom.xml");
+        Files.writeString(pomFile, pomContent);
+
+        // When: Probe is applied
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn("test-plugin");
+
+        ProbeContext context = mock(ProbeContext.class);
+        when(context.getScmRepository()).thenReturn(Optional.of(temp));
+
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        ProbeResult result = probe.apply(plugin, context);
+
+        // Then: Result should be success with version
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(ProbeResult.Status.SUCCESS);
+        assertThat(result.message()).isEqualTo("4.80");
+    }
+
+    @Test
+    void shouldHandleMissingPomFile(@TempDir Path temp) {
+        // Given: No pom.xml in repository
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn("test-plugin");
+
+        ProbeContext context = mock(ProbeContext.class);
+        when(context.getScmRepository()).thenReturn(Optional.of(temp));
+
+        // When: Probe is applied
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        ProbeResult result = probe.apply(plugin, context);
+
+        // Then: Should return error
+        assertThat(result.status()).isEqualTo(ProbeResult.Status.ERROR);
+        assertThat(result.message()).asString().contains("pom.xml not found");
+    }
+
+    @Test
+    void shouldHandleNoParentPom(@TempDir Path temp) throws IOException {
+        // Given: A pom.xml without parent
+        String pomContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <groupId>test</groupId>
+                <artifactId>test-plugin</artifactId>
+                <version>1.0.0</version>
+            </project>
+            """;
+
+        Path pomFile = temp.resolve("pom.xml");
+        Files.writeString(pomFile, pomContent);
+
+        // When: Probe is applied
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn("test-plugin");
+
+        ProbeContext context = mock(ProbeContext.class);
+        when(context.getScmRepository()).thenReturn(Optional.of(temp));
+
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        ProbeResult result = probe.apply(plugin, context);
+
+        // Then: Should return error
+        assertThat(result.status()).isEqualTo(ProbeResult.Status.ERROR);
+        assertThat(result.message()).asString().contains("No parent POM found");
+    }
+
+    @Test
+    void shouldHandleNoLocalRepository() {
+        // Given: No local repository available
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn("test-plugin");
+
+        ProbeContext context = mock(ProbeContext.class);
+        when(context.getScmRepository()).thenReturn(Optional.empty());
+
+        // When: Probe is applied
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        ProbeResult result = probe.apply(plugin, context);
+
+        // Then: Should return error
+        assertThat(result.status()).isEqualTo(ProbeResult.Status.ERROR);
+        assertThat(result.message()).asString().contains("no local repository");
+    }
+
+    @Test
+    void shouldHandleMultilineParentBlock(@TempDir Path temp) throws IOException {
+        // Given: Parent block with formatting/whitespace
+        String pomContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>
+                        4.75
+                    </version>
+                    <relativePath />
+                </parent>
+                <artifactId>test-plugin</artifactId>
+            </project>
+            """;
+
+        Path pomFile = temp.resolve("pom.xml");
+        Files.writeString(pomFile, pomContent);
+
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getName()).thenReturn("test-plugin");
+
+        ProbeContext context = mock(ProbeContext.class);
+        when(context.getScmRepository()).thenReturn(Optional.of(temp));
+
+        // When: Probe is applied
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        ProbeResult result = probe.apply(plugin, context);
+
+        // Then: Should handle whitespace correctly
+        assertThat(result.status()).isEqualTo(ProbeResult.Status.SUCCESS);
+        assertThat(result.message()).isEqualTo("4.75");
+    }
+
+    @Test
+    void shouldReturnCorrectKey() {
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        assertThat(probe.key()).isEqualTo("parent-pom-version");
+    }
+
+    @Test
+    void shouldReturnDescription() {
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        assertThat(probe.getDescription()).isNotBlank().contains("parent POM version");
+    }
+
+    @Test
+    void shouldBeSourceCodeRelated() {
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        assertThat(probe.isSourceCodeRelated()).isTrue();
+    }
+
+    @Test
+    void shouldHaveVersionOne() {
+        ParentPomVersionProbe probe = new ParentPomVersionProbe();
+        assertThat(probe.getVersion()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### What this does

This PR adds a new probe that checks what parent POM version each Jenkins plugin is using. The probe reads the plugin's pom.xml and extracts the version number.

This is the first part of #317 - just collecting the data for now. We'll add the scoring/comparison part later once this is working.

### How it works

- Reads pom.xml from the plugin repository
- Extracts the `<parent><version>` using regex
- Returns the version number (like "4.80")
- Handles cases where pom.xml doesn't exist or has no parent

### Testing

I've tested this pretty thoroughly:
- 9 unit tests all passing
- Ran `mvn verify` successfully  
- Started the app locally and saw it running on actual plugins
- Confirmed error handling works (saw it handle missing pom.xml gracefully)

### Why Phase 1 only?

As @alecharp mentioned, the ideal solution needs a "scoring context" to fetch the latest plugin-pom version once and compare all plugins against it. That's architectural work that should be discussed separately.

This PR just collects the data - which is immediately useful and can be built upon later.

This is my first contribution here, so feedback is very welcome! Thanks for the guidance @alecharp. I am ready for review when you have time. Let me know if anything needs to be changed!
