### PR TITLE
fix(compose): correct env var name for GitHub private key path

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
     env_file:
       - .env
     environment:
-      - GITHUB_PRIVATEKEYPATH=/app/github-app-private-key.pem
+      - GITHUB_APP_PRIVATE_KEY_PATH=/app/github-app-private-key.pem
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
       - SPRING_PROFILES_ACTIVE=dev


### PR DESCRIPTION
## Summary

- `GITHUB_PRIVATEKEYPATH` was set in the `environment` block instead of `GITHUB_APP_PRIVATE_KEY_PATH`, causing `Files.exists()` to return `false` inside the container and the app to connect to GitHub anonymously despite the private key being present on the host

## Test plan

- [ ] `docker compose up` with a valid `.env` connects to GitHub as authenticated (health endpoint reports `UP`)