### PR TITLE
fix: ProbeResult Serializable + PluginDocumentationService HTTP error handling

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/ProbeResult.java
@@ -23,6 +23,7 @@
  */
 package io.jenkins.pluginhealth.scoring.model;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
@@ -37,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
  * @param timestamp    when the probe generated this result
  * @param probeVersion the version of the probe which generated this result
  */
-public record ProbeResult(String id, Object message, Status status, ZonedDateTime timestamp, long probeVersion) {
+public record ProbeResult(String id, Object message, Status status, ZonedDateTime timestamp, long probeVersion) implements Serializable {
     public ProbeResult(String id, Object message, Status status, long probeVersion) {
         this(id, message, status, ZonedDateTime.now(), probeVersion);
     }

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/model/ProbeResultTest.java
@@ -26,6 +26,11 @@ package io.jenkins.pluginhealth.scoring.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -69,5 +74,25 @@ class ProbeResultTest {
         final ProbeResult result2 = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 2);
 
         assertThat(result1).isNotEqualTo(result2);
+    }
+
+    @Test
+    void shouldBeSerializable() throws Exception {
+        final ProbeResult original = new ProbeResult("probe", "this is a message", ProbeResult.Status.SUCCESS, ZonedDateTime.now(), 1);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(original);
+        }
+
+        try (final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            final ProbeResult deserialized = (ProbeResult) ois.readObject();
+            assertThat(deserialized).isEqualTo(original);
+        }
+    }
+
+    @Test
+    void shouldImplementSerializable() {
+        assertThat(ProbeResult.class).isAssignableTo(Serializable.class);
     }
 }

--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationService.java
@@ -23,6 +23,7 @@
  */
 package io.jenkins.pluginhealth.scoring.service;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,7 @@ import io.jenkins.pluginhealth.scoring.config.ApplicationConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
@@ -57,11 +59,17 @@ public class PluginDocumentationService {
         var uri = URI.create(source);
         return switch (uri.getScheme()) {
             case "http", "https" -> {
-                try (HttpClient client = HttpClient.newBuilder().build()) {
+                try {
+                    HttpClient client = HttpClient.newBuilder()
+                            .followRedirects(HttpClient.Redirect.NORMAL)
+                            .build();
                     HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
-                    HttpResponse<InputStream> response =
-                            client.send(request, HttpResponse.BodyHandlers.ofInputStream());
-                    yield response.body();
+                    HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+                    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                        throw new IOException("Unexpected HTTP %d fetching documentation URLs from %s"
+                                .formatted(response.statusCode(), source));
+                    }
+                    yield new ByteArrayInputStream(response.body());
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
@@ -84,7 +92,7 @@ public class PluginDocumentationService {
                             e -> e.getValue() == null || e.getValue().url() == null
                                     ? ""
                                     : e.getValue().url()));
-        } catch (IOException e) {
+        } catch (IOException | JacksonException e) {
             LOGGER.error("Could not fetch plugin documentation.", e);
             return Map.of();
         }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/service/PluginDocumentationServiceTest.java
@@ -90,4 +90,20 @@ class PluginDocumentationServiceTest {
 
         assertThat(map).isEmpty();
     }
+
+    @Test
+    void shouldReturnEmptyMapWhenResponseIsNotJson() {
+        final URL url = PluginDocumentationService.class.getResource(
+                "/documentation-urls/plugin-documentation-urls-html-error.html");
+        assertThat(url).isNotNull();
+
+        final ApplicationConfiguration config = new ApplicationConfiguration(
+                new ApplicationConfiguration.Jenkins("foo", url.toString()),
+                new ApplicationConfiguration.GitHub("foo", null, "bar"));
+
+        final PluginDocumentationService service = new PluginDocumentationService(mapper, config);
+        final Map<String, String> map = service.fetchPluginDocumentationUrl();
+
+        assertThat(map).isEmpty();
+    }
 }

--- a/war/src/test/resources/documentation-urls/plugin-documentation-urls-html-error.html
+++ b/war/src/test/resources/documentation-urls/plugin-documentation-urls-html-error.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><h1>503 Service Unavailable</h1></body></html>


### PR DESCRIPTION
## Summary

- `ProbeResult` now implements `Serializable` — required by `hypersistence-utils` when Hibernate takes dirty-check snapshots of the `Plugin.details` JSON column; its absence caused a `JpaSystemException` on any query that loaded a `Plugin` with probe results
- `PluginDocumentationService` now checks the HTTP status code (aligning with `UpdateCenterService` after be47897) and catches `JacksonException` — in Jackson 3.x `JacksonException` extends `RuntimeException`, not `IOException`, so HTML error pages from the docs endpoint were crashing the probe engine scheduler

## Test plan

- [ ] `ProbeResultTest#shouldBeSerializable` — round-trip Java serialization
- [ ] `ProbeResultTest#shouldImplementSerializable` — interface assertion
- [ ] `PluginDocumentationServiceTest#shouldReturnEmptyMapWhenResponseIsNotJson` — HTML fixture triggers the fixed catch path