### PR TITLE
fix: throw IOException on non-2xx HTTP response in UpdateCenterService

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterService.java
@@ -23,6 +23,7 @@
  */
 package io.jenkins.pluginhealth.scoring.service;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,11 +52,17 @@ public class UpdateCenterService {
         var uri = URI.create(source);
         return switch (uri.getScheme()) {
             case "http", "https" -> {
-                try (HttpClient client = HttpClient.newBuilder().build()) {
+                try {
+                    HttpClient client = HttpClient.newBuilder()
+                            .followRedirects(HttpClient.Redirect.NORMAL)
+                            .build();
                     HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
-                    HttpResponse<InputStream> response =
-                            client.send(request, HttpResponse.BodyHandlers.ofInputStream());
-                    yield response.body();
+                    HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+                    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                        throw new IOException("Unexpected HTTP %d fetching update center from %s"
+                                .formatted(response.statusCode(), source));
+                    }
+                    yield new ByteArrayInputStream(response.body());
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/service/UpdateCenterServiceTest.java
@@ -24,12 +24,17 @@
 package io.jenkins.pluginhealth.scoring.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import io.jenkins.pluginhealth.scoring.config.ApplicationConfiguration;
 import io.jenkins.pluginhealth.scoring.model.updatecenter.UpdateCenter;
 
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
@@ -53,5 +58,30 @@ class UpdateCenterServiceTest {
 
         UpdateCenter updateCenter = updateCenterService.fetchUpdateCenter();
         assertThat(updateCenter.plugins()).hasSize(25);
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnNonOkHttpResponse() throws Exception {
+        byte[] htmlBody = "<html>Service Unavailable</html>".getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/uc.json", exchange -> {
+            exchange.sendResponseHeaders(503, htmlBody.length);
+            try (var os = exchange.getResponseBody()) {
+                os.write(htmlBody);
+            }
+        });
+        server.start();
+        try {
+            int port = server.getAddress().getPort();
+            ApplicationConfiguration configuration = new ApplicationConfiguration(
+                    new ApplicationConfiguration.Jenkins("http://localhost:%d/uc.json".formatted(port), "foo"),
+                    new ApplicationConfiguration.GitHub("foo", null, "bar"));
+            UpdateCenterService service = new UpdateCenterService(objectMapper, configuration);
+            assertThatThrownBy(service::fetchUpdateCenter)
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("503");
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
### Description

Fixes the production error reported on 2026-08-31 where Jackson received an HTML response (starting with `<`) instead of JSON from `updates.jenkins.io`, causing a `StreamReadException`.

Root cause: `UpdateCenterService.getDataStream()` never checked the HTTP response status code. Java's `HttpClient` has a redirect policy of `NEVER` by default, so any 3xx redirect response, or any 4xx/5xx error page, was passed directly to Jackson as a body stream. Additionally, the response body `InputStream` was yielded after the `HttpClient` was closed by `try-with-resources`, which could cause intermittent stream-closed failures.

Changes:
- Add `followRedirects(HttpClient.Redirect.NORMAL)` so standard redirects are followed automatically
- Switch `ofInputStream()` to `ofByteArray()` to fully buffer the response before the client closes
- Throw a descriptive `IOException("Unexpected HTTP <status> fetching update center from <url>")` on any non-2xx status

### Testing done

A new unit test `shouldThrowIOExceptionOnNonOkHttpResponse` was added to `UpdateCenterServiceTest`. It starts a local `HttpServer` (JDK built-in, no new dependency), serves a 503 response with an HTML body, and asserts that `fetchUpdateCenter()` throws an `IOException` containing the status code.

Local test execution was skipped — the `git-commit-id-plugin` fails in this git worktree environment (bare repo + worktree, pre-existing issue). CI validation is relied upon per the contributor's explicit decision.

### Submitter checklist

- [ ] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.