### PR TITLE
fix(security): exclude UserDetailsServiceAutoConfiguration

### DIFF
--- a/war/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
+++ b/war/src/main/java/io/jenkins/pluginhealth/scoring/PluginHealthScoring.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jenkins Infra
+ * Copyright (c) 2023-2026 Jenkins Infra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package io.jenkins.pluginhealth.scoring;
 
 import io.jenkins.pluginhealth.scoring.config.ApplicationConfiguration;
@@ -29,9 +28,12 @@ import io.jenkins.pluginhealth.scoring.config.ApplicationConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 
 @EnableConfigurationProperties(value = ApplicationConfiguration.class)
-@SpringBootApplication(scanBasePackages = "io.jenkins.pluginhealth.scoring")
+@SpringBootApplication(
+        scanBasePackages = "io.jenkins.pluginhealth.scoring",
+        exclude = UserDetailsServiceAutoConfiguration.class)
 public class PluginHealthScoring {
     public static void main(String[] args) {
         SpringApplication.run(PluginHealthScoring.class, args);


### PR DESCRIPTION
### Description

Closes #946.

Spring Boot's `UserDetailsServiceAutoConfiguration` generates a random password and logs it at startup when no `UserDetailsService` bean is present. Since the application uses `permitAll`/`denyAll` filter chains with no form login or basic auth, no `UserDetailsService` is needed. Excluding the auto-configuration removes the log line entirely.

Clean startup logs (no token):

```
app-1  | openjdk version "25" 2025-09-16 LTS
app-1  | OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
app-1  | OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed mode, sharing)
app-1  |
app-1  | ###########################################################
app-1  | ###########################################################
app-1  |
app-1  | :: Plugin Health Scoring ::
app-1  | :: Spring Boot ::              (v4.1.1)
app-1  |
app-1  | ###########################################################
app-1  | ###########################################################
app-1  |
app-1  | 2026-09-10T20:33:44.704Z  INFO 1 --- [           main] i.j.p.scoring.PluginHealthScoring        : Starting PluginHealthScoring using Java 25 with PID 1 (/app started by phs in /app)
app-1  | 2026-09-10T20:33:44.705Z DEBUG 1 --- [           main] i.j.p.scoring.PluginHealthScoring        : Running with Spring Boot v4.1.1, Spring v7.0.9
app-1  | 2026-09-10T20:33:44.705Z  INFO 1 --- [           main] i.j.p.scoring.PluginHealthScoring        : The following 1 profile is active: "dev"
app-1  | 2026-09-10T20:33:45.025Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
app-1  | 2026-09-10T20:33:45.042Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 12 ms. Found 2 JPA repository interfaces.
app-1  | 2026-09-10T20:33:45.353Z  INFO 1 --- [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat initialized with port 8080 (http)
app-1  | 2026-09-10T20:33:45.358Z  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
app-1  | 2026-09-10T20:33:45.359Z  INFO 1 --- [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/11.0.24]
app-1  | 2026-09-10T20:33:45.376Z  INFO 1 --- [           main] b.w.c.s.WebApplicationContextInitializer : Root WebApplicationContext: initialization completed in 583 ms
app-1  | 2026-09-10T20:33:45.472Z  INFO 1 --- [           main] org.hibernate.orm.jpa                    : HHH008540: Processing PersistenceUnitInfo [name: default]
app-1  | 2026-09-10T20:33:45.488Z  INFO 1 --- [           main] org.hibernate.orm.core                   : HHH000001: Hibernate ORM core version 7.4.5.Final
app-1  | 2026-09-10T20:33:45.564Z  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
app-1  | 2026-09-10T20:33:45.627Z  INFO 1 --- [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@4e671ef
app-1  | 2026-09-10T20:33:45.628Z  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
app-1  | 2026-09-10T20:33:45.650Z  INFO 1 --- [           main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
app-1  |     Database JDBC URL [jdbc:postgresql://db:5432/postgres]
app-1  |     Database driver: PostgreSQL JDBC Driver
app-1  |     Database dialect: PostgreSQLDialect
app-1  |     Database version: 17.9
app-1  |     Default catalog/schema: postgres/public
app-1  |     Autocommit mode: undefined/unknown
app-1  |     Isolation level: READ_COMMITTED [default READ_COMMITTED]
app-1  |     JDBC fetch size: none
app-1  |     Pool: DataSourceConnectionProvider
app-1  |     Minimum pool size: undefined/unknown
app-1  |     Maximum pool size: undefined/unknown
app-1  | 2026-09-10T20:33:46.063Z  INFO 1 --- [           main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
app-1  | 2026-09-10T20:33:46.063Z  WARN 1 --- [           main] org.hibernate.orm.jdbc.warn              : HHH000247: ErrorCode: 0, SQLState: 00000
app-1  | 2026-09-10T20:33:46.085Z  WARN 1 --- [           main] org.hibernate.orm.jdbc.warn              : constraint "uk6xe1v0fh7nkqho8mf1fppi1po" of relation "plugins" does not exist, skipping
app-1  | 2026-09-10T20:33:46.088Z  INFO 1 --- [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
app-1  | 2026-09-10T20:33:46.220Z  INFO 1 --- [           main] o.s.d.j.r.query.QueryEnhancerFactories   : Hibernate is in classpath; If applicable, HQL parser will be used.
app-1  | 2026-09-10T20:33:46.472Z  INFO 1 --- [           main] o.s.b.w.a.WelcomePageHandlerMapping      : Adding welcome page template: index
app-1  | 2026-09-10T20:33:46.622Z  INFO 1 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
app-1  | 2026-09-10T20:33:46.652Z  INFO 1 --- [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat started on port 8080 (http) with context path '/'
app-1  | 2026-09-10T20:33:46.658Z  INFO 1 --- [           main] i.j.p.scoring.PluginHealthScoring        : Started PluginHealthScoring in 2.114 seconds (process running for 2.238)
```

### Testing done

Verified the startup logs no longer contain the `Using generated security password:` line. All existing tests pass (`mvn verify`).

### Submitter checklist

- [x] If an issue exists, it is well described and linked in the description
- [x] The description of this pull request is detailed and explain why this pull request is needed
- [x] The changeset is on a specific branch. Using `feature/` for new feature, or improvements ; Using `fix/` for bug fixes ; Using `docs/` for any documentation changes.
- [ ] If required, the documentation has been updated
- [x] There is automated tests to cover the code change / addition or an explanation why there is no tests in the description.
