### PR TITLE
feat(health): add connection details to GitHub health indicator

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicator.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicator.java
@@ -24,8 +24,11 @@
 package io.jenkins.pluginhealth.scoring.config;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GitHub;
 import org.springframework.boot.health.contributor.AbstractHealthIndicator;
 import org.springframework.boot.health.contributor.Health;
@@ -44,10 +47,27 @@ public class GitHubHealthIndicator extends AbstractHealthIndicator {
         try {
             if (Objects.isNull(github)) {
                 builder.down().withDetail("error", "GitHub object is null");
-            } else {
-                github.checkApiUrlValidity();
-                builder.up();
+                return;
             }
+            github.checkApiUrlValidity();
+            boolean authenticated = !github.isAnonymous();
+            Map<String, Object> connection = new HashMap<>();
+            connection.put("authenticated", authenticated);
+            GHRateLimit rateLimit = github.lastRateLimit();
+            if (rateLimit != null) {
+                connection.put(
+                        "rateLimit",
+                        Map.of(
+                                "limit", rateLimit.getLimit(),
+                                "remaining", rateLimit.getRemaining(),
+                                "resetDate", rateLimit.getResetDate()));
+            }
+            if (authenticated) {
+                builder.up();
+            } else {
+                builder.outOfService();
+            }
+            builder.withDetail("connection", connection);
         } catch (IOException ex) {
             builder.down(ex);
         }

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicatorIT.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicatorIT.java
@@ -1,0 +1,134 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2026 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Date;
+
+import io.jenkins.pluginhealth.scoring.AbstractDBContainerTest;
+
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHRateLimit;
+import org.kohsuke.github.GitHub;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+            "app.github.app-id=test-app-id",
+            "app.github.app-installation-name=test-installation",
+            "app.github.private-key-path=/dev/null",
+            "management.endpoint.health.show-details=always",
+            "management.endpoint.health.show-components=always"
+        })
+class GitHubHealthIndicatorIT extends AbstractDBContainerTest {
+    @MockitoBean
+    private GitHub github;
+
+    @LocalServerPort
+    private int port;
+
+    private final RestTemplate restTemplate = restTemplate();
+
+    private static RestTemplate restTemplate() {
+        RestTemplate t = new RestTemplate();
+        t.setErrorHandler(new ResponseErrorHandler() {
+            @Override
+            public boolean hasError(ClientHttpResponse response) {
+                return false;
+            }
+
+            @Override
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {}
+        });
+        return t;
+    }
+
+    private String healthUrl(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    @Test
+    void healthEndpointIsUpWithConnectionDetailsWhenAuthenticated() throws IOException {
+        GHRateLimit rateLimit = mock(GHRateLimit.class);
+        when(github.isAnonymous()).thenReturn(false);
+        when(github.lastRateLimit()).thenReturn(rateLimit);
+        when(rateLimit.getLimit()).thenReturn(5000);
+        when(rateLimit.getRemaining()).thenReturn(4999);
+        when(rateLimit.getResetDate()).thenReturn(new Date(0));
+
+        ResponseEntity<String> response = restTemplate.getForEntity(healthUrl("/actuator/health/gitHub"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .contains("\"status\":\"UP\"")
+                .contains("\"connection\"")
+                .contains("\"authenticated\":true")
+                .contains("\"rateLimit\"")
+                .contains("\"limit\":5000")
+                .contains("\"remaining\":4999")
+                .contains("\"resetDate\"");
+    }
+
+    @Test
+    void healthEndpointIsOutOfServiceWhenAnonymous() throws IOException {
+        GHRateLimit rateLimit = mock(GHRateLimit.class);
+        when(github.isAnonymous()).thenReturn(true);
+        when(github.lastRateLimit()).thenReturn(rateLimit);
+        when(rateLimit.getLimit()).thenReturn(60);
+        when(rateLimit.getRemaining()).thenReturn(59);
+        when(rateLimit.getResetDate()).thenReturn(new Date(0));
+
+        ResponseEntity<String> response = restTemplate.getForEntity(healthUrl("/actuator/health/gitHub"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).contains("\"status\":\"OUT_OF_SERVICE\"").contains("\"authenticated\":false");
+    }
+
+    @Test
+    void healthEndpointHasNoRateLimitKeyWhenNotCachedYet() throws IOException {
+        when(github.isAnonymous()).thenReturn(false);
+        when(github.lastRateLimit()).thenReturn(null);
+
+        ResponseEntity<String> response = restTemplate.getForEntity(healthUrl("/actuator/health/gitHub"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"authenticated\":true").doesNotContain("\"rateLimit\"");
+    }
+}

--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicatorTest.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/config/GitHubHealthIndicatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2026 Jenkins Infra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.jenkins.pluginhealth.scoring.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHRateLimit;
+import org.kohsuke.github.GitHub;
+import org.springframework.boot.health.contributor.Status;
+
+class GitHubHealthIndicatorTest {
+
+    @Test
+    void statusIsDownWhenGitHubIsNull() {
+        var indicator = new GitHubHealthIndicator(null);
+        var health = indicator.health();
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("error");
+    }
+
+    @Test
+    void statusIsDownWhenApiUrlCheckFails() throws IOException {
+        var github = mock(GitHub.class);
+        doThrow(new IOException("unreachable")).when(github).checkApiUrlValidity();
+
+        var health = new GitHubHealthIndicator(github).health();
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    }
+
+    @Test
+    void statusIsUpAndConnectionDetailsPresentWhenAuthenticated() throws IOException {
+        var github = mock(GitHub.class);
+        var rateLimit = mock(GHRateLimit.class);
+        when(github.isAnonymous()).thenReturn(false);
+        when(github.lastRateLimit()).thenReturn(rateLimit);
+        when(rateLimit.getLimit()).thenReturn(5000);
+        when(rateLimit.getRemaining()).thenReturn(4999);
+        when(rateLimit.getResetDate()).thenReturn(new Date(0));
+
+        var health = new GitHubHealthIndicator(github).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsKey("connection");
+        @SuppressWarnings("unchecked")
+        var connection = (Map<String, Object>) health.getDetails().get("connection");
+        assertThat(connection).containsEntry("authenticated", true);
+        assertThat(connection).containsKey("rateLimit");
+    }
+
+    @Test
+    void statusIsOutOfServiceWhenAnonymous() throws IOException {
+        var github = mock(GitHub.class);
+        var rateLimit = mock(GHRateLimit.class);
+        when(github.isAnonymous()).thenReturn(true);
+        when(github.lastRateLimit()).thenReturn(rateLimit);
+        when(rateLimit.getLimit()).thenReturn(60);
+        when(rateLimit.getRemaining()).thenReturn(59);
+        when(rateLimit.getResetDate()).thenReturn(new Date(0));
+
+        var health = new GitHubHealthIndicator(github).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsKey("connection");
+        @SuppressWarnings("unchecked")
+        var connection = (Map<String, Object>) health.getDetails().get("connection");
+        assertThat(connection).containsEntry("authenticated", false);
+    }
+
+    @Test
+    void connectionDetailHasNoRateLimitKeyWhenLastRateLimitIsNull() throws IOException {
+        var github = mock(GitHub.class);
+        when(github.isAnonymous()).thenReturn(false);
+        when(github.lastRateLimit()).thenReturn(null);
+
+        var health = new GitHubHealthIndicator(github).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        @SuppressWarnings("unchecked")
+        var connection = (Map<String, Object>) health.getDetails().get("connection");
+        assertThat(connection).doesNotContainKey("rateLimit");
+    }
+}


### PR DESCRIPTION
## Summary

- Exposes whether the GitHub connection is authenticated (vs. anonymous) under a nested `connection` key in the `/actuator/health/gitHub` endpoint
- Includes the last known rate limit (`limit`, `remaining`, `resetDate`) when available; key is omitted when no request has been made yet
- Status is `UP` when authenticated, `OUT_OF_SERVICE` when anonymous, `DOWN` on API errors

## Test plan

- [ ] Unit tests cover: null GitHub, API URL check failure, authenticated + rate limit present, anonymous, rate limit absent
- [ ] Integration tests validate the JSON structure of `/actuator/health/gitHub` for all three states (authenticated, anonymous, no cached rate limit)