### PR TITLE
test: mock GitHub bean in EngineHealthGroupIT

### DIFF
--- a/war/src/test/java/io/jenkins/pluginhealth/scoring/config/EngineHealthGroupIT.java
+++ b/war/src/test/java/io/jenkins/pluginhealth/scoring/config/EngineHealthGroupIT.java
@@ -32,11 +32,13 @@ import java.time.ZonedDateTime;
 import io.jenkins.pluginhealth.scoring.AbstractDBContainerTest;
 
 import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GitHub;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -49,6 +51,9 @@ import org.springframework.test.web.servlet.MockMvc;
             "app.github.app-installation-name=test"
         })
 class EngineHealthGroupIT extends AbstractDBContainerTest {
+
+    @MockitoBean
+    private GitHub github;
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary

- `EngineHealthGroupIT.aggregateHealthEndpointIsAccessibleWithoutAuthentication` was failing with HTTP 503 instead of 200
- Root cause: `GitHubHealthIndicator` uses a real `GitHub` bean (anonymous connection, since `private-key-path=/nonexistent`) which reports `OUT_OF_SERVICE`, degrading the aggregate health endpoint
- Fix: add `@MockitoBean GitHub github` — same pattern already used in `GitHubHealthIndicatorIT` — so the indicator stays UP and the test focuses on engine health behavior

## Test plan

- [ ] `mvn verify -pl war` passes with all 19 integration tests green