### PR TITLE
fix(probe): honour firstVersion lower bound in security warning range

### DIFF
--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/model/updatecenter/SecurityWarningVersion.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2026 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,13 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring.model.updatecenter;
 
 import hudson.util.VersionNumber;
 
-public record SecurityWarningVersion(
-    VersionNumber lastVersion,
-    String pattern
-) {
-}
+public record SecurityWarningVersion(VersionNumber firstVersion, VersionNumber lastVersion, String pattern) {}

--- a/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
+++ b/core/src/main/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbe.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Jenkins Infra
+ * Copyright (c) 2023-2026 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,11 @@ public class KnownSecurityVulnerabilityProbe extends Probe {
                 .filter(w -> w.versions().stream().anyMatch(securityWarningVersion -> {
                     if (securityWarningVersion.lastVersion() != null) {
                         if (plugin.getVersion().isOlderThanOrEqualTo(securityWarningVersion.lastVersion())) {
-                            return true;
+                            if (securityWarningVersion.firstVersion() == null
+                                    || plugin.getVersion()
+                                            .isNewerThanOrEqualTo(securityWarningVersion.firstVersion())) {
+                                return true;
+                            }
                         }
                     }
                     final Pattern pattern = Pattern.compile(securityWarningVersion.pattern());

--- a/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
+++ b/core/src/test/java/io/jenkins/pluginhealth/scoring/probes/KnownSecurityVulnerabilityProbeTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Jenkins Infra
+ * Copyright (c) 2023-2026 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 "SECURITY-1",
                                 "wiz",
                                 "http://link-to-issue",
-                                List.of(new SecurityWarningVersion(null, ".*"))))));
+                                List.of(new SecurityWarningVersion(null, null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -119,7 +119,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 "SECURITY-1",
                                 pluginName,
                                 "http://link-to-issue",
-                                List.of(new SecurityWarningVersion(new VersionNumber("1.0"), "0\\.*"))))));
+                                List.of(new SecurityWarningVersion(null, new VersionNumber("1.0"), "0\\.*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -151,7 +151,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 warningId,
                                 pluginName,
                                 url,
-                                List.of(new SecurityWarningVersion(pluginVersion, "1.0"))))));
+                                List.of(new SecurityWarningVersion(null, pluginVersion, "1.0"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -180,7 +180,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                         Collections.emptyMap(),
                         Collections.emptyMap(),
                         List.of(new SecurityWarning(
-                                warningId, pluginName, url, List.of(new SecurityWarningVersion(null, ".*"))))));
+                                warningId, pluginName, url, List.of(new SecurityWarningVersion(null, null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -212,12 +212,15 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                         Collections.emptyMap(),
                         List.of(
                                 new SecurityWarning(
-                                        warningId1, pluginName, url1, List.of(new SecurityWarningVersion(null, ".*"))),
+                                        warningId1,
+                                        pluginName,
+                                        url1,
+                                        List.of(new SecurityWarningVersion(null, null, ".*"))),
                                 new SecurityWarning(
                                         warningId2,
                                         pluginName,
                                         url2,
-                                        List.of(new SecurityWarningVersion(null, ".*"))))));
+                                        List.of(new SecurityWarningVersion(null, null, ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -251,12 +254,15 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                         Collections.emptyMap(),
                         List.of(
                                 new SecurityWarning(
-                                        warningId1, pluginName, url1, List.of(new SecurityWarningVersion(null, ".*"))),
+                                        warningId1,
+                                        pluginName,
+                                        url1,
+                                        List.of(new SecurityWarningVersion(null, null, ".*"))),
                                 new SecurityWarning(
                                         warningId2,
                                         pluginName,
                                         url2,
-                                        List.of(new SecurityWarningVersion(new VersionNumber("1.1"), ".*"))))));
+                                        List.of(new SecurityWarningVersion(null, new VersionNumber("1.1"), ".*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -278,32 +284,33 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                 "SECURITY-2665-1",
                 pluginName,
                 "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2665%20(1)",
-                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("2.2.0"), ".*")));
         SecurityWarning sw2 = new SecurityWarning(
                 "SECURITY-2665-2",
                 pluginName,
                 "https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-2665%20(2)",
-                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("2.2.0"), ".*")));
         SecurityWarning sw3 = new SecurityWarning(
                 "SECURITY-2784-repository-connector",
                 pluginName,
                 "https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2784",
-                List.of(new SecurityWarningVersion(new VersionNumber("2.2.0"), ".*")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("2.2.0"), ".*")));
         SecurityWarning sw4 = new SecurityWarning(
                 "SECURITY-2183",
                 pluginName,
                 "https://www.jenkins.io/security/advisory/2021-02-24/#SECURITY-2183",
-                List.of(new SecurityWarningVersion(new VersionNumber("2.0.2"), "([01]|2[.]0[.][0-2])(|[.-].+)")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("2.0.2"), "([01]|2[.]0[.][0-2])(|[.-].+)")));
         SecurityWarning sw5 = new SecurityWarning(
                 "SECURITY-1520",
                 pluginName,
                 "https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1520",
-                List.of(new SecurityWarningVersion(new VersionNumber("1.3.1"), "([01])(|[.-].+)")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("1.3.1"), "([01])(|[.-].+)")));
         SecurityWarning sw6 = new SecurityWarning(
                 "SECURITY-958",
                 pluginName,
                 "https://jenkins.io/security/advisory/2019-03-06/#SECURITY-958",
-                List.of(new SecurityWarningVersion(new VersionNumber("1.2.4"), "(0|1[.]([01]|2[.][0-4]))(|[-.].*)")));
+                List.of(new SecurityWarningVersion(
+                        null, new VersionNumber("1.2.4"), "(0|1[.]([01]|2[.][0-4]))(|[-.].*)")));
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
@@ -336,17 +343,17 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                 "SECURITY-495",
                 pluginName,
                 "https://jenkins.io/security/advisory/2017-04-10/",
-                List.of(new SecurityWarningVersion(new VersionNumber("2.30.5"), "2\\.([0-2]\\d?|30)\\..*")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("2.30.5"), "2\\.([0-2]\\d?|30)\\..*")));
         SecurityWarning sw2 = new SecurityWarning(
                 "SECURITY-1341",
                 pluginName,
                 "https://jenkins.io/security/advisory/2019-04-17/#SECURITY-1341",
-                List.of(new SecurityWarningVersion(new VersionNumber("3.4"), "(2|3[.]([0-3]))(|[.-].*)|3[.]4")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("3.4"), "(2|3[.]([0-3]))(|[.-].*)|3[.]4")));
         SecurityWarning sw3 = new SecurityWarning(
                 "SECURITY-2784-ontrack",
                 pluginName,
                 "https://www.jenkins.io/security/advisory/2022-06-22/#SECURITY-2784",
-                List.of(new SecurityWarningVersion(new VersionNumber("4.0.0"), ".*")));
+                List.of(new SecurityWarningVersion(null, new VersionNumber("4.0.0"), ".*")));
 
         final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
         final ProbeContext ctx = mock(ProbeContext.class);
@@ -386,7 +393,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 warningId,
                                 pluginName,
                                 url,
-                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+                                List.of(new SecurityWarningVersion(null, null, "([12][.].+|3[.][34])(|[.-].*)"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -417,7 +424,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 warningId,
                                 pluginName,
                                 url,
-                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+                                List.of(new SecurityWarningVersion(null, null, "([12][.].+|3[.][34])(|[.-].*)"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -448,7 +455,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 warningId,
                                 pluginName,
                                 url,
-                                List.of(new SecurityWarningVersion(null, "([12][.].+|3[.][34])(|[.-].*)"))))));
+                                List.of(new SecurityWarningVersion(null, null, "([12][.].+|3[.][34])(|[.-].*)"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -478,7 +485,7 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                                 "SECURITY-1",
                                 pluginName,
                                 "http://link-to-issue",
-                                List.of(new SecurityWarningVersion(null, "[0-1]\\..*"))))));
+                                List.of(new SecurityWarningVersion(null, null, "[0-1]\\..*"))))));
 
         final ProbeResult result = probe.apply(plugin, ctx);
         assertThat(result)
@@ -487,5 +494,75 @@ class KnownSecurityVulnerabilityProbeTest extends AbstractProbeTest<KnownSecurit
                 .comparingOnlyFields("id", "status", "message")
                 .isEqualTo(ProbeResult.success(
                         KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+    }
+
+    @Test
+    void rogueReleaseWithHigherVersionSchemeShouldNotFlagCurrentLegitimateVersion() {
+        final String pluginName = "checkmarx-ast-scanner";
+        final VersionNumber pluginVersion = new VersionNumber("2.0.13-853.v1fa_8405d5991");
+        final String warningId = "rogue-checkmarx-ast-scanner-2026.5.09";
+        final String url = "https://github.com/jenkins-infra/update-center2/pull/914";
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(pluginVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId,
+                                pluginName,
+                                url,
+                                List.of(new SecurityWarningVersion(
+                                        new VersionNumber("2026.5.09"),
+                                        new VersionNumber("2026.5.09"),
+                                        "2026[.]5[.]09"))))));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, "No known security vulnerabilities.", probe.getVersion()));
+    }
+
+    @Test
+    void rogueReleaseVersionItselfShouldStillBeReportedAsSecurity() {
+        final String pluginName = "checkmarx-ast-scanner";
+        final VersionNumber rogueVersion = new VersionNumber("2026.5.09");
+        final String warningId = "rogue-checkmarx-ast-scanner-2026.5.09";
+        final String url = "https://github.com/jenkins-infra/update-center2/pull/914";
+
+        final var plugin = mock(io.jenkins.pluginhealth.scoring.model.Plugin.class);
+        final ProbeContext ctx = mock(ProbeContext.class);
+        final KnownSecurityVulnerabilityProbe probe = getSpy();
+
+        when(plugin.getName()).thenReturn(pluginName);
+        when(plugin.getVersion()).thenReturn(rogueVersion);
+        when(ctx.getUpdateCenter())
+                .thenReturn(new UpdateCenter(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        List.of(new SecurityWarning(
+                                warningId,
+                                pluginName,
+                                url,
+                                List.of(new SecurityWarningVersion(
+                                        new VersionNumber("2026.5.09"),
+                                        new VersionNumber("2026.5.09"),
+                                        "2026[.]5[.]09"))))));
+
+        final ProbeResult result = probe.apply(plugin, ctx);
+        assertThat(result)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .comparingOnlyFields("id", "status", "message")
+                .isEqualTo(ProbeResult.success(
+                        KnownSecurityVulnerabilityProbe.KEY, warningId + "|" + url, probe.getVersion()));
     }
 }


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/helpdesk/issues/5257.

## Summary

- `SecurityWarningVersion` was missing the `firstVersion` field, so the version range check was one-sided (upper-bound only).
- Advisories where `firstVersion == lastVersion` (e.g. the rogue release `2026.5.09` using a date-based scheme) incorrectly flagged all legitimate plugin versions as affected because they are numerically lower than the rogue version number.
- Added `firstVersion` to `SecurityWarningVersion` and used it as a lower bound in `KnownSecurityVulnerabilityProbe` when non-null; existing advisories without `firstVersion` (`null`) preserve the current behaviour.

## Test plan

- [ ] `rogueReleaseWithHigherVersionSchemeShouldNotFlagCurrentLegitimateVersion` — verifies `2.0.13-853.v1fa_8405d5991` is no longer falsely flagged against the `2026.5.09` rogue warning
- [ ] `rogueReleaseVersionItselfShouldStillBeReportedAsSecurity` — verifies the rogue version `2026.5.09` itself is still reported as a security issue
- [ ] All 14 existing `KnownSecurityVulnerabilityProbeTest` tests continue to pass