### PR TITLE
feat(banner): display app version and git commit at startup

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -171,6 +171,12 @@
 
   <build>
     <finalName>plugin-health-scoring</finalName>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -227,6 +233,15 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <delimiters>
+            <delimiter>@</delimiter>
+          </delimiters>
+          <useDefaultDelimiters>false</useDefaultDelimiters>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot.version}</version>
@@ -267,7 +282,7 @@
             <goals>
               <goal>revision</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>initialize</phase>
           </execution>
         </executions>
       </plugin>

--- a/war/src/main/resources/banner.txt
+++ b/war/src/main/resources/banner.txt
@@ -2,7 +2,7 @@
 ###########################################################
 ###########################################################
 
-:: Plugin Health Scoring ::   ${application.formatted-version}
+:: Plugin Health Scoring ::   @project.version@ (@git.commit.id.abbrev@)
 :: Spring Boot ::             ${spring-boot.formatted-version}
 
 ###########################################################


### PR DESCRIPTION
### Description

Closes #947.

Enable Maven resource filtering to embed the project version and git commit hash into the startup banner.

Previously, `${application.formatted-version}` was empty in exploded-JAR mode (no JAR manifest at runtime). The fix uses Maven's `@..@` delimiter syntax — substituted at build time — so `${...}` placeholders in `application.yaml` and `${spring-boot.formatted-version}` in the banner remain untouched for Spring Boot's runtime resolution.

### Testing done

Validated with `docker compose up`:

```
app-1  | openjdk version "25" 2025-09-16 LTS
app-1  | OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
app-1  | OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed mode, sharing)
app-1  |
app-1  | ###########################################################
app-1  | ###########################################################
app-1  |
app-1  | :: Plugin Health Scoring ::   6.0.3-SNAPSHOT (475c499)
app-1  | :: Spring Boot ::              (v4.1.1)
app-1  |
app-1  | ###########################################################
app-1  | ###########################################################
app-1  |
```

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
